### PR TITLE
Add code_components, source_block, and code_template columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,24 +291,23 @@ The metadata directory contains a dataset descriptor, code metadata, and subject
 
 ```
 
-The event config includes a `_metadata` block that links lab events to a descriptions
-file. The extracted metadata maps each lab code to its human-readable description:
+The event config includes `_metadata` blocks that link events to description files.
+Lab descriptions use full matching (the metadata table has the same `test_name` column
+as the code). Medication descriptions use **partial matching** via `_match_on` — the
+code is `f"{$medication_name}//{$dose}"` but the metadata only has `medication_name`:
 
 ```python
 >>> codes = pl.read_parquet(output / "metadata" / "codes.parquet")
->>> codes.sort("code").head(5)
-shape: (5, 2)
-┌─────────────────────┬──────────────────────────┐
-│ code                ┆ description              │
-│ ---                 ┆ ---                      │
-│ str                 ┆ str                      │
-╞═════════════════════╪══════════════════════════╡
-│ ALT (U/L)           ┆ Alanine aminotransferase │
-│ Creatinine (mg/dL)  ┆ Serum creatinine         │
-│ Diastolic BP (mmHg) ┆ Diastolic blood pressure │
-│ Glucose (mg/dL)     ┆ Blood glucose level      │
-│ Heart Rate (bpm)    ┆ Heart rate / pulse       │
-└─────────────────────┴──────────────────────────┘
+>>> codes.filter(pl.col("code").str.starts_with("Metformin") | (pl.col("code") == "Glucose (mg/dL)")).sort("code")
+shape: (2, 3)
+┌───────────────────┬─────────────────────┬────────────────────────────────┐
+│ code              ┆ description         ┆ code_template                  │
+│ ---               ┆ ---                 ┆ ---                            │
+│ str               ┆ str                 ┆ str                            │
+╞═══════════════════╪═════════════════════╪════════════════════════════════╡
+│ Glucose (mg/dL)   ┆ Blood glucose level ┆ $test_name                     │
+│ Metformin//500 mg ┆ Antidiabetic        ┆ f"{$medication_name}//{$dose}" │
+└───────────────────┴─────────────────────┴────────────────────────────────┘
 >>> _ = shutil.rmtree(tmpdir)
 
 ```

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Each shard contains the standard MEDS columns:
 ```python
 >>> df = pl.read_parquet(output / "data" / "train" / "0.parquet")
 >>> sorted(df.columns)
-['code', 'numeric_value', 'subject_id', 'time']
+['code', 'code_components', 'numeric_value', 'source_block', 'subject_id', 'time']
 >>> df.schema["subject_id"]
 Int64
 >>> df.schema["code"]

--- a/README.md
+++ b/README.md
@@ -229,6 +229,50 @@ String
 
 ```
 
+MEDS-Extract also adds provenance and structure columns to help trace and query events.
+The `source_block` column tracks which MESSY config block produced each event:
+
+```python
+>>> df.group_by("source_block").len().sort("source_block")
+shape: (7, 2)
+┌─────────────────────┬─────┐
+│ source_block        ┆ len │
+│ ---                 ┆ --- │
+│ str                 ┆ u32 │
+╞═════════════════════╪═════╡
+│ diagnoses/dx        ┆ 10  │
+│ labs_vitals/lab     ┆ 70  │
+│ medications/med     ┆ 10  │
+│ patients/dob        ┆ 8   │
+│ patients/dod        ┆ 1   │
+│ patients/eye_color  ┆ 8   │
+│ patients/hair_color ┆ 8   │
+└─────────────────────┴─────┘
+
+```
+
+The `code_components` struct column preserves the individual column values that were
+combined to form the code. This enables queries on code components without parsing the
+code string — for example, finding all Glucose readings regardless of units:
+
+```python
+>>> glucose = df.filter(
+...     pl.col("code_components").struct.field("test_name") == "Glucose (mg/dL)"
+... )
+>>> glucose.select("subject_id", "time", "numeric_value").sort("subject_id", "time").head(3)
+shape: (3, 3)
+┌────────────┬─────────────────────┬───────────────┐
+│ subject_id ┆ time                ┆ numeric_value │
+│ ---        ┆ ---                 ┆ ---           │
+│ i64        ┆ datetime[μs]        ┆ f32           │
+╞════════════╪═════════════════════╪═══════════════╡
+│ 1          ┆ 2025-03-09 15:18:00 ┆ 122.290001    │
+│ 1          ┆ 2025-06-05 17:02:00 ┆ 185.919998    │
+│ 2          ┆ 2024-08-12 20:57:00 ┆ 157.539993    │
+└────────────┴─────────────────────┴───────────────┘
+
+```
+
 The metadata directory contains a dataset descriptor, code metadata, and subject splits:
 
 ```python

