### PR TITLE
dev: null code components as an explicit author choice (dftly 0.5 `??`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,61 @@ from the parser:
 
 ```
 
+#### Null components in composite codes
+
+A MEDS `code` may never be null, and string interpolation **null-propagates**: if any interpolated
+component is null, the whole `code` becomes null and that row is **dropped**. To keep such rows, give
+the component a fallback with dftly's `??` (coalesce) operator — single-quote a literal fallback
+*inside* the double-quoted f-string. Whether a missing component drops the row or is filled in is
+your choice, made per component:
+
+```python
+>>> import polars as pl
+>>> from MEDS_extract.config import EventConfig
+>>> labs = pl.DataFrame({
+...     "subject_id": [1, 2, 3, 4],
+...     "itemid": ["GLU", "GLU", None, None],        # present, present, null, null
+...     "valueuom": ["mg/dL", None, "mg/dL", None],  # present, null,    present, null
+... })
+>>> def codes(expr):  # surviving (subject_id, code) rows for a `code` expression
+...     ev = EventConfig.parse("lab", {"code": expr, "time": None})
+...     return ev.extract(labs.lazy(), "labs/lab").collect().sort("subject_id").select(
+...         "subject_id", "code"
+...     )
+>>> codes('f"{$itemid}//{$valueuom}"')  # plain: any null component drops the row
+shape: (1, 2)
+┌────────────┬────────────┐
+│ subject_id ┆ code       │
+│ ---        ┆ ---        │
+│ i64        ┆ str        │
+╞════════════╪════════════╡
+│ 1          ┆ GLU//mg/dL │
+└────────────┴────────────┘
+>>> codes("f\"{$itemid ?? 'UNK'}//{$valueuom ?? 'UNK'}\"")  # fill both -> keep every row
+shape: (4, 2)
+┌────────────┬────────────┐
+│ subject_id ┆ code       │
+│ ---        ┆ ---        │
+│ i64        ┆ str        │
+╞════════════╪════════════╡
+│ 1          ┆ GLU//mg/dL │
+│ 2          ┆ GLU//UNK   │
+│ 3          ┆ UNK//mg/dL │
+│ 4          ┆ UNK//UNK   │
+└────────────┴────────────┘
+>>> codes("f\"{$itemid}//{$valueuom ?? 'UNK'}\"")  # fill only the unit: a null itemid still drops
+shape: (2, 2)
+┌────────────┬────────────┐
+│ subject_id ┆ code       │
+│ ---        ┆ ---        │
+│ i64        ┆ str        │
+╞════════════╪════════════╡
+│ 1          ┆ GLU//mg/dL │
+│ 2          ┆ GLU//UNK   │
+└────────────┴────────────┘
+
+```
+
 ### Time Handling
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -479,6 +479,18 @@ shape: (4, 2)
 │ 3          ┆ UNK//mg/dL │
 │ 4          ┆ UNK//UNK   │
 └────────────┴────────────┘
+>>> codes("f\"{$itemid ?? 'NO_ITEM'}//{$valueuom ?? 'NO_UNIT'}\"")  # the fallback is any literal
+shape: (4, 2)
+┌────────────┬──────────────────┐
+│ subject_id ┆ code             │
+│ ---        ┆ ---              │
+│ i64        ┆ str              │
+╞════════════╪══════════════════╡
+│ 1          ┆ GLU//mg/dL       │
+│ 2          ┆ GLU//NO_UNIT     │
+│ 3          ┆ NO_ITEM//mg/dL   │
+│ 4          ┆ NO_ITEM//NO_UNIT │
+└────────────┴──────────────────┘
 >>> codes("f\"{$itemid}//{$valueuom ?? 'UNK'}\"")  # fill only the unit: a null itemid still drops
 shape: (2, 2)
 ┌────────────┬────────────┐

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "meds~=0.4.0",
   "MEDS-transforms>=0.6.7,<0.7",
   "universal_pathlib",
-  "dftly>=0.3.0",
+  "dftly>=0.5.0",
 ]
 
 [dependency-groups]

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -37,26 +37,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _null_safe_code_expr(code_node: NodeBase) -> pl.Expr:
-    """Compile a composite ``code`` so each null component renders as the literal ``"UNK"``.
-
-    dftly string interpolation null-propagates, so a null in any referenced component would make
-    the whole ``code`` null (which MEDS forbids). This rebuilds the interpolation from the dftly
-    node's ordered pieces, casting each to a string and filling nulls with ``"UNK"`` — restoring
-    the pre-dftly ``pl.col(c).cast(pl.Utf8).fill_null("UNK")`` behaviour (including non-string
-    columns, which are cast to their string form). It is scoped to the code expression, so
-    ``code_components`` keeps the raw, typed values. See issue #109.
-    """
-    if type(code_node).__name__ == "StringInterpolate":
-        template = code_node.args[0].args[0]  # e.g. "LAB//{}//{}"
-        pieces = [arg.polars_expr for arg in code_node.args[1:]]
-        if isinstance(template, str) and template.count("{}") == len(pieces):
-            filled = [p.cast(pl.Utf8, strict=False).fill_null(pl.lit("UNK")) for p in pieces]
-            return pl.format(template, *filled)
-    # Unexpected node shape: at least guarantee the whole code is never null.
-    return code_node.polars_expr.cast(pl.Utf8, strict=False).fill_null(pl.lit("UNK"))
-
-
 # ── JoinConfig ───────────────────────────────────────────────────────
 
 
@@ -383,13 +363,9 @@ class EventConfig:
             │ 1          ┆ A    ┆ 2021-01-01 │
             └────────────┴──────┴────────────┘
 
-            The rule above applies to a *bare column* code (``code: $col``): a null value is a
-            meaningless event, so the row is dropped. A *composite / interpolated* code behaves
-            differently — every null component is rendered as the literal ``"UNK"`` so a missing
-            part (e.g. a unit) doesn't discard the whole event, and the code is never null. This
-            applies to **every** referenced column, including the leading one even when the code
-            has no literal prefix. ``$itemid`` and ``$valueuom`` below cover all four null/non-null
-            combinations (see issue #109):
+            A *composite / interpolated* code null-propagates the same way: if **any** referenced
+            component is null, the whole code is null, so the row is dropped. Below, only the row
+            with both ``$itemid`` and ``$valueuom`` present survives:
 
             >>> raw = pl.DataFrame({
             ...     "subject_id": [1, 2, 3, 4],
@@ -397,20 +373,22 @@ class EventConfig:
             ...     "valueuom": ["mg/dL", None, "mg/dL", None],  # present, null, present, null
             ... })
             >>> ev = EventConfig.parse("lab", {"code": 'f"{$itemid}//{$valueuom}"', "time": None})
-            >>> ev.extract(raw.lazy(), "labs/lab").collect().select("subject_id", "code").sort(
-            ...     "subject_id"
-            ... )
-            shape: (4, 2)
+            >>> ev.extract(raw.lazy(), "labs/lab").collect().select("subject_id", "code")
+            shape: (1, 2)
             ┌────────────┬────────────┐
             │ subject_id ┆ code       │
             │ ---        ┆ ---        │
             │ i64        ┆ str        │
             ╞════════════╪════════════╡
             │ 1          ┆ GLU//mg/dL │
-            │ 2          ┆ GLU//UNK   │
-            │ 3          ┆ UNK//mg/dL │
-            │ 4          ┆ UNK//UNK   │
             └────────────┴────────────┘
+
+            To keep rows with missing components, coalesce them in the MESSY expression with the
+            dftly ``??`` operator (single-quote the literal fallback inside the f-string) — e.g.
+            ``code: f"{$itemid ?? 'UNK'}//{$valueuom ?? 'UNK'}"`` fills each null component with
+            ``"UNK"`` (yielding ``GLU//UNK``, ``UNK//mg/dL``, ``UNK//UNK``) so all four rows are
+            retained. See the README's *Code Construction* section for runnable examples of each
+            option.
 
             With ``do_dedup_text_and_numeric=True``, a ``text_value`` that
             numerically equals ``numeric_value`` is nulled out:
@@ -442,14 +420,13 @@ class EventConfig:
         """
         exprs: dict[str, pl.Expr] = {"subject_id": pl.col("subject_id")}
 
-        # A composite code renders each null component as "UNK" (see issue #109); a bare-column
-        # or literal code is used as-is.
-        if self.code_source_columns and type(self.columns["code"]).__name__ != "Column":
-            exprs["code"] = _null_safe_code_expr(self.columns["code"])
-        else:
-            exprs["code"] = self.polars_exprs["code"]
+        # `code` is the native dftly expression. String interpolation null-propagates: if any
+        # referenced component is null the whole code is null, and the row is dropped below (a MEDS
+        # code may not be null). Authors opt into retaining such rows by coalescing components in
+        # the MESSY expression, e.g. `f"{$itemid ?? 'UNK'}//{$valueuom ?? 'UNK'}"`.
+        exprs["code"] = self.polars_exprs["code"]
         if self.code_source_columns:
-            # Raw, typed component values (unaffected by the "UNK" rendering above).
+            # Raw, typed component values (the `code` string above is derived from these).
             exprs["code_components"] = pl.struct(
                 **{col: pl.col(col) for col in sorted(self.code_source_columns)}
             )
@@ -472,13 +449,12 @@ class EventConfig:
 
         exprs["source_block"] = pl.lit(source_block)
 
-        if self.code_source_columns and type(self.columns["code"]).__name__ == "Column":
-            # A bare-column code is a bare identifier: a null value is a meaningless event (no
-            # identifier), so drop the row. A composite code instead renders each null component
-            # as "UNK" in the code expression above (restoring the pre-dftly behavior that the
-            # dftly migration regressed — dftly interpolation null-propagates). See issue #109.
-            (only_col,) = self.code_source_columns
-            df = df.filter(pl.col(only_col).is_not_null())
+        if self.code_source_columns:
+            # A MEDS `code` may never be null. A bare-column code that is null, or an interpolated
+            # code with a null (un-coalesced) component, evaluates to a null code — drop those rows.
+            # Filter on the code expression itself (not the raw source columns) so rows the author
+            # rescued with a `??` coalesce are kept, since those never evaluate to null.
+            df = df.filter(exprs["code"].is_not_null())
 
         if not self.is_static:
             # Filter on source columns being non-null/non-empty rather than on the parsed time

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -393,11 +393,31 @@ class EventConfig:
             └────────────┴────────────┘
 
             To keep rows with missing components, coalesce them in the MESSY expression with the
-            dftly ``??`` operator (single-quote the literal fallback inside the f-string) — e.g.
-            ``code: f"{$itemid ?? 'UNK'}//{$valueuom ?? 'UNK'}"`` fills each null component with
-            ``"UNK"`` (yielding ``GLU//UNK``, ``UNK//mg/dL``, ``UNK//UNK``) so all four rows are
-            retained. See the README's *Code Construction* section for runnable examples of each
-            option.
+            dftly ``??`` operator (single-quote the literal fallback inside the f-string) — each
+            null component is filled with your chosen literal, so all four rows are retained:
+
+            >>> ev = EventConfig.parse(
+            ...     "lab",
+            ...     {"code": '''f"{$itemid ?? 'UNK'}//{$valueuom ?? 'UNK'}"''', "time": None},
+            ... )
+            >>> ev.extract(raw.lazy(), "labs/lab").collect().sort("subject_id").select(
+            ...     "subject_id", "code"
+            ... )
+            shape: (4, 2)
+            ┌────────────┬────────────┐
+            │ subject_id ┆ code       │
+            │ ---        ┆ ---        │
+            │ i64        ┆ str        │
+            ╞════════════╪════════════╡
+            │ 1          ┆ GLU//mg/dL │
+            │ 2          ┆ GLU//UNK   │
+            │ 3          ┆ UNK//mg/dL │
+            │ 4          ┆ UNK//UNK   │
+            └────────────┴────────────┘
+
+            The fallback is per-component and any literal you choose — coalescing only some
+            components, or with distinct markers, are both fine (see the README's *Code
+            Construction* section for more variations).
 
             With ``do_dedup_text_and_numeric=True``, a ``text_value`` that
             numerically equals ``numeric_value`` is nulled out:

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ toml = [
 
 [[package]]
 name = "dftly"
-version = "0.3.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lark" },
@@ -318,9 +318,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/f2/7c3945b3cc718d03bd37ee3311b26e75c649d07817082c7d2478273eff7d/dftly-0.3.0.tar.gz", hash = "sha256:ab3962304b3a13dc78b276378645cbc991ac028eb4328a0659bf461d23afd241", size = 74802, upload-time = "2026-04-16T10:20:26.736Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/22/22f512a4536282b81d68312bc1683fd3cbedf3d8d7825ce4cc9a12e54ac2/dftly-0.5.0.tar.gz", hash = "sha256:289e7d23b6259aedc5b65b4ca71479de54e4192c98bf69d390ceef818a821017", size = 82925, upload-time = "2026-07-08T00:15:03.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/db/cafe56bb430b97aab03bea104bfea70ed31926f715a9ab255c74b8383120/dftly-0.3.0-py3-none-any.whl", hash = "sha256:ba5e171ea16fdbdccd37d6a881c8458071cc4cfb70970b07837f7013a5d8fbf9", size = 41142, upload-time = "2026-04-16T10:20:25.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7a/ff10f912174040c7f0b3d1861d5def0965aae21f2ed2708906475595efe4/dftly-0.5.0-py3-none-any.whl", hash = "sha256:93cd6f0b3573c1db6070e4fd289b1223b7b7e715b98458c859792feb94f2deb2", size = 48595, upload-time = "2026-07-08T00:15:01.831Z" },
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dftly", specifier = ">=0.3.0" },
+    { name = "dftly", specifier = ">=0.5.0" },
     { name = "httpx", marker = "extra == 'download'", specifier = ">=0.27" },
     { name = "hydra-core" },
     { name = "hydra-joblib-launcher", marker = "extra == 'local-parallelism'" },


### PR DESCRIPTION
Makes null `code` components an **explicit author choice** on the 0.7 line, using dftly 0.5's new `??` coalesce operator — reverting the automatic `"UNK"` fill from #118. This intentionally diverges from main (0.6.x), where null components are silently auto-filled with `"UNK"`.

## Behavior change
A composite `code` now uses the **native** dftly expression, which null-propagates: if any interpolated component is null, the whole `code` is null and the row is **dropped** (a MEDS `code` may never be null). The author decides, **per component**, whether a missing value drops the row or is filled in — by coalescing with `??`:

| MESSY `code` | null component → |
|---|---|
| `f"{$itemid}//{$valueuom}"` | row dropped |
| `f"{$itemid ?? 'UNK'}//{$valueuom ?? 'UNK'}"` | filled with `UNK`, row kept |
| `f"{$itemid}//{$valueuom ?? 'UNK'}"` | unit filled; a null `itemid` still drops |

(Single-quote the literal fallback *inside* the double-quoted f-string; `?? "UNK"` with double quotes clashes with the f-string delimiter.)

## Changes
- **`pyproject.toml` / `uv.lock`**: `dftly>=0.3.0` → `>=0.5.0` (0.5.0 introduces `??`).
- **`config.py`**: remove `_null_safe_code_expr`; `code` = native dftly expr; the null-code drop filter now keys on the **code expression** being non-null (so `??`-rescued rows survive), replacing the bare-column-only drop.
- **`config.py` docstring**: rewritten null-handling section (plain → drop; `??` → keep).
- **`README.md`** → *Code Construction* gains a **"Null components in composite codes"** section with runnable doctests for all three options above.

## Testing
- Full suite **74 passed** (1 integration deselected); config.py + README doctests pass under dftly 0.5.0.
- `ruff`, `mdformat`, `codespell` clean.

## Notes
- Refs #121 (design discussion of the desired behavior and user control) — this is the dev direction: user-controlled, not a hidden default.
- The `??` operator is dftly's resolution of the null-safe-interpolation request (dftly#75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
