### PR TITLE
Lower test_example concurrency from 8 to 4 (PhysioNet rate limit)

### DIFF
--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -100,17 +100,20 @@ def test_example_pipeline_end_to_end():
 
         # Stage 0: ``meds-extract-download`` — populates ``raw_input`` from both the
         # ``fsspec`` source (bundled synthetic CSVs) AND the ``physionet`` source
-        # (MIMIC-IV demo, ~5 MiB of real network traffic). ``concurrency=8`` shaves
-        # seconds off the PhysioNet leg. ``hydra.run.dir`` redirects the Hydra output
-        # tree under ``tmp_path`` so the test doesn't leave droppings in CWD — users
-        # running the README's invocation don't need this override. ``timeout=`` caps a
-        # wedged PhysioNet fetch at ~10 min so the whole job fails fast instead of
-        # hitting GHA's 30-minute job timeout.
+        # (MIMIC-IV demo, ~5 MiB of real network traffic). ``concurrency=4`` matches
+        # the ``Fetcher`` docstring's safe-floor recommendation for PhysioNet —
+        # ``concurrency=8`` empirically tripped intermittent ``httpx.ConnectTimeout``
+        # against PhysioNet's rate limiter, both locally and in CI. The savings (a
+        # few seconds on a ~30s leg) aren't worth the flake. ``hydra.run.dir``
+        # redirects the Hydra output tree under ``tmp_path`` so the test doesn't
+        # leave droppings in CWD — users running the README's invocation don't need
+        # this override. ``timeout=`` caps a wedged PhysioNet fetch at ~10 min so
+        # the whole job fails fast instead of hitting GHA's 30-minute job timeout.
         download_cmd = [
             "meds-extract-download",
             f"spec={MESSY_YAML}",
             f"raw_input_dir={raw_input}",
-            "concurrency=8",
+            "concurrency=4",
             f"hydra.run.dir={tmpdir_p / '.hydra_download'}",
         ]
         download_run = subprocess.run(download_cmd, capture_output=True, text=True, env=env, timeout=600)


### PR DESCRIPTION
## Summary

`test_example_pipeline_end_to_end` (the `@integration`-gated end-to-end test) was hitting `httpx.ConnectTimeout` against PhysioNet's rate limiter when `concurrency=8`. Empirically:

- **Local repro**: `concurrency=8` fails partway through the 34-file PhysioNet leg (some files succeed, then a connection times out). `concurrency=2` succeeds in ~30s.
- **CI repro**: Identical pattern across PRs #96, #97, #99 in the last hour — partial successes then `httpcore.ConnectTimeout: timed out`. Unrelated to any code change in those PRs.

The `Fetcher` docstring already calls 4 the polite floor for PhysioNet (`max_concurrency=4` is the constructor default) and 8 only "typically safe." The few seconds of savings from `concurrency=8` aren't worth the flake.

## Test plan

- [x] Verified local PhysioNet fetch succeeds with `concurrency=2` and fails with `concurrency=8` against the same network conditions.
- [ ] Watch this PR's integration job: should pass at `concurrency=4`.

## Why a separate PR

Orthogonal to every other open PR. Lands first to unblock #96 / #97 / #99 from the same flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