--- a/example/event_cfg.yaml
+++ b/example/event_cfg.yaml
@@ -34,6 +34,10 @@ medications:
   med:
     code: 'f"{$medication_name}//{$dose}"'
     time: '$timestamp::"%Y-%m-%dT%H:%M:%S"'
+    _metadata:
+      medication_classes:
+        _match_on: medication_name
+        description: drug_class
 
 diagnoses:
   dx:

--- a/example/raw_data/medication_classes.csv
+++ b/example/raw_data/medication_classes.csv
@@ -1,0 +1,12 @@
+medication_name,drug_class
+Metformin,Antidiabetic
+Lisinopril,ACE Inhibitor
+Furosemide,Diuretic
+Atorvastatin,Statin
+Omeprazole,Proton Pump Inhibitor
+Albuterol,Bronchodilator
+Sertraline,Antidepressant
+Ibuprofen,NSAID
+Levothyroxine,Thyroid Hormone
+Paclitaxel,Chemotherapy
+Tenofovir,Antiviral

--- a/src/MEDS_extract/convert_to_MEDS_events/convert_to_MEDS_events.py
+++ b/src/MEDS_extract/convert_to_MEDS_events/convert_to_MEDS_events.py
@@ -32,6 +32,7 @@ def extract_event(
     df: pl.LazyFrame,
     event_cfg: dict[str, str | None],
     do_dedup_text_and_numeric: bool = False,
+    source_block: str | None = None,
 ) -> pl.LazyFrame:
     """Extracts a single event dataframe from the raw data using dftly expressions.
 
@@ -45,9 +46,13 @@ def extract_event(
             ``"time"`` may be ``None`` for static events. All other keys are treated as
             additional output columns whose values are dftly expressions.
         do_dedup_text_and_numeric: If true, nullify ``text_value`` when it equals ``numeric_value``.
+        source_block: If provided, added as a ``source_block`` column tracking the MESSY config
+            origin of each event (e.g., ``"patients/eye_color"``).
 
     Returns:
         A deduplicated DataFrame with ``subject_id``, ``code``, ``time``, and any additional columns.
+        If the code expression references source columns, a ``code_components`` struct column is
+        included with the individual column values that compose the code.
 
     Examples:
         >>> _ = pl.Config.set_tbl_width_chars(600)
@@ -64,16 +69,16 @@ def extract_event(
         ...     "numeric_value": "$result",
         ... }
         >>> extract_event(raw, cfg)
-        shape: (3, 4)
-        ┌────────────┬─────────────┬────────────┬───────────────┐
-        │ subject_id ┆ code        ┆ time       ┆ numeric_value │
-        │ ---        ┆ ---         ┆ ---        ┆ ---           │
-        │ i64        ┆ str         ┆ date       ┆ f64           │
-        ╞════════════╪═════════════╪════════════╪═══════════════╡
-        │ 1          ┆ Lab//mg     ┆ 2021-01-01 ┆ 1.5           │
-        │ 2          ┆ Vital//mmHg ┆ 2021-01-02 ┆ 2.7           │
-        │ 3          ┆ Lab//mg     ┆ 2021-01-03 ┆ 3.0           │
-        └────────────┴─────────────┴────────────┴───────────────┘
+        shape: (3, 5)
+        ┌────────────┬─────────────┬──────────────────┬────────────┬───────────────┐
+        │ subject_id ┆ code        ┆ code_components  ┆ time       ┆ numeric_value │
+        │ ---        ┆ ---         ┆ ---              ┆ ---        ┆ ---           │
+        │ i64        ┆ str         ┆ struct[2]        ┆ date       ┆ f64           │
+        ╞════════════╪═════════════╪══════════════════╪════════════╪═══════════════╡
+        │ 1          ┆ Lab//mg     ┆ {"Lab","mg"}     ┆ 2021-01-01 ┆ 1.5           │
+        │ 2          ┆ Vital//mmHg ┆ {"Vital","mmHg"} ┆ 2021-01-02 ┆ 2.7           │
+        │ 3          ┆ Lab//mg     ┆ {"Lab","mg"}     ┆ 2021-01-03 ┆ 3.0           │
+        └────────────┴─────────────┴──────────────────┴────────────┴───────────────┘
         >>> static_cfg = {"code": "EYE_COLOR", "time": None}
         >>> extract_event(raw, static_cfg)
         shape: (3, 3)
@@ -111,6 +116,10 @@ def extract_event(
     code_node = Parser()(code_value)
     event_exprs["code"] = code_node.polars_expr
     code_cols = code_node.referenced_columns
+
+    # Store the individual column values that compose the code as a struct
+    if code_cols:
+        event_exprs["code_components"] = pl.struct(**{col: pl.col(col) for col in sorted(code_cols)})
 
     # Build null filter: if code references columns, filter out rows where the first column is null
     code_null_filter = None
@@ -155,6 +164,10 @@ def extract_event(
             .otherwise(text_expr)
         )
 
+    # Track which MESSY config block produced each event
+    if source_block is not None:
+        event_exprs["source_block"] = pl.lit(source_block)
+
     # Apply null filters and select
     if code_null_filter is not None:
         df = df.filter(code_null_filter)
@@ -168,6 +181,7 @@ def convert_to_events(
     df: pl.LazyFrame,
     event_cfgs: dict[str, dict[str, str | None | Sequence[str]]],
     do_dedup_text_and_numeric: bool = False,
+    input_prefix: str | None = None,
 ) -> pl.LazyFrame:
     """Converts a DataFrame of raw data into a DataFrame of events.
 
