### PR TITLE
Upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -17,7 +17,7 @@ runs:
         python-version: "${{ inputs.python-version }}"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         cache-suffix: "py${{ inputs.python-version }}"

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -12,12 +12,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "${{ inputs.python-version }}"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8
       with:
         enable-cache: true
         cache-suffix: "py${{ inputs.python-version }}"

--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup package
         uses: ./.github/actions/setup

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -15,7 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          # Need history back to the PR base so `git diff` can report what changed.
+          fetch-depth: 0
 
       - name: Setup package
         uses: ./.github/actions/setup
@@ -24,12 +27,19 @@ jobs:
 
       - name: Find modified files
         id: file_changes
-        uses: tj-actions/changed-files@v46.0.5
-
-      - name: List all changed files
-        run: echo '${{ steps.file_changes.outputs.all_changed_files }}'
+        # Native ``git diff`` replaces ``tj-actions/changed-files``. Output is a
+        # space-separated list of paths that were Added / Copied / Modified / Renamed
+        # between the PR base and the current ref. GitHub sets ``GITHUB_BASE_REF`` on
+        # ``pull_request`` events.
+        run: |
+          base_ref="origin/${GITHUB_BASE_REF}"
+          git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}"
+          files=$(git diff --name-only --diff-filter=ACMR "${base_ref}"...HEAD | tr '\n' ' ')
+          echo "Changed files: ${files}"
+          echo "all_changed_files=${files}" >> "$GITHUB_OUTPUT"
 
       - name: Run pre-commits
+        if: ${{ steps.file_changes.outputs.all_changed_files != '' }}
         run: >
           uv run pre-commit run --show-diff-on-failure
-          --files ${{ steps.file_changes.outputs.all_changed_files}}
+          --files ${{ steps.file_changes.outputs.all_changed_files }}

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -12,15 +12,15 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -28,7 +28,7 @@ jobs:
         run: uv build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -69,13 +69,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup package
         uses: ./.github/actions/setup
@@ -30,7 +30,7 @@ jobs:
           uv run pytest -v --cov=src --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov


### PR DESCRIPTION
## Summary
- Bump every action pin to its current major tag (checkout v6, setup-python v6, upload/download-artifact v7/v8, setup-uv v8, codecov v6, sigstore v3.3).
- Replace `tj-actions/changed-files` (March 2025 supply-chain incident + flaky) with an inline `git diff` against the PR base ref.
- Scope is strictly `.github/` — no source or test changes.

## Rationale
You flagged some of these as known flaky at their current pinned versions. `tj-actions/changed-files` specifically had a publicized supply-chain incident where a malicious commit was injected into the action, so the safer move is to drop the dependency entirely rather than upgrade it; a three-line `git diff` replaces it cleanly.

## Version table
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `astral-sh/setup-uv` | v6 | v8 |
| `codecov/codecov-action` | v4.0.1 | v6 |
| `sigstore/gh-action-sigstore-python` | v3.0.0 | v3.3.0 |
| `tj-actions/changed-files` | v46.0.5 | **removed** (→ native `git diff`) |
| `codecov/test-results-action` | v1 | v1 (unchanged — already current) |
| `pypa/gh-action-pypi-publish` | release/v1 | release/v1 (rolling tag) |

## Test plan
- [ ] `tests` job (core + download, 3.11 + 3.12) passes.
- [ ] `code-quality-pr` runs the inline `git diff` step cleanly and feeds pre-commit.
- [ ] `python-build` still builds the sdist + wheel (the publish/release stages are tag-gated, won't fire here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)