### PR TITLE
Fix bugs in code_template aggregation and _match_on validation

### DIFF
--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -158,10 +158,10 @@ def extract_metadata(
         final_cols.append(out_col)
         needed_cols.update(needed)
 
-    code_value = str(event_cfg.pop("code"))
-    code_node = Parser()(code_value)
+    code_template_str = str(event_cfg.pop("code"))
+    code_node = Parser()(code_template_str)
     code_expr = code_node.polars_expr
-    needed_code_cols = code_node.referenced_columns
+    code_referenced_cols = code_node.referenced_columns
 
     columns = metadata_df.collect_schema().names()
 
@@ -170,6 +170,14 @@ def extract_metadata(
         # The metadata table only needs the _match_on columns, not all code columns.
         if isinstance(match_on, str):
             match_on = [match_on]
+
+        invalid_match_cols = set(match_on) - code_referenced_cols
+        if invalid_match_cols:
+            raise KeyError(
+                f"_match_on columns {invalid_match_cols} are not referenced by the code expression "
+                f"'{code_template_str}'. Valid columns: {code_referenced_cols}"
+            )
+
         missing_match_cols = set(match_on) - set(columns) - set(final_cols)
         if missing_match_cols:
             raise KeyError(f"_match_on columns {missing_match_cols} not found in metadata columns: {columns}")
@@ -183,28 +191,27 @@ def extract_metadata(
                 df_select_exprs[col] = pl.col(col)
 
         metadata_df = metadata_df.select(**df_select_exprs).with_columns(
-            code_template=pl.lit(code_value),
+            code_template=pl.lit(code_template_str),
         )
 
         if allowed_codes is not None:
-            # Build a partial code → full codes mapping from allowed_codes using code_components
             # For partial matching, we can't filter by exact code — we broadcast metadata to all
             # matching codes. allowed_codes filtering happens after the join in the reducer.
             pass
 
     else:
         # Full matching: reconstruct the complete code from the metadata table
-        missing_cols = (needed_cols | needed_code_cols) - set(columns) - set(final_cols)
+        missing_cols = (needed_cols | code_referenced_cols) - set(columns) - set(final_cols)
         if missing_cols:
             raise KeyError(f"Columns {missing_cols} not found in metadata columns: {columns}")
 
-        for col in needed_code_cols:
+        for col in code_referenced_cols:
             if col not in df_select_exprs:
                 df_select_exprs[col] = pl.col(col)
 
         metadata_df = metadata_df.select(**df_select_exprs).with_columns(
             code=code_expr,
-            code_template=pl.lit(code_value),
+            code_template=pl.lit(code_template_str),
         )
 
         if allowed_codes:
@@ -525,12 +532,15 @@ def main(cfg: DictConfig):
     logger.info(f"Collected metadata for {n_unique_obs} unique codes among {n_rows} total observations.")
 
     if n_unique_obs != n_rows:
-        aggs = {c: pl.col(c) for c in metadata_cols if c not in MEDS_METADATA_MANDATORY_TYPES}
+        skip_cols = {*MEDS_METADATA_MANDATORY_TYPES, "code_template"}
+        aggs = {c: pl.col(c) for c in metadata_cols if c not in skip_cols}
         if "description" in metadata_cols:
             separator = cfg.stage_cfg.description_separator
             aggs["description"] = pl.col("description").str.join(separator)
         if "parent_codes" in metadata_cols:
             aggs["parent_codes"] = pl.col("parent_codes").explode()
+        if "code_template" in metadata_cols:
+            aggs["code_template"] = pl.col("code_template").first()
 
         reduced = reduced.group_by(join_cols).agg(**aggs)
 

--- a/tests/test_inprocess_pipeline.py
+++ b/tests/test_inprocess_pipeline.py
@@ -622,3 +622,97 @@ data:
         assert "HR" in codes_df["code"].to_list()
         # custom_prop should be present
         assert "custom_prop" in codes_df.columns
+
+
+def test_extract_code_metadata_code_template_survives_aggregation():
+    """Tests that code_template remains a scalar string (not a list) after duplicate code aggregation."""
+    from MEDS_extract.extract_code_metadata.extract_code_metadata import main as ecm_stage
+
+    metadata_cfg = """\
+subject_id_col: subject_id
+data:
+  measurement:
+    code: $lab_code
+    _metadata:
+      source_a:
+        description: title_a
+      source_b:
+        description: title_b
+"""
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+
+        events_dir = root / "events" / "train" / "0"
+        events_dir.mkdir(parents=True)
+        pl.DataFrame({"subject_id": [1], "time": [None], "code": ["HR"], "numeric_value": [None]}).cast(
+            {"subject_id": pl.Int64, "time": pl.Datetime("us"), "numeric_value": pl.Float32}
+        ).write_parquet(events_dir / "data.parquet")
+
+        raw_dir = root / "raw"
+        raw_dir.mkdir()
+        (raw_dir / "source_a.csv").write_text("lab_code,title_a\nHR,Heart Rate\n")
+        (raw_dir / "source_b.csv").write_text("lab_code,title_b\nHR,Pulse Rate\n")
+
+        event_cfg_fp = root / "event_cfgs.yaml"
+        event_cfg_fp.write_text(metadata_cfg)
+        shards_fp = root / "metadata" / ".shards.json"
+        shards_fp.parent.mkdir(parents=True)
+        shards_fp.write_text(json.dumps({"train/0": [1]}))
+
+        out_dir = root / "metadata_out" / "metadata"
+        out_dir.mkdir(parents=True)
+
+        cfg = _make_cfg(
+            {
+                "input_dir": str(raw_dir),
+                "stage_cfg": {
+                    "data_input_dir": str(root / "events"),
+                    "output_dir": str(out_dir),
+                    "metadata_input_dir": str(root / "empty_meta"),
+                    "reducer_output_dir": str(out_dir),
+                    "description_separator": "; ",
+                },
+                "event_conversion_config_fp": str(event_cfg_fp),
+                "shards_map_fp": str(shards_fp),
+            }
+        )
+        ecm_stage.main_fn(cfg)
+
+        codes_df = pl.read_parquet(out_dir / "codes.parquet")
+        assert "code_template" in codes_df.columns
+        # code_template must be a String, not a List — regression test for aggregation bug
+        assert codes_df.schema["code_template"] == pl.String
+        hr_row = codes_df.filter(pl.col("code") == "HR")
+        assert hr_row["code_template"][0] == "$lab_code"
+
+
+def test_extract_metadata_invalid_match_on():
+    """Tests that _match_on raises KeyError when column isn't referenced by the code expression."""
+    from MEDS_extract.extract_code_metadata.extract_code_metadata import extract_metadata
+
+    metadata_df = pl.DataFrame({"medication_name": ["X"], "desc": ["Y"]}).lazy()
+    event_cfg = {
+        "code": 'f"{$medication_name}//{$dose}"',
+        "_metadata": {"_match_on": "typo_column", "description": "desc"},
+    }
+
+    with pytest.raises(KeyError, match="not referenced by the code expression"):
+        extract_metadata(metadata_df, event_cfg)
+
+
+def test_extract_metadata_partial_match_multi_column():
+    """Tests _match_on with multiple columns."""
+    from MEDS_extract.extract_code_metadata.extract_code_metadata import extract_metadata
+
+    metadata_df = pl.DataFrame({"a": ["X", "Y"], "b": ["1", "2"], "desc": ["X-1", "Y-2"]}).lazy()
+    event_cfg = {
+        "code": 'f"{$a}//{$b}//{$c}"',
+        "_metadata": {"_match_on": ["a", "b"], "description": "desc"},
+    }
+
+    result = extract_metadata(metadata_df, event_cfg)
+    collected = result.collect()
+    assert set(collected.columns) == {"a", "b", "code_template", "description"}
+    assert len(collected) == 2
+    assert collected["code_template"][0] == 'f"{$a}//{$b}//{$c}"'


### PR DESCRIPTION
Fixes:
- code_template was becoming a list column during duplicate code aggregation because it wasn't excluded from the generic agg dict. Now uses .first() aggregation (template is the same for all rows of the same code).
- Renamed confusing code_value variable to code_template_str
- Added validation that _match_on columns are actually referenced by the code expression, catching typos early