### PR TITLE
Docs: strict vs. lenient timestamp parsing (`?`-prefix) + dftly>=0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,59 @@ demographics:
     time: null
 ```
 
+#### Strict vs. lenient timestamp parsing
+
+In a MESSY file, a `time` format cast is **strict** by default: if a value does not match the format string,
+extraction **aborts** rather than silently guessing. Prefix the format with `?` to parse **leniently**
+instead, so an unparsable value becomes a **null** timestamp rather than aborting the whole run. Strict is
+the safe default — it surfaces malformed source timestamps loudly; reach for lenient when a column is known
+to be occasionally malformed and a null timestamp is acceptable for those rows:
+
+```yaml
+lab_results:
+  lab:
+    code: f"LAB//{$test_name}"
+    # Strict (default): a malformed timestamp aborts the run.
+    time: $result_time as "%Y-%m-%d %H:%M:%S"
+
+  lab_lenient:
+    code: f"LAB//{$test_name}"
+    # Lenient ("?" prefix): a malformed timestamp becomes a null timestamp.
+    time: $result_time as ?"%Y-%m-%d %H:%M:%S"
+```
+
+The `?` is the only difference between the two `time` expressions above. Applying each event
+configuration to a raw table — subject 2's timestamp is malformed:
+
+```python
+>>> import polars as pl
+>>> from MEDS_extract.convert_to_MEDS_events.convert_to_MEDS_events import extract_event
+>>> raw = pl.DataFrame({
+...     "subject_id": [1, 2],
+...     "result_time": ["2021-01-01", "not-a-date"],  # subject 2's timestamp is malformed
+...     "test_name": ["GLU", "HR"],
+... })
+>>> # Lenient ("?" prefix): the malformed timestamp parses to null instead of aborting.
+>>> extract_event(
+...     raw, {"code": 'f"LAB//{$test_name}"', "time": '$result_time as ?"%Y-%m-%d"'}
+... ).select("subject_id", "time", "code").sort("subject_id")
+shape: (2, 3)
+┌────────────┬────────────┬──────────┐
+│ subject_id ┆ time       ┆ code     │
+│ ---        ┆ ---        ┆ ---      │
+│ i64        ┆ date       ┆ str      │
+╞════════════╪════════════╪══════════╡
+│ 1          ┆ 2021-01-01 ┆ LAB//GLU │
+│ 2          ┆ null       ┆ LAB//HR  │
+└────────────┴────────────┴──────────┘
+>>> # Strict (the default, no "?"): the malformed timestamp aborts extraction.
+>>> extract_event(raw, {"code": 'f"LAB//{$test_name}"', "time": '$result_time as "%Y-%m-%d"'})
+Traceback (most recent call last):
+    ...
+polars.exceptions.InvalidOperationError: conversion from `str` to `date` failed ...
+
+```
+
 ### Subject ID Configuration
 
 ```yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "meds~=0.4.0",
   "MEDS-transforms~=0.6.0",
   "universal_pathlib",
-  "dftly>=0.1.2,<0.2.0"
+  "dftly>=0.1.3,<0.2.0"  # >=0.1.3 for the `?`-prefix non-strict strptime documented in the README
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -491,7 +491,7 @@ wheels = [
 
 [[package]]
 name = "dftly"
-version = "0.1.2"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lark" },
@@ -499,9 +499,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/2f/58c23363968aeb3841bc177e35c134efd3e892f03541bedb802242d492ac/dftly-0.1.2.tar.gz", hash = "sha256:e1013d3482751333c8a85fe89777b867ab4ec9d75cc9fb80e311e764375464eb", size = 56479, upload-time = "2026-04-08T19:44:00.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/5e/917bb6701404e5e1ed269e7d2847c9bc7babdb63636d5b67b3a56529a28f/dftly-0.1.5.tar.gz", hash = "sha256:283565dbab46e5bca0db71deaf8cd081efdafbe001bbfe2876156436b14f4183", size = 61529, upload-time = "2026-04-14T01:24:08.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/e0/438072fe5ff892e82e90a8b7e39faa4f0de29312b4914e12c68634277ba2/dftly-0.1.2-py3-none-any.whl", hash = "sha256:fd175bd42fb02682cec519e1df29f91de3ac6ce680c3d0ae4133af5b23b4ac0a", size = 32120, upload-time = "2026-04-08T19:43:59.54Z" },
+    { url = "https://files.pythonhosted.org/packages/37/df/8af572009467a49981af636311e87f1a4c31acd8a7e67b947682d69a73ff/dftly-0.1.5-py3-none-any.whl", hash = "sha256:4e6c8dec4bdd543494cc3f4b06f51ca2e29302204f90a95a3a70617c4b0aecd6", size = 35248, upload-time = "2026-04-14T01:24:07.263Z" },
 ]
 
 [[package]]
@@ -1276,7 +1276,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dftly", specifier = ">=0.1.2,<0.2.0" },
+    { name = "dftly", specifier = ">=0.1.3,<0.2.0" },
     { name = "hydra-core" },
     { name = "hydra-joblib-launcher", marker = "extra == 'local-parallelism'" },
     { name = "hydra-submitit-launcher", marker = "extra == 'slurm-parallelism'" },


### PR DESCRIPTION
Documents that timestamp format casts are **strict by default** and that dftly's `?`-prefix opts into **lenient** parsing — closing the loop on the strict-`strptime` behavior change from the dftly migration (it's user-controllable, not a bug).

## What changed
- **README → Time Handling** gains a *"Strict vs. lenient timestamp parsing"* subsection with a runnable doctest:
  - `time: $col as "%Y-%m-%d %H:%M:%S"` → strict; a malformed value **aborts the run**.
  - `time: $col as ?"%Y-%m-%d %H:%M:%S"` → lenient; a malformed value becomes **null** (and the timeless row is dropped) — this is the pre-dftly silent-drop behavior, now an explicit opt-in.
- **`dftly` floor `>=0.1.2` → `>=0.1.3`** (still `<0.2.0`) + **lock refresh `0.1.2` → `0.1.5`**.

## Why the dependency bump
The `?`-prefix was introduced in **dftly 0.1.3**. Main's `pyproject` range already allowed it (and a fresh `pip install MEDS-extract` resolves to 0.1.5, which has it), but the committed **lockfile was pinned at 0.1.2**, so the new README doctest would fail in CI. Bumping the floor guarantees the documented feature is present and refreshes the lock to match what users already get. No functional code change.

## Testing
- New README doctest **passes** under the refreshed lock (dftly 0.1.5).
- `mdformat` (pinned pre-commit hook, rev 0.7.22) **passes** — diff is limited to the new subsection.
- Full suite: **84 passed**.

## Context
This is the documentation half of the strptime discussion from the dftly-regression scan; companion tracking issue #125 captures the open design question of whether the *default* should remain strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
