### PR TITLE
Bump MEDS-transforms to >=0.6.7,<0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "hydra-core",
   "numpy",
   "meds~=0.4.0",
-  "MEDS-transforms~=0.6.0",
+  "MEDS-transforms>=0.6.7,<0.7",
   "universal_pathlib",
   "dftly>=0.3.0"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1381,7 +1381,7 @@ requires-dist = [
     { name = "hydra-submitit-launcher", marker = "extra == 'slurm-parallelism'" },
     { name = "jupyter", marker = "extra == 'example'" },
     { name = "meds", specifier = "~=0.4.0" },
-    { name = "meds-transforms", specifier = "~=0.6.0" },
+    { name = "meds-transforms", specifier = ">=0.6.7,<0.7" },
     { name = "numpy" },
     { name = "polars", specifier = ">=1.26" },
     { name = "pyarrow" },
@@ -1431,7 +1431,7 @@ wheels = [
 
 [[package]]
 name = "meds-transforms"
-version = "0.6.3"
+version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -1443,10 +1443,11 @@ dependencies = [
     { name = "pretty-print-directory" },
     { name = "pyarrow" },
     { name = "pytest" },
+    { name = "yaml-to-disk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/a7/b99f69a275c76ac10577c3687bfbdabaa59f8748257e0e6c6ba20a79fe7d/meds_transforms-0.6.3.tar.gz", hash = "sha256:7d023d00fd94b019b16a929b4cb6e6b1e2a6bb969f0eae149ad2c9792fb82e44", size = 431697, upload-time = "2026-04-08T02:01:05.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/19/407efdafc8adbb8385495579934d88fdf8c5c8373fc2e76026fe0b54e26d/meds_transforms-0.6.7.tar.gz", hash = "sha256:8c957a5743d7e53b2262d3898356feb7c2ebcb3236b5b10156ef5c44c2774149", size = 589647, upload-time = "2026-04-18T14:45:25.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/36/10009e5522f6359186b5bc200180dfefe854ff1f3dfbcb6e7f42ace5d8cf/meds_transforms-0.6.3-py3-none-any.whl", hash = "sha256:e8584626789a0eb8d997bd5f225144fdcabf2e85a2c1065900f11527b0158425", size = 206617, upload-time = "2026-04-08T02:01:02.72Z" },
+    { url = "https://files.pythonhosted.org/packages/40/19/55d217de368c7fb643f89f7ef312092740c24c189f75ec28d7c68b0b1dbd/meds_transforms-0.6.7-py3-none-any.whl", hash = "sha256:ce4b458f9e26e31a3e1fe7000769bb7be5b3bf58c3ba0da071d639a6a4a013c0", size = 219935, upload-time = "2026-04-18T14:45:23.714Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First in a sequence of PRs migrating MEDS_extract onto MEDS-transforms 0.6.x's `StageExample`-based testing + auto stage-docs infrastructure (the same pattern that was applied in [meds-torch-data#86](https://github.com/mmcdermott/meds-torch-data/pull/86) and [meds-torch-data#90](https://github.com/mmcdermott/meds-torch-data/pull/90)).

This PR does only the dependency bump so it can land in isolation:

- `MEDS-transforms~=0.6.0` → `>=0.6.7,<0.7`

0.6.7 adds the `StageExample.render_content(example_dir)` hook and `MEDS_transforms.stages.docgen.generate_stage_docs(package)` helper that the subsequent PRs depend on.

## Test plan

- [x] `uv sync` resolves cleanly against 0.6.7
- [x] `uv run pytest` — 67 passed locally
- [ ] CI: tests on 3.11 and 3.12

## Follow-ups

- Add `MEDSExtractStageExample` subclass (if needed) + migrate one pilot stage
- Migrate remaining stages to `examples/` scenario directories, delete bespoke test files as we go
- Wire up `docs/gen_stage_docs.py` + mkdocs-gen-files

🤖 Generated with [Claude Code](https://claude.com/claude-code)