### PR TITLE
Hotfix: pin dftly<0.2.0 for MEDS-extract 0.6.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "meds~=0.4.0",
   "MEDS-transforms~=0.6.0",
   "universal_pathlib",
-  "dftly>=0.1.2"
+  "dftly>=0.1.2,<0.2.0"
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1276,7 +1276,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dftly", specifier = ">=0.1.2" },
+    { name = "dftly", specifier = ">=0.1.2,<0.2.0" },
     { name = "hydra-core" },
     { name = "hydra-joblib-launcher", marker = "extra == 'local-parallelism'" },
     { name = "hydra-submitit-launcher", marker = "extra == 'slurm-parallelism'" },


### PR DESCRIPTION
## Summary
- Pin `dftly<0.2.0` to match MEDS-extract 0.6.x's use of `extract_columns`.
- Targets `main` (not `dev`) because the published 0.6.0 release is affected; `dev` has already moved past this import and uses `dftly>=0.3.0`.

## Background
`src/MEDS_extract/shard_events/shard_events.py` imports `extract_columns` from `dftly`. That symbol was removed from dftly's public API in **0.2.0**. Until now, MEDS-extract 0.6.0's dep line was `dftly>=0.1.2` (unbounded), so fresh installs pip-resolve to the latest dftly (currently 0.3.x) and fail at import time with `ImportError: cannot import name 'extract_columns' from 'dftly'`.

The user report indicated the break was at dftly 0.1.5, but empirical testing shows:

| dftly | 0.6.0 import | 
|-------|--------------|
| 0.1.2 | ✅ works |
| 0.1.3 | ✅ works |
| 0.1.4 | ✅ works |
| 0.1.5 | ✅ works (last working) |
| 0.2.0 | ❌ `extract_columns` removed |
| 0.2.x | ❌ |
| 0.3.x | ❌ |

So the correct ceiling is `<0.2.0`.

## Release notes / followups
- MEDS-extract **0.6.0** is already on PyPI with the unbounded dep. Consider cutting **0.6.1** from this hotfix so users get a fixed version on `pip install`. Optionally yank 0.6.0 on PyPI since it is currently broken against the default dftly resolution.
- No code changes are needed; `dev` / next-release line already uses `dftly>=0.3.0` and the `extract_columns` import is gone there. This ceiling applies to 0.6.x only.

## Test plan
- [x] `uv pip compile pyproject.toml` resolves to `dftly==0.1.5` under the new constraint.
- [ ] CI passes on this branch.
- [ ] Confirm plan for 0.6.1 release / 0.6.0 yank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)