### PR TITLE
HTTPSource: support custom request headers (#91)

### DIFF
--- a/src/MEDS_extract/download/backends/http.py
+++ b/src/MEDS_extract/download/backends/http.py
@@ -66,8 +66,10 @@ class HTTPSource(Source):
             at :meth:`list_files` time (e.g. :class:`PhysioNetSource`) may pass ``None``.
         client: Optional pre-built :class:`httpx.Client`. When omitted, one is built via
             :meth:`_make_client` with the remaining kwargs.
-        auth, timeout, max_attempts, transport: Forwarded to :meth:`_make_client` when
-            ``client`` is not provided.
+        auth, headers, timeout, max_attempts, transport: Forwarded to :meth:`_make_client`
+            when ``client`` is not provided. ``headers`` is a ``{name: value}`` mapping
+            applied as default headers on every request — used for API-key auth
+            (``X-Dataverse-key``, bearer tokens) and content negotiation (``Accept:``).
 
     Examples:
         Plain string URLs resolve to basename-based relative paths:
@@ -115,6 +117,7 @@ class HTTPSource(Source):
         urls: list[str | dict] | None = None,
         client: httpx.Client | None = None,
         auth: tuple[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: tuple[float, float] = (10.0, 60.0),
         max_attempts: int = 5,
         transport: httpx.BaseTransport | None = None,
@@ -127,7 +130,13 @@ class HTTPSource(Source):
         self._client = (
             client
             if client is not None
-            else self._make_client(auth=auth, timeout=timeout, max_attempts=max_attempts, transport=transport)
+            else self._make_client(
+                auth=auth,
+                headers=headers,
+                timeout=timeout,
+                max_attempts=max_attempts,
+                transport=transport,
+            )
         )
 
     def list_files(self) -> Iterable[RemoteFile]:
@@ -156,6 +165,7 @@ class HTTPSource(Source):
     def _make_client(
         cls,
         auth: tuple[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: tuple[float, float] = (10.0, 60.0),
         max_attempts: int = 5,
         transport: httpx.BaseTransport | None = None,
@@ -164,6 +174,11 @@ class HTTPSource(Source):
 
         Args:
             auth: Optional ``(username, password)`` for Basic auth — e.g. PhysioNet credentials.
+            headers: Optional ``{name: value}`` mapping applied as default headers on every
+                request the client issues (both ``list_files`` GETs and streaming ``.part``
+                downloads). Intended for API-key auth (DataVerse's ``X-Dataverse-key``,
+                generic bearer tokens) and content negotiation (``Accept:``). ``None``
+                behaves like absent.
             timeout: ``(connect_timeout, read_timeout)`` in seconds.
             max_attempts: Total number of attempts (including the first) before giving up.
                 ``max_attempts=5`` = 1 initial try + up to 4 retries.
@@ -209,10 +224,30 @@ class HTTPSource(Source):
             >>> len(attempts)  # 2 retries before the 200
             3
             >>> client.close()
+
+            Custom ``headers`` reach the transport on every request — the motivating case
+            is DataVerse's ``X-Dataverse-key`` API-key auth, but the same kwarg covers
+            bearer tokens and ``Accept:`` content negotiation:
+
+            >>> seen_headers = []
+            >>> def capture(request):
+            ...     seen_headers.append(dict(request.headers))
+            ...     return _httpx.Response(200, text="ok")
+            >>> client = HTTPSource._make_client(
+            ...     headers={"X-Dataverse-key": "secret-token", "Accept": "application/json"},
+            ...     transport=_httpx.MockTransport(capture),
+            ... )
+            >>> _ = client.get("https://example.com/x")
+            >>> seen_headers[0]["x-dataverse-key"]
+            'secret-token'
+            >>> seen_headers[0]["accept"]
+            'application/json'
+            >>> client.close()
         """
         connect_timeout, read_timeout = timeout
         client_kwargs: dict = {
             "auth": httpx.BasicAuth(*auth) if auth else None,
+            "headers": headers,
             "timeout": httpx.Timeout(
                 connect=connect_timeout, read=read_timeout, write=read_timeout, pool=60.0
             ),

--- a/src/MEDS_extract/download/backends/physionet.py
+++ b/src/MEDS_extract/download/backends/physionet.py
@@ -34,8 +34,10 @@ class PhysioNetSource(HTTPSource):
         password: PhysioNet password. Omit for open-access datasets.
         client: Optional injected :class:`httpx.Client` (used by tests). When omitted,
             one is built via :meth:`HTTPSource._make_client` with the supplied auth.
-        timeout, max_attempts, transport: Forwarded to :meth:`HTTPSource._make_client`
-            when ``client`` is not provided.
+        headers, timeout, max_attempts, transport: Forwarded to :meth:`HTTPSource._make_client`
+            when ``client`` is not provided. ``headers`` is rarely needed for PhysioNet —
+            Basic auth covers the credentialed releases — but it's passed through for
+            symmetry with :class:`HTTPSource`.
 
     Examples:
         Public releases (e.g. MIMIC-IV demo) need no auth — construction is eager but does
@@ -67,6 +69,7 @@ class PhysioNetSource(HTTPSource):
         username: str | None = None,
         password: str | None = None,
         client: httpx.Client | None = None,
+        headers: dict[str, str] | None = None,
         timeout: tuple[float, float] = (10.0, 60.0),
         max_attempts: int = 5,
         transport: httpx.BaseTransport | None = None,
@@ -83,6 +86,7 @@ class PhysioNetSource(HTTPSource):
             urls=None,
             client=client,
             auth=auth,
+            headers=headers,
             timeout=timeout,
             max_attempts=max_attempts,
             transport=transport,

--- a/src/MEDS_extract/download/dispatch.py
+++ b/src/MEDS_extract/download/dispatch.py
@@ -52,6 +52,18 @@ def source_from_config(cfg: dict) -> Source:
         Traceback (most recent call last):
             ...
         ValueError: Source config is missing a 'type:' key. Got: {'urls': ['https://example.com/x.csv']}
+
+        Backend-specific kwargs pass through verbatim — e.g. ``HTTPSource``'s ``headers:``
+        for API-key auth (DataVerse ``X-Dataverse-key``, bearer tokens, ``Accept:``):
+
+        >>> src = source_from_config({
+        ...     "type": "http",
+        ...     "urls": ["https://example.com/x.csv"],
+        ...     "headers": {"X-Dataverse-key": "secret-token"},
+        ... })
+        >>> src._client.headers["X-Dataverse-key"]
+        'secret-token'
+        >>> src.close()
     """
     cfg = dict(cfg)
     source_type = cfg.pop("type", None)

--- a/src/MEDS_extract/download/fetcher.py
+++ b/src/MEDS_extract/download/fetcher.py
@@ -172,13 +172,19 @@ class Fetcher:
         >>> report.ok
         False
 
-        Without ``continue_on_error``, the first failure re-raises:
+        Without ``continue_on_error``, the first failure re-raises. Caught
+        explicitly so the doctest matches the *type and message* of the
+        underlying exception rather than the full traceback — Python 3.12.x
+        bumps add chained "During handling of the above exception" frames to
+        ``concurrent.futures``-wrapped errors that the bare ``Traceback ...``
+        form can't ELLIPSIS over.
 
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     Fetcher(Path(d), continue_on_error=False).fetch_all(PartialSource())
-        Traceback (most recent call last):
-            ...
-        RuntimeError: transport failure
+        ...     try:
+        ...         Fetcher(Path(d), continue_on_error=False).fetch_all(PartialSource())
+        ...     except RuntimeError as e:
+        ...         print(f"raised: {type(e).__name__}: {e}")
+        raised: RuntimeError: transport failure
 
         ``do_overwrite=True`` forces re-fetch even when the file already exists on disk
         with the right size + hash (normally that path returns ``skipped``):


### PR DESCRIPTION
## Summary

- Adds `headers: dict[str, str] | None = None` kwarg to `HTTPSource.__init__` and `HTTPSource._make_client`, threaded into `httpx.Client(headers=...)`. Values apply as default headers on every request — both `list_files` GETs and streaming `.part` downloads.
- `PhysioNetSource` forwards the kwarg for symmetry.
- Dispatcher at `download/dispatch.py` already splats `**cfg` into the backend constructor, so `headers:` in YAML passes through verbatim. Added a doctest to lock this in.
- `None` behaves identically to the kwarg being absent — no change in behavior for existing configs (MIMIC-IV, eICU, HIRID, etc.).

Motivating case: AUMCdb on DANS Data Stations (DataVerse) authenticates via `X-Dataverse-key: <api-key>` rather than HTTP Basic. Without this kwarg, AUMCdb_MEDS can't migrate off its hand-rolled `curl -H ... | zipfile.extractall` download.py. Also unblocks bearer-token auth and `Accept:` content negotiation.

Closes #91.

## Breaking-change assessment

Non-breaking — new kwarg with safe default. `None` ≡ absent ≡ current behavior.

## Follow-ups (separate PRs)

- #92 (archive unpack): AUMCdb ships a single zip at the DataVerse URL, so the migration also needs post-fetch unpack. This PR is the first of the two.
- #89 (`DataverseSource`): A full DataVerse-API backend would be nicer long-term but costs a dep and a new class. This minimal change is enough to unblock AUMCdb today.

## Test plan

- [x] New doctest on `_make_client` using `httpx.MockTransport` that captures and asserts on `request.headers["x-dataverse-key"]` + `["accept"]`.
- [x] New doctest on `dispatch.source_from_config` that builds a `headers:`-carrying config and verifies `src._client.headers["X-Dataverse-key"]` is set.
- [x] Existing doctests on `_make_client` (basic auth, 5xx-retry, 4xx-fail-fast) still pass unchanged.
- [x] `pytest --doctest-modules -m "not integration"` — 118 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)