### PR TITLE
Hotfix follow-up to #106: fix step-4 pipeline block + quoting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ shards_map_fp: ${output_dir}/metadata/.shards.json
 cloud_io_storage_options: {}
 
 stages:
-  - shard_events:
-      data_input_dir: ${input_dir}
+  - shard_events
   - split_and_shard_subjects
   - convert_to_subject_sharded
   - convert_to_MEDS_events
@@ -376,11 +375,11 @@ are:
 - **Hashing**: `hash($mrn)` for converting string IDs to integers
 
 > [!NOTE]
-> Quoting these expressions in YAML is optional for the forms shown here, but YAML requires it when a value
-> would otherwise be misread (e.g. one beginning with `{`, `[`, or `*`). The shipped
-> [`example/`](./example/) configs single-quote exactly the expressions YAML would otherwise mangle — the
-> f-strings and the `::`/`as` casts (e.g. `code: 'f"EYE_COLOR//{$eye_color}"'`,
-> `time: '$dob::"%Y-%m-%dT%H:%M:%S"'`) — while leaving bare literals (`MEDS_BIRTH`) and plain `$column`
+> Quoting these expressions in YAML is optional for the forms shown here (the Quick Start above leaves them
+> unquoted and they parse fine); YAML only *requires* quoting when a value would otherwise be misread — e.g.
+> one beginning with `{`, `[`, or `*`. As a safe default, the shipped [`example/`](./example/) configs
+> single-quote the f-strings and the `::`/`as` casts (e.g. `code: 'f"EYE_COLOR//{$eye_color}"'`,
+> `time: '$dob::"%Y-%m-%dT%H:%M:%S"'`) while leaving bare literals (`MEDS_BIRTH`) and plain `$column`
 > references unquoted.
 
 ### Code Construction


### PR DESCRIPTION
Follow-up to #106, which merged before this last review fix landed on the branch. Two issues remain in the merged README; both were surfaced by the deep review of the `dev` counterpart (#107) and reproduced here against the released-line deps (dftly 0.1.2, MEDS-transforms 0.6.3).

## Fixes

1. **(blocker) Step-4 pipeline block** — drop the `data_input_dir: ${input_dir}` override on the first stage. `shard_events` uses `data_input_dir.parent` as the raw-cohort root (`shard_events.py:337`), so the override makes it search one directory *too high*, and following the documented step-4 → step-5 path literally fails with `FileNotFoundError`. Bare `- shard_events` inherits the correct `${input_dir}/data` default (matching the packaged `MEDS_extract.configs._extract.yaml`).

   Verified: the hand-written pipeline from the Quick Start now runs **end-to-end (exit 0)** on `example/` data and writes `metadata/{codes,dataset.json,subject_splits}`.

2. **(minor) Quoting note** — softened the wording: the f-strings and `::`/`as` casts parse fine unquoted (the Quick Start shows them unquoted); `example/` configs quote them as a *safe default*, not because YAML would otherwise mangle them.

## Testing
- `pytest README.md` passes; `pre-commit` clean.
- Documented pipeline run reproduced exit 0 on a fresh output dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)