### PR TITLE
Fix retrieve_columns join/transform bugs and time null filter type error

### DIFF
--- a/src/MEDS_extract/convert_to_MEDS_events/convert_to_MEDS_events.py
+++ b/src/MEDS_extract/convert_to_MEDS_events/convert_to_MEDS_events.py
@@ -140,9 +140,16 @@ def extract_event(
         # parquet scanning before nulls are filtered (see polars issue with scan_parquet + filter).
         ts_source_cols = ts_node.referenced_columns
         if ts_source_cols:
-            ts_null_filter = pl.all_horizontal(
-                *[pl.col(c).is_not_null() & (pl.col(c) != pl.lit("")) for c in ts_source_cols]
-            )
+            # Only apply empty-string check for string columns; non-string columns (e.g., integers
+            # from transforms) would raise ComputeError on the != "" comparison.
+            schema = df.collect_schema()
+            ts_filters = []
+            for c in ts_source_cols:
+                col_filter = pl.col(c).is_not_null()
+                if schema.get(c) == pl.String or (schema.get(c) is None):
+                    col_filter = col_filter & (pl.col(c) != pl.lit(""))
+                ts_filters.append(col_filter)
+            ts_null_filter = pl.all_horizontal(*ts_filters)
         else:
             ts_null_filter = event_exprs["time"].is_not_null()
 

--- a/src/MEDS_extract/shard_events/shard_events.py
+++ b/src/MEDS_extract/shard_events/shard_events.py
@@ -222,7 +222,7 @@ def retrieve_columns(event_conversion_cfg: DictConfig) -> dict[str, list[str]]:
         ...     },
         ... })
         >>> retrieve_columns(cfg)
