### PR TITLE
Add metadata extraction to the example and demonstrate in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,27 @@ The metadata directory contains a dataset descriptor, code metadata, and subject
 ['held_out', 'train', 'tuning']
 >>> len(splits)
 10
+
+```
+
+The event config includes a `_metadata` block that links lab events to a descriptions
+file. The extracted metadata maps each lab code to its human-readable description:
+
+```python
+>>> codes = pl.read_parquet(output / "metadata" / "codes.parquet")
+>>> codes.sort("code").head(5)
+shape: (5, 2)
+┌─────────────────────┬──────────────────────────┐
+│ code                ┆ description              │
+│ ---                 ┆ ---                      │
+│ str                 ┆ str                      │
+╞═════════════════════╪══════════════════════════╡
+│ ALT (U/L)           ┆ Alanine aminotransferase │
+│ Creatinine (mg/dL)  ┆ Serum creatinine         │
+│ Diastolic BP (mmHg) ┆ Diastolic blood pressure │
+│ Glucose (mg/dL)     ┆ Blood glucose level      │
+│ Heart Rate (bpm)    ┆ Heart rate / pulse       │
+└─────────────────────┴──────────────────────────┘
 >>> _ = shutil.rmtree(tmpdir)
 
 ```

--- a/example/event_cfg.yaml
+++ b/example/event_cfg.yaml
@@ -26,6 +26,9 @@ labs_vitals:
     code: $test_name
     time: '$timestamp::"%Y-%m-%dT%H:%M:%S"'
     numeric_value: $result
+    _metadata:
+      lab_descriptions:
+        description: description
 
 medications:
   med:

--- a/example/raw_data/lab_descriptions.csv
+++ b/example/raw_data/lab_descriptions.csv
@@ -1,0 +1,10 @@
+test_name,description,loinc_code
+Systolic BP (mmHg),Systolic blood pressure,8480-6
+Diastolic BP (mmHg),Diastolic blood pressure,8462-4
+Glucose (mg/dL),Blood glucose level,2345-7
+Heart Rate (bpm),Heart rate / pulse,8867-4
+ALT (U/L),Alanine aminotransferase,1742-6
+Creatinine (mg/dL),Serum creatinine,2160-0
+Hemoglobin A1c (%),Glycated hemoglobin,4548-4
+Temperature (F),Body temperature,8310-5
+WBC (10^3/uL),White blood cell count,6690-2


### PR DESCRIPTION
- Add lab_descriptions.csv with test names, descriptions, and LOINC codes
- Add _metadata block to event config linking lab events to descriptions
- Extend README end-to-end doctest to show extracted code metadata (codes.parquet with description column)