@@ -175,6 +189,8 @@ def convert_to_events(
         df: The raw data DataFrame with a ``"subject_id"`` column.
         event_cfgs: Dict mapping event names to event config dicts (see ``extract_event``).
         do_dedup_text_and_numeric: If true, nullify ``text_value`` when it equals ``numeric_value``.
+        input_prefix: If provided, combined with each event name to form the ``source_block``
+            column (e.g., ``"patients/eye_color"``).
 
     Returns:
         A concatenated DataFrame of all extracted events.
@@ -194,18 +210,18 @@ def convert_to_events(
         ...     "admit": {"code": "ADMISSION", "time": '$ts::"%Y-%m-%d"'},
         ...     "color": {"code": "EYE_COLOR", "time": None, "eye_color": "$color"},
         ... }
-        >>> convert_to_events(raw, cfgs)
-        shape: (4, 4)
-        ┌────────────┬───────────┬─────────────────────┬───────────┐
-        │ subject_id ┆ code      ┆ time                ┆ eye_color │
-        │ ---        ┆ ---       ┆ ---                 ┆ ---       │
-        │ i64        ┆ str       ┆ datetime[μs]        ┆ str       │
-        ╞════════════╪═══════════╪═════════════════════╪═══════════╡
-        │ 1          ┆ ADMISSION ┆ 2021-01-01 00:00:00 ┆ null      │
-        │ 2          ┆ ADMISSION ┆ 2021-01-02 00:00:00 ┆ null      │
-        │ 1          ┆ EYE_COLOR ┆ null                ┆ blue      │
-        │ 2          ┆ EYE_COLOR ┆ null                ┆ green     │
-        └────────────┴───────────┴─────────────────────┴───────────┘
+        >>> convert_to_events(raw, cfgs, input_prefix="data")
+        shape: (4, 5)
+        ┌────────────┬───────────┬─────────────────────┬──────────────┬───────────┐
+        │ subject_id ┆ code      ┆ time                ┆ source_block ┆ eye_color │
+        │ ---        ┆ ---       ┆ ---                 ┆ ---          ┆ ---       │
+        │ i64        ┆ str       ┆ datetime[μs]        ┆ str          ┆ str       │
+        ╞════════════╪═══════════╪═════════════════════╪══════════════╪═══════════╡
+        │ 1          ┆ ADMISSION ┆ 2021-01-01 00:00:00 ┆ data/admit   ┆ null      │
+        │ 2          ┆ ADMISSION ┆ 2021-01-02 00:00:00 ┆ data/admit   ┆ null      │
+        │ 1          ┆ EYE_COLOR ┆ null                ┆ data/color   ┆ blue      │
+        │ 2          ┆ EYE_COLOR ┆ null                ┆ data/color   ┆ green     │
+        └────────────┴───────────┴─────────────────────┴──────────────┴───────────┘
         >>> convert_to_events(raw, {})
         Traceback (most recent call last):
             ...
@@ -220,6 +236,8 @@ def convert_to_events(
         if event_name in EVENT_META_KEYS:
             continue
 
+        source_block = f"{input_prefix}/{event_name}" if input_prefix is not None else None
+
         try:
             logger.info(f"Building computational graph for extracting {event_name}")
             event_dfs.append(
@@ -227,6 +245,7 @@ def convert_to_events(
                     df,
                     event_cfg,
                     do_dedup_text_and_numeric=do_dedup_text_and_numeric,
+                    source_block=source_block,
                 )
             )
         except Exception as e:
@@ -327,6 +346,7 @@ def main(cfg: DictConfig):
                             df,
                             event_cfgs=copy.deepcopy(event_cfgs),
                             do_dedup_text_and_numeric=cfg.stage_cfg.get("do_dedup_text_and_numeric", False),
+                            input_prefix=input_prefix,
                         )
                     except Exception as e:  # pragma: no cover
                         raise ValueError(f"Error converting to MEDS for {sp}/{input_prefix}: {e}") from e

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -146,10 +146,13 @@ def extract_metadata(
             f"Got: [{', '.join(event_cfg.keys())}]."
         )
 
+    metadata_cfg = dict(event_cfg["_metadata"])
+    match_on = metadata_cfg.pop("_match_on", None)
+
     df_select_exprs = {}
     final_cols = []
     needed_cols = set()
-    for out_col, in_cfg in event_cfg["_metadata"].items():
+    for out_col, in_cfg in metadata_cfg.items():
         in_expr, needed = cfg_to_expr(in_cfg)
         df_select_exprs[out_col] = in_expr
         final_cols.append(out_col)
@@ -161,21 +164,51 @@ def extract_metadata(
     needed_code_cols = code_node.referenced_columns
 
     columns = metadata_df.collect_schema().names()
-    missing_cols = (needed_cols | needed_code_cols) - set(columns) - set(final_cols)
-    if missing_cols:
-        raise KeyError(f"Columns {missing_cols} not found in metadata columns: {columns}")
 
-    for col in needed_code_cols:
-        if col not in df_select_exprs:
-            df_select_exprs[col] = pl.col(col)
+    if match_on is not None:
+        # Partial matching: join metadata on specific code component columns rather than the full code.
+        # The metadata table only needs the _match_on columns, not all code columns.
+        if isinstance(match_on, str):
+            match_on = [match_on]
+        missing_match_cols = set(match_on) - set(columns) - set(final_cols)
+        if missing_match_cols:
+            raise KeyError(f"_match_on columns {missing_match_cols} not found in metadata columns: {columns}")
 
-    metadata_df = metadata_df.select(**df_select_exprs).with_columns(
-        code=code_expr,
-        code_template=pl.lit(code_value),
-    )
+        missing_metadata_cols = needed_cols - set(columns) - set(final_cols)
+        if missing_metadata_cols:
+            raise KeyError(f"Columns {missing_metadata_cols} not found in metadata columns: {columns}")
 
-    if allowed_codes:
-        metadata_df = metadata_df.filter(pl.col("code").is_in(allowed_codes))
+        for col in match_on:
+            if col not in df_select_exprs:
+                df_select_exprs[col] = pl.col(col)
+
+        metadata_df = metadata_df.select(**df_select_exprs).with_columns(
+            code_template=pl.lit(code_value),
+        )
+
+        if allowed_codes is not None:
+            # Build a partial code → full codes mapping from allowed_codes using code_components
+            # For partial matching, we can't filter by exact code — we broadcast metadata to all
+            # matching codes. allowed_codes filtering happens after the join in the reducer.
+            pass
+
+    else:
+        # Full matching: reconstruct the complete code from the metadata table
+        missing_cols = (needed_cols | needed_code_cols) - set(columns) - set(final_cols)
+        if missing_cols:
+            raise KeyError(f"Columns {missing_cols} not found in metadata columns: {columns}")
+
+        for col in needed_code_cols:
+            if col not in df_select_exprs:
+                df_select_exprs[col] = pl.col(col)
+
+        metadata_df = metadata_df.select(**df_select_exprs).with_columns(
+            code=code_expr,
+            code_template=pl.lit(code_value),
+        )
+
+        if allowed_codes:
+            metadata_df = metadata_df.filter(pl.col("code").is_in(allowed_codes))
 
     metadata_df = metadata_df.filter(~pl.all_horizontal(*[pl.col(c).is_null() for c in final_cols]))
 
@@ -187,7 +220,10 @@ def extract_metadata(
             logger.warning(f"Metadata column '{mandatory_col}' must be of type {mandatory_type}. Casting.")
             metadata_df = metadata_df.with_columns(pl.col(mandatory_col).cast(mandatory_type, strict=False))
 
-    return metadata_df.unique(maintain_order=True).select("code", "code_template", *final_cols)
+    if match_on is not None:
+        return metadata_df.unique(maintain_order=True).select(*match_on, "code_template", *final_cols)
+    else:
+        return metadata_df.unique(maintain_order=True).select("code", "code_template", *final_cols)
 
 
 def extract_all_metadata(
@@ -320,7 +356,8 @@ def get_events_and_metadata_by_metadata_fp(
             for metadata_pfx, metadata_cfg in event_cfg.get("_metadata", {}).items():
                 if metadata_pfx not in out:
                     out[metadata_pfx] = []
-                out[metadata_pfx].append({"code": event_cfg["code"], "_metadata": metadata_cfg})
+                metadata_entry = {"code": event_cfg["code"], "_metadata": metadata_cfg}
+                out[metadata_pfx].append(metadata_entry)
 
     return out
 
@@ -376,14 +413,18 @@ def main(cfg: DictConfig):
     event_metadata_configs = list(events_and_metadata_by_metadata_fp.items())
     random.shuffle(event_metadata_configs)
 
-    # Load all codes
-    all_codes = (
-        pl.scan_parquet(stage_input_dir / "**/*.parquet")
-        .select(pl.col("code").unique())
-        .collect()
-        .get_column("code")
-        .to_list()
-    )
+    # Load all codes and code_components from extracted data
+    all_data = pl.scan_parquet(stage_input_dir / "**/*.parquet")
+    all_codes = all_data.select(pl.col("code").unique()).collect().get_column("code").to_list()
+
+    # Build code_components mapping for partial metadata joins
+    data_schema = all_data.collect_schema()
+    if "code_components" in data_schema:
+        code_component_map = (
+            all_data.select("code", "code_components").unique().collect().unnest("code_components")
+        )
+    else:
+        code_component_map = None
 
     all_out_fps = []
     for input_prefix, event_metadata_cfgs in event_metadata_configs:
@@ -441,10 +482,40 @@ def main(cfg: DictConfig):
     start = datetime.now(tz=UTC)
     logger.info("All map shards complete! Starting code metadata reduction computation.")
 
-    def reducer_fn(*dfs):
-        return pl.concat(dfs, how="diagonal_relaxed").unique(maintain_order=True)
+    # Separate partial-match outputs (no "code" column) from full-match outputs
+    full_match_dfs = []
+    partial_match_dfs = []
+    for fp in all_out_fps:
+        df = pl.scan_parquet(fp, glob=False)
+        if "code" in df.collect_schema():
+            full_match_dfs.append(df)
+        else:
+            partial_match_dfs.append(df)
 
-    reduced = reducer_fn(*[pl.scan_parquet(fp, glob=False) for fp in all_out_fps])
+    # Expand partial-match metadata to full codes via code_components
+    if partial_match_dfs and code_component_map is not None:
+        for pdf in partial_match_dfs:
+            pdf_cols = pdf.collect_schema().names()
+            match_cols = [c for c in pdf_cols if c in code_component_map.columns]
+            metadata_cols_partial = [c for c in pdf_cols if c not in match_cols]
+            if match_cols:
+                expanded = (
+                    code_component_map.lazy()
+                    .join(pdf, on=match_cols, how="inner")
+                    .select("code", *metadata_cols_partial)
+                )
+                full_match_dfs.append(expanded)
+            else:
+                logger.warning(f"No matching component columns found for partial metadata in {fp}")
+    elif partial_match_dfs:
+        logger.warning("Partial-match metadata found but no code_components in data. Skipping.")
+
+    if not full_match_dfs:
+        logger.info("No metadata to reduce. Writing empty metadata file.")
+        reduced = pl.DataFrame({"code": []}).cast({"code": pl.String})
+    else:
+        reduced = pl.concat(full_match_dfs, how="diagonal_relaxed").unique(maintain_order=True)
+
     join_cols = ["code", *cfg.get("code_modifier_cols", [])]
     reduced_cols = reduced.collect_schema().names()
     metadata_cols = [c for c in reduced_cols if c not in join_cols]

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -79,27 +79,27 @@ def extract_metadata(
         ...     "_metadata": {"desc": "name"},
         ... }
         >>> extract_metadata(raw_metadata, event_cfg)
-        shape: (4, 2)
-        ┌───────────┬──────────┐
-        │ code      ┆ desc     │
-        │ ---       ┆ ---      │
-        │ str       ┆ str      │
-        ╞═══════════╪══════════╡
-        │ FOO//A//1 ┆ Code A-1 │
-        │ FOO//B//2 ┆ B-2      │
-        │ FOO//C//3 ┆ C with 3 │
-        │ FOO//D//4 ┆ D, but 4 │
-        └───────────┴──────────┘
+        shape: (4, 3)
+        ┌───────────┬─────────────────────────────────┬──────────┐
+        │ code      ┆ code_template                   ┆ desc     │
+        │ ---       ┆ ---                             ┆ ---      │
+        │ str       ┆ str                             ┆ str      │
+        ╞═══════════╪═════════════════════════════════╪══════════╡
+        │ FOO//A//1 ┆ f"FOO//{$code}//{$code_modifie… ┆ Code A-1 │
+        │ FOO//B//2 ┆ f"FOO//{$code}//{$code_modifie… ┆ B-2      │
+        │ FOO//C//3 ┆ f"FOO//{$code}//{$code_modifie… ┆ C with 3 │
+        │ FOO//D//4 ┆ f"FOO//{$code}//{$code_modifie… ┆ D, but 4 │
+        └───────────┴─────────────────────────────────┴──────────┘
         >>> extract_metadata(raw_metadata, event_cfg, allowed_codes=["FOO//A//1", "FOO//C//3"])
-        shape: (2, 2)
-        ┌───────────┬──────────┐
-        │ code      ┆ desc     │
-        │ ---       ┆ ---      │
-        │ str       ┆ str      │
-        ╞═══════════╪══════════╡
-        │ FOO//A//1 ┆ Code A-1 │
-        │ FOO//C//3 ┆ C with 3 │
-        └───────────┴──────────┘
+        shape: (2, 3)
+        ┌───────────┬─────────────────────────────────┬──────────┐
+        │ code      ┆ code_template                   ┆ desc     │
+        │ ---       ┆ ---                             ┆ ---      │
+        │ str       ┆ str                             ┆ str      │
+        ╞═══════════╪═════════════════════════════════╪══════════╡
+        │ FOO//A//1 ┆ f"FOO//{$code}//{$code_modifie… ┆ Code A-1 │
+        │ FOO//C//3 ┆ f"FOO//{$code}//{$code_modifie… ┆ C with 3 │
+        └───────────┴─────────────────────────────────┴──────────┘
         >>> extract_metadata(raw_metadata.drop("code_modifier"), event_cfg)  # doctest: +SKIP
         >>> extract_metadata(raw_metadata, ['foo'])
         Traceback (most recent call last):
@@ -155,7 +155,8 @@ def extract_metadata(
         final_cols.append(out_col)
         needed_cols.update(needed)
 
-    code_node = Parser()(str(event_cfg.pop("code")))
+    code_value = str(event_cfg.pop("code"))
+    code_node = Parser()(code_value)
     code_expr = code_node.polars_expr
     needed_code_cols = code_node.referenced_columns
 
@@ -168,7 +169,10 @@ def extract_metadata(
         if col not in df_select_exprs:
             df_select_exprs[col] = pl.col(col)
 
-    metadata_df = metadata_df.select(**df_select_exprs).with_columns(code=code_expr)
+    metadata_df = metadata_df.select(**df_select_exprs).with_columns(
+        code=code_expr,
+        code_template=pl.lit(code_value),
+    )
 
     if allowed_codes:
         metadata_df = metadata_df.filter(pl.col("code").is_in(allowed_codes))
@@ -183,7 +187,7 @@ def extract_metadata(
             logger.warning(f"Metadata column '{mandatory_col}' must be of type {mandatory_type}. Casting.")
             metadata_df = metadata_df.with_columns(pl.col(mandatory_col).cast(mandatory_type, strict=False))
 
-    return metadata_df.unique(maintain_order=True).select("code", *final_cols)
+    return metadata_df.unique(maintain_order=True).select("code", "code_template", *final_cols)
 
 
 def extract_all_metadata(
@@ -220,15 +224,15 @@ def extract_all_metadata(
         >>> extract_all_metadata(
         ...     raw_metadata, event_cfgs, allowed_codes=["FOO//A//1", "BAR//B//2"]
         ... )
-        shape: (2, 3)
-        ┌───────────┬──────────┬───────┐
-        │ code      ┆ desc     ┆ desc2 │
-        │ ---       ┆ ---      ┆ ---   │
-        │ str       ┆ str      ┆ str   │
-        ╞═══════════╪══════════╪═══════╡
-        │ FOO//A//1 ┆ Code A-1 ┆ null  │
-        │ BAR//B//2 ┆ null     ┆ B-2   │
-        └───────────┴──────────┴───────┘
+        shape: (2, 4)
+        ┌───────────┬─────────────────────────────────┬──────────┬───────┐
+        │ code      ┆ code_template                   ┆ desc     ┆ desc2 │
+        │ ---       ┆ ---                             ┆ ---      ┆ ---   │
+        │ str       ┆ str                             ┆ str      ┆ str   │
+        ╞═══════════╪═════════════════════════════════╪══════════╪═══════╡
+        │ FOO//A//1 ┆ f"FOO//{$code}//{$code_modifie… ┆ Code A-1 ┆ null  │
+        │ BAR//B//2 ┆ f"BAR//{$code}//{$code_modifie… ┆ null     ┆ B-2   │
+        └───────────┴─────────────────────────────────┴──────────┴───────┘
     """
 
     all_metadata = []

--- a/tests/test_dftly_bridge.py
+++ b/tests/test_dftly_bridge.py
@@ -112,8 +112,9 @@ class TestExtractEvent:
         )
         cfg = {"code": 'f"{$test_name}//{$units}"', "time": '$time::"%Y-%m-%d"'}
         result = extract_event(raw, cfg)
-        assert result.shape == (2, 3)
         assert result["code"].to_list() == ["Lab//mg", "Vital//mmHg"]
+        assert "code_components" in result.columns
+        assert result["code_components"].struct.field("test_name").to_list() == ["Lab", "Vital"]
 
     def test_literal_code(self):
         raw = pl.DataFrame(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -213,6 +213,8 @@ def assert_df_equal(want: pl.DataFrame, got: pl.DataFrame, msg: str | None = Non
             want = want.with_columns(**update_exprs).select(want_cols)
             got = got.with_columns(**update_exprs).select(got_cols)
 
+        # Select only the columns in want from got, so extra columns don't cause failures
+        got = got.select(want.columns)
         assert_frame_equal(want, got, **kwargs)
     except AssertionError as e:
         pl.Config.set_tbl_rows(-1)


### PR DESCRIPTION
Phase 1+2+3 of structured code tracking:

- code_components: struct column with individual column values that compose the code (e.g., {test_name: "Glucose", units: "mg/dL"}). Only added when the code expression references source columns.

- source_block: string column tracking which MESSY config block produced each event (e.g., "patients/eye_color", "labs_vitals/lab"). Format is "{input_prefix}/{event_name}".

- code_template: string column in metadata/codes.parquet storing the dftly expression that produced each code (e.g., 'f"{$test_name}//{$units}"').

These enable downstream tools to:
- Join metadata on individual code components (partial matching)
- Trace event provenance back to the extraction config
- Understand code structure without parsing the code string