-        {'patients': ['date_col', 'full_time', 'mrn', 'time_col']}
+        {'patients': ['date_col', 'mrn', 'time_col']}
     """
 
     event_conversion_cfg = copy.deepcopy(event_conversion_cfg)
@@ -239,21 +239,22 @@ def retrieve_columns(event_conversion_cfg: DictConfig) -> dict[str, list[str]]:
             prefix_to_columns.setdefault(input_prefix, set()).add(input_subject_id_column)
 
         transforms_cfg = event_cfgs.get("transforms")
+        transform_outputs = set()
         if transforms_cfg is not None:
+            transform_outputs = {k for k, v in transforms_cfg.items() if isinstance(v, str)}
             for transform_value in transforms_cfg.values():
                 if isinstance(transform_value, str):
                     prefix_to_columns[input_prefix].update(extract_columns(transform_value))
 
         join_cfg = event_cfgs.get("join")
+        joined_columns = set()
         if join_cfg is not None:
             join_prefix = join_cfg["input_prefix"]
             prefix_to_columns[input_prefix].add(join_cfg["left_on"])
             prefix_to_columns.setdefault(join_prefix, set()).add(join_cfg["right_on"])
             for col in join_cfg.get("columns_from_right", []):
                 prefix_to_columns.setdefault(join_prefix, set()).add(col)
-                if col in prefix_to_columns[input_prefix]:
-                    logger.debug(f"Removing {col} from {input_prefix} extraction plan as it is joined in")
-                    prefix_to_columns[input_prefix].remove(col)
+                joined_columns.add(col)
 
         for event_name, event_cfg in event_cfgs.items():
             if event_name in EVENT_META_KEYS:
@@ -265,6 +266,10 @@ def retrieve_columns(event_conversion_cfg: DictConfig) -> dict[str, list[str]]:
                     continue
                 if isinstance(value, str):
                     prefix_to_columns[input_prefix].update(extract_columns(value))
+
+        # Remove columns that don't come from the source file: transform outputs are computed
+        # at runtime, and joined columns come from the right-side table.
+        prefix_to_columns[input_prefix] -= transform_outputs | joined_columns
 
     return {k: sorted(v) for k, v in prefix_to_columns.items()}
 

--- a/tests/test_dftly_bridge.py
+++ b/tests/test_dftly_bridge.py
@@ -264,6 +264,20 @@ class TestExtractEvent:
         assert result["subject_id"][0] == 1
         assert result["code"][0] == "MEDS_DEATH"
 
+    def test_time_from_non_string_column(self):
+        """Regression: time null filter must not compare non-string columns with empty string (#68)."""
+        raw = pl.DataFrame(
+            {
+                "subject_id": [1, 2, 3],
+                "year_of_birth": [1980, None, 1990],
+            }
+        )
+        cfg = {"code": "MEDS_BIRTH", "time": "$year_of_birth::year"}
+        result = extract_event(raw, cfg)
+        # Should filter out the null row, not crash with ComputeError
+        assert len(result) == 2
+        assert set(result["subject_id"].to_list()) == {1, 3}
+
 
 # ── convert_to_events() ───────────────────────────────────────────────
 

--- a/tests/test_shard_events.py
+++ b/tests/test_shard_events.py
@@ -234,6 +234,58 @@ data:
     assert "val" in cols["data"]
 
 
+def test_retrieve_columns_excludes_transform_outputs():
+    """Regression: transform output columns must not appear in the source file extraction plan (#67)."""
+    cfg_yaml = """\
+hosp/patients:
+  transforms:
+    year_of_birth: "$anchor_year - $anchor_age"
+  dob:
+    code: MEDS_BIRTH
+    time: '$year_of_birth::year'
+"""
+    cfg = OmegaConf.create(load_yaml(cfg_yaml, Loader=Loader))
+    cols = retrieve_columns(cfg)
+    # year_of_birth is a transform OUTPUT, not a source column
+    assert "year_of_birth" not in cols["hosp/patients"], (
+        f"Transform output 'year_of_birth' should not be in extraction plan: {cols['hosp/patients']}"
+    )
+    # But the transform's SOURCE columns should be present
+    assert "anchor_year" in cols["hosp/patients"]
+    assert "anchor_age" in cols["hosp/patients"]
+
+
+def test_retrieve_columns_excludes_joined_columns_referenced_in_events():
+    """Regression: joined columns must not be re-added to left-side extraction plan (#66)."""
+    cfg_yaml = """\
+hosp/drgcodes:
+  join:
+    input_prefix: hosp/admissions
+    left_on: hadm_id
+    right_on: hadm_id
+    columns_from_right:
+      - dischtime
+  subject_id_col: subject_id
+  drg:
+    code: 'f"DRG//{$drg_type}//{$drg_code}"'
+    time: '$dischtime::"%Y-%m-%d %H:%M:%S"'
+hosp/admissions:
+  subject_id_col: subject_id
+"""
+    cfg = OmegaConf.create(load_yaml(cfg_yaml, Loader=Loader))
+    cols = retrieve_columns(cfg)
+    # dischtime comes from the join (columns_from_right), not the left-side file
+    assert "dischtime" not in cols["hosp/drgcodes"], (
+        f"Joined column 'dischtime' should not be in left-side extraction plan: {cols['hosp/drgcodes']}"
+    )
+    # It should be in the right-side extraction plan
+    assert "dischtime" in cols["hosp/admissions"]
+    # Left-side should have its own columns
+    assert "drg_type" in cols["hosp/drgcodes"]
+    assert "drg_code" in cols["hosp/drgcodes"]
+    assert "hadm_id" in cols["hosp/drgcodes"]
+
+
 def test_shard_events_join():
     single_stage_tester(
         script=SHARD_EVENTS_SCRIPT,


### PR DESCRIPTION
## Summary
- Fix `retrieve_columns` adding joined columns back to left-side extraction plan (#66)
- Fix `retrieve_columns` adding transform output columns to source file extraction plan (#67)
- Fix time null filter comparing non-string columns with empty string (#68)

All three bugs were discovered during MIMIC-IV pipeline migration and prevent real-world usage of `join` and `transforms` features.

## Test plan
- [x] `test_retrieve_columns_excludes_transform_outputs` — verifies transform outputs excluded from plan
- [x] `test_retrieve_columns_excludes_joined_columns_referenced_in_events` — verifies joined columns excluded from left-side plan
- [x] `test_time_from_non_string_column` — verifies non-string time columns don't crash
- [x] All 71 existing tests pass
- [x] `retrieve_columns` doctest updated (was showing wrong expected output)

Closes #66, closes #67, closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)