### PR TITLE
extract_code_metadata: fix partial-match component-join correctness (#110, #134, #135)

### DIFF
--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -1115,10 +1115,15 @@ class MessyConfig:
 
         Each event's ``_metadata`` block maps metadata-file prefixes to
         per-prefix metadata config dicts. This returns the reverse: each
-        metadata prefix gets the list of ``{code, _metadata}`` entries that
-        reference it. The ``code`` value is the original raw dftly expression
-        string when available (so downstream ``code_template`` columns stay
-        human-readable), falling back to the parsed node otherwise.
+        metadata prefix gets the list of ``{code, _metadata, source_block}``
+        entries that reference it. The ``code`` value is the original raw
+        dftly expression string when available (so downstream
+        ``code_template`` columns stay human-readable), falling back to the
+        parsed node otherwise. The ``source_block`` value is the
+        ``{input_prefix}/{event_name}`` tag that :meth:`EventConfig.extract`
+        stamps on every output row — ``extract_code_metadata`` uses it to
+        scope partial-match (``_match_on``) expansions to the event that
+        declared the ``_metadata`` block (see issue #134).
 
         Used by ``extract_code_metadata``.
 
@@ -1141,12 +1146,18 @@ class MessyConfig:
             >>> entry = grouped["proc_datetimeevents"][0]
             >>> entry["code"]
             'f"PROC//START//{$itemid}"'
+            >>> entry["source_block"]
+            'icu/procedureevents/start'
             >>> MessyConfig.parse({"t": {"e": {"code": "X", "time": None}}}).events_by_metadata_prefix()
             {}
         """
         out: dict[str, list[dict]] = {}
-        for event in self.iter_events():
-            code: str | NodeBase = event.raw_code if event.raw_code is not None else event.columns["code"]
-            for metadata_prefix, metadata_cfg in event.metadata.items():
-                out.setdefault(metadata_prefix, []).append({"code": code, "_metadata": metadata_cfg})
+        for table in self.tables:
+            for event in table.events:
+                code: str | NodeBase = event.raw_code if event.raw_code is not None else event.columns["code"]
+                source_block = f"{table.input_prefix}/{event.name}"
+                for metadata_prefix, metadata_cfg in event.metadata.items():
+                    out.setdefault(metadata_prefix, []).append(
+                        {"code": code, "_metadata": metadata_cfg, "source_block": source_block}
+                    )
         return out

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -36,6 +36,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Output column tagging every data row (and metadata-map row) with the MESSY config
+# block that produced it, as ``f"{table_prefix}/{event_name}"`` — e.g.
+# ``"diagnoses/dx"``. Note this is finer-grained than a source *table*: two events in
+# one table carry distinct source_blocks. Stamped unconditionally by
+# :meth:`EventConfig.extract`; consumed by ``extract_code_metadata`` to scope
+# partial-match metadata joins to their declaring event (issue #134).
+SOURCE_BLOCK_COL = "source_block"
+
 
 def _null_safe_code_expr(code_node: NodeBase) -> pl.Expr:
     """Compile a composite ``code`` so each null component renders as the literal ``"UNK"``.
@@ -439,6 +447,16 @@ class EventConfig:
             │ 1.5           ┆ null       │
             │ 2.0           ┆ other      │
             └───────────────┴────────────┘
+
+            The ``code_components`` struct's fields are named for the *source* columns the
+            code references — including when a source column is literally named ``code``
+            (the shape behind issue #110; ``extract_code_metadata`` unnests this struct and
+            must alias the assembled code away from it):
+
+            >>> raw = pl.DataFrame({"subject_id": [1], "code": ["250.00"], "ts": ["2020-01-01"]})
+            >>> ev = EventConfig.parse("dx", {"code": 'f"ICD//{$code}"', "time": '$ts::"%Y-%m-%d"'})
+            >>> ev.extract(raw.lazy(), "diagnoses/dx").collect().schema["code_components"]
+            Struct({'code': String})
         """
         exprs: dict[str, pl.Expr] = {"subject_id": pl.col("subject_id")}
 
@@ -470,7 +488,7 @@ class EventConfig:
                 .otherwise(text_expr)
             )
 
-        exprs["source_block"] = pl.lit(source_block)
+        exprs[SOURCE_BLOCK_COL] = pl.lit(source_block)
 
         if self.code_source_columns and type(self.columns["code"]).__name__ == "Column":
             # A bare-column code is a bare identifier: a null value is a meaningless event (no
@@ -1158,6 +1176,6 @@ class MessyConfig:
                 source_block = f"{table.input_prefix}/{event.name}"
                 for metadata_prefix, metadata_cfg in event.metadata.items():
                     out.setdefault(metadata_prefix, []).append(
-                        {"code": code, "_metadata": metadata_cfg, "source_block": source_block}
+                        {"code": code, "_metadata": metadata_cfg, SOURCE_BLOCK_COL: source_block}
                     )
         return out

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -41,7 +41,8 @@ logger = logging.getLogger(__name__)
 # ``"diagnoses/dx"``. Note this is finer-grained than a source *table*: two events in
 # one table carry distinct source_blocks. Stamped unconditionally by
 # :meth:`EventConfig.extract`; consumed by ``extract_code_metadata`` to scope
-# partial-match metadata joins to their declaring event (issue #134).
+# partial-match metadata joins to their declaring event (without it, one event's
+# metadata would attach to other events' codes sharing a component value).
 SOURCE_BLOCK_COL = "source_block"
 
 
@@ -450,8 +451,8 @@ class EventConfig:
 
             The ``code_components`` struct's fields are named for the *source* columns the
             code references — including when a source column is literally named ``code``
-            (the shape behind issue #110; ``extract_code_metadata`` unnests this struct and
-            must alias the assembled code away from it):
+            (the idiomatic ICD/OMOP vocabulary shape; ``extract_code_metadata`` unnests this
+            struct and must alias the assembled code away from it):
 
             >>> raw = pl.DataFrame({"subject_id": [1], "code": ["250.00"], "ts": ["2020-01-01"]})
             >>> ev = EventConfig.parse("dx", {"code": 'f"ICD//{$code}"', "time": '$ts::"%Y-%m-%d"'})
@@ -1141,7 +1142,7 @@ class MessyConfig:
         ``{input_prefix}/{event_name}`` tag that :meth:`EventConfig.extract`
         stamps on every output row — ``extract_code_metadata`` uses it to
         scope partial-match (``_match_on``) expansions to the event that
-        declared the ``_metadata`` block (see issue #134).
+        declared the ``_metadata`` block.
 
         Used by ``extract_code_metadata``.
 

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -32,29 +32,30 @@ MEDS_METADATA_MANDATORY_TYPES = {
 
 # Reserved internal alias for the fully-assembled output code inside the code-component map.
 # Keeping the full code under this name (rather than "code") means unnesting the
-# ``code_components`` struct can never collide with it — even when a code expression
-# references a source column literally named ``code`` (see issue #110).
+# ``code_components`` struct can never collide with it — a code expression may reference
+# a source column literally named ``code`` (the idiomatic ICD/OMOP vocabulary shape).
 FULL_CODE_COL = "__meds_full_code"
 
 
-def normalize_join_key(col: str, dtype: pl.DataType) -> pl.Expr:
-    """Render the join-key column ``col`` of type ``dtype`` as a canonical String expression.
+def normalize_join_key(expr: pl.Expr, dtype: pl.DataType) -> pl.Expr:
+    """Render the join-key expression ``expr`` of type ``dtype`` as a canonical String expression.
 
     Code components keep their raw source dtypes (an ``Int64`` ``itemid``, say), while
     csv-sourced metadata keys are uniformly ``String`` (they are read with
-    ``infer_schema=False``). Joining the two directly raises a ``SchemaError`` (issue #135),
-    so both sides of the partial-match join are normalized through this single canonical
-    string rendering:
+    ``infer_schema=False``). Joining the two directly is a ``SchemaError``, so both sides
+    of the partial-match join are normalized through this single canonical string
+    rendering:
 
-    - String columns pass through unchanged.
-    - Non-float columns cast directly: ``220045`` renders as ``"220045"``.
-    - Float columns render integer-valued entries via ``Int64`` so that ``220045.0`` matches
-      the metadata string ``"220045"`` rather than rendering as ``"220045.0"``; non-integer
-      values keep their float rendering (``1.5`` renders as ``"1.5"``). Integer-valued floats
-      outside the ``Int64`` range render as null (and thus match nothing).
+    - String expressions pass through unchanged.
+    - Non-float expressions cast directly: ``220045`` renders as ``"220045"``.
+    - Float expressions render integer-valued entries via ``Int64`` so that ``220045.0``
+      matches the metadata string ``"220045"`` rather than rendering as ``"220045.0"``;
+      non-integer values keep their float rendering (``1.5`` renders as ``"1.5"``).
+      Integer-valued floats outside the ``Int64`` range render as null (and thus match
+      nothing).
 
-    The returned expression preserves the column name (nulls stay null and never match under
-    the default ``join_nulls=False``).
+    The output keeps the input expression's root name (nulls stay null and never match
+    under the default ``join_nulls=False``).
 
     Examples:
         >>> df = pl.DataFrame({
@@ -63,9 +64,9 @@ def normalize_join_key(col: str, dtype: pl.DataType) -> pl.Expr:
         ...     "s": ["220045", "01.90", None],
         ... })
         >>> df.select(
-        ...     normalize_join_key("i", df.schema["i"]),
-        ...     normalize_join_key("f", df.schema["f"]),
-        ...     normalize_join_key("s", df.schema["s"]),
+        ...     normalize_join_key(pl.col("i"), df.schema["i"]),
+        ...     normalize_join_key(pl.col("f"), df.schema["f"]),
+        ...     normalize_join_key(pl.col("s"), df.schema["s"]),
         ... )
         shape: (3, 3)
         ┌────────┬────────┬────────┐
@@ -78,7 +79,6 @@ def normalize_join_key(col: str, dtype: pl.DataType) -> pl.Expr:
         │ null   ┆ null   ┆ null   │
         └────────┴────────┴────────┘
     """
-    expr = pl.col(col)
     if dtype == pl.String:
         return expr
     if dtype.is_float():
@@ -86,9 +86,51 @@ def normalize_join_key(col: str, dtype: pl.DataType) -> pl.Expr:
             pl.when(expr == expr.round(0))
             .then(expr.cast(pl.Int64, strict=False).cast(pl.String))
             .otherwise(expr.cast(pl.String))
-            .alias(col)
+            .name.keep()
         )
     return expr.cast(pl.String)
+
+
+def validate_event_data_schema(data_schema: pl.Schema) -> bool:
+    """Validate extracted-event input schema for metadata extraction; return whether components exist.
+
+    ``code_components`` is only attached by ``EventConfig.extract`` when a code expression
+    references at least one source column — a dataset whose codes are all literals
+    legitimately has no components (and therefore nothing to partial-match on), so its
+    absence is allowed and reported as ``False``.
+
+    When components ARE present, ``source_block`` must be too: ``EventConfig.extract``
+    stamps it on every row unconditionally, so its absence means the events were produced
+    by a pre-0.7 extraction pipeline — and without it, partial-match metadata cannot be
+    scoped to the event that declared it (one event's metadata would silently attach to
+    other events' codes sharing a component value).
+
+    Examples:
+        >>> validate_event_data_schema(pl.Schema({"code": pl.String}))
+        False
+        >>> validate_event_data_schema(pl.Schema({
+        ...     "code": pl.String,
+        ...     "code_components": pl.Struct({"itemid": pl.Int64}),
+        ...     "source_block": pl.String,
+        ... }))
+        True
+        >>> validate_event_data_schema(pl.Schema({
+        ...     "code": pl.String,
+        ...     "code_components": pl.Struct({"itemid": pl.Int64}),
+        ... }))
+        Traceback (most recent call last):
+            ...
+        ValueError: Extracted event data carries 'code_components' but no 'source_block' column. ...
+    """
+    if "code_components" not in data_schema:
+        return False
+    if SOURCE_BLOCK_COL not in data_schema:
+        raise ValueError(
+            f"Extracted event data carries 'code_components' but no {SOURCE_BLOCK_COL!r} "
+            "column. These events were produced by a pre-0.7 convert_to_MEDS_events; "
+            "re-run the extraction pipeline before extracting code metadata."
+        )
+    return True
 
 
 def extract_metadata(
@@ -467,22 +509,10 @@ def main(cfg: DictConfig):
     all_data = pl.concat(all_event_dfs, how="diagonal_relaxed")
     all_codes = all_data.select(pl.col("code").unique()).collect().get_column("code").to_list()
 
-    # Build code_components mapping for partial metadata joins. The full output code is kept
-    # under the reserved FULL_CODE_COL alias so that unnesting the struct can never collide
-    # with it — a code expression may reference a source column literally named "code" (#110).
-    # source_block is carried along so each partial-match expansion can be scoped to the event
-    # that declared the _metadata block (#134).
-    data_schema = all_data.collect_schema()
-    if "code_components" in data_schema:
-        if SOURCE_BLOCK_COL not in data_schema:
-            # ``EventConfig.extract`` stamps source_block on every row unconditionally, so
-            # its absence means the events predate 0.7's extraction pipeline — partial-match
-            # scoping (#134) cannot work without it.
-            raise ValueError(
-                f"Extracted event data carries 'code_components' but no {SOURCE_BLOCK_COL!r} "
-                "column. These events were produced by a pre-0.7 convert_to_MEDS_events; "
-                "re-run the extraction pipeline before extracting code metadata."
-            )
+    # Build the code_components mapping for partial metadata joins: full code (under the
+    # reserved collision-proof alias), unnested component columns, and the declaring
+    # source_block so each expansion joins only against its own event's codes.
+    if validate_event_data_schema(all_data.collect_schema()):
         code_component_map = (
             all_data.select(pl.col("code").alias(FULL_CODE_COL), "code_components", SOURCE_BLOCK_COL)
             .unique()
@@ -496,7 +526,7 @@ def main(cfg: DictConfig):
     # Explicit bookkeeping for partial-match outputs: out_fp -> (match_cols, source_block).
     # The reducer is driven by this record rather than by sniffing output schemas — a partial
     # output whose _match_on includes a column named "code" would otherwise be misclassified
-    # as full-match (#110).
+    # as full-match and land raw source codes in codes.parquet.
     partial_info: dict[Path, tuple[list[str], str]] = {}
     for input_prefix, event_metadata_cfgs in event_metadata_configs:
         event_metadata_cfgs = copy.deepcopy(event_metadata_cfgs)
@@ -559,7 +589,7 @@ def main(cfg: DictConfig):
     # Separate partial-match outputs from full-match outputs. Classification is driven by the
     # explicit partial_info record from map time, never by output schemas — a partial output
     # whose _match_on includes "code" carries a "code" column of raw component values and
-    # would be silently misclassified as full-match by schema sniffing (#110).
+    # would be silently misclassified as full-match by schema sniffing.
     full_match_dfs = []
     partial_match_dfs = []
     for fp in all_out_fps:
@@ -588,19 +618,19 @@ def main(cfg: DictConfig):
             components = code_component_map.lazy()
             # Scope the expansion to the event config that declared this _metadata block —
             # other events may reference same-named component columns with colliding values,
-            # and must not receive this metadata (#134).
+            # and must not receive this metadata.
             components = components.filter(pl.col(SOURCE_BLOCK_COL) == source_block)
 
             # Restrict the left side to exactly the full code and the join keys: any other
             # component column sharing a name with a metadata output column would otherwise
             # shadow it in the post-join select. Join keys are normalized to a canonical
             # String rendering on both sides — components keep raw source dtypes while
-            # csv-sourced metadata keys are uniformly String (#135).
+            # csv-sourced metadata keys are uniformly String.
             components = components.select(
                 FULL_CODE_COL,
-                *[normalize_join_key(c, component_schema[c]) for c in match_cols],
+                *[normalize_join_key(pl.col(c), component_schema[c]) for c in match_cols],
             ).unique()
-            pdf = pdf.with_columns(normalize_join_key(c, pdf_schema[c]) for c in match_cols)
+            pdf = pdf.with_columns(normalize_join_key(pl.col(c), pdf_schema[c]) for c in match_cols)
 
             expanded = (
                 components.join(pdf, on=match_cols, how="inner")

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -18,7 +18,7 @@ from omegaconf import DictConfig
 from upath import UPath
 
 from .._stage_example import MEDSExtractStageExample
-from ..config import MessyConfig
+from ..config import SOURCE_BLOCK_COL, MessyConfig
 from ..io import resolve_source_files, scan_source
 
 logger = logging.getLogger(__name__)
@@ -474,10 +474,21 @@ def main(cfg: DictConfig):
     # that declared the _metadata block (#134).
     data_schema = all_data.collect_schema()
     if "code_components" in data_schema:
-        map_cols = [pl.col("code").alias(FULL_CODE_COL), pl.col("code_components")]
-        if "source_block" in data_schema:
-            map_cols.append(pl.col("source_block"))
-        code_component_map = all_data.select(*map_cols).unique().collect().unnest("code_components")
+        if SOURCE_BLOCK_COL not in data_schema:
+            # ``EventConfig.extract`` stamps source_block on every row unconditionally, so
+            # its absence means the events predate 0.7's extraction pipeline — partial-match
+            # scoping (#134) cannot work without it.
+            raise ValueError(
+                f"Extracted event data carries 'code_components' but no {SOURCE_BLOCK_COL!r} "
+                "column. These events were produced by a pre-0.7 convert_to_MEDS_events; "
+                "re-run the extraction pipeline before extracting code metadata."
+            )
+        code_component_map = (
+            all_data.select(pl.col("code").alias(FULL_CODE_COL), "code_components", SOURCE_BLOCK_COL)
+            .unique()
+            .collect()
+            .unnest("code_components")
+        )
     else:
         code_component_map = None
 
@@ -486,7 +497,7 @@ def main(cfg: DictConfig):
     # The reducer is driven by this record rather than by sniffing output schemas — a partial
     # output whose _match_on includes a column named "code" would otherwise be misclassified
     # as full-match (#110).
-    partial_info: dict[Path, tuple[list[str], str | None]] = {}
+    partial_info: dict[Path, tuple[list[str], str]] = {}
     for input_prefix, event_metadata_cfgs in event_metadata_configs:
         event_metadata_cfgs = copy.deepcopy(event_metadata_cfgs)
 
@@ -504,7 +515,9 @@ def main(cfg: DictConfig):
             out_fp = partial_metadata_dir / f"{input_prefix}_{cfg_idx}.parquet"
             logger.info(f"Extracting metadata from {metadata_fps} and saving to {out_fp}")
 
-            source_block = event_cfg.pop("source_block", None)
+            # Always present: ``events_by_metadata_prefix`` stamps every entry (see
+            # SOURCE_BLOCK_COL in config.py); a KeyError here means that contract broke.
+            source_block = event_cfg.pop(SOURCE_BLOCK_COL)
 
             compute_fn = partial(
                 extract_all_metadata,
@@ -576,8 +589,7 @@ def main(cfg: DictConfig):
             # Scope the expansion to the event config that declared this _metadata block —
             # other events may reference same-named component columns with colliding values,
             # and must not receive this metadata (#134).
-            if source_block is not None and "source_block" in component_schema:
-                components = components.filter(pl.col("source_block") == source_block)
+            components = components.filter(pl.col(SOURCE_BLOCK_COL) == source_block)
 
             # Restrict the left side to exactly the full code and the join keys: any other
             # component column sharing a name with a metadata output column would otherwise

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -30,6 +30,66 @@ MEDS_METADATA_MANDATORY_TYPES = {
     CodeMetadataSchema.parent_codes_name: pl.List(pl.String),
 }
 
+# Reserved internal alias for the fully-assembled output code inside the code-component map.
+# Keeping the full code under this name (rather than "code") means unnesting the
+# ``code_components`` struct can never collide with it — even when a code expression
+# references a source column literally named ``code`` (see issue #110).
+FULL_CODE_COL = "__meds_full_code"
+
+
+def normalize_join_key(col: str, dtype: pl.DataType) -> pl.Expr:
+    """Render the join-key column ``col`` of type ``dtype`` as a canonical String expression.
+
+    Code components keep their raw source dtypes (an ``Int64`` ``itemid``, say), while
+    csv-sourced metadata keys are uniformly ``String`` (they are read with
+    ``infer_schema=False``). Joining the two directly raises a ``SchemaError`` (issue #135),
+    so both sides of the partial-match join are normalized through this single canonical
+    string rendering:
+
+    - String columns pass through unchanged.
+    - Non-float columns cast directly: ``220045`` renders as ``"220045"``.
+    - Float columns render integer-valued entries via ``Int64`` so that ``220045.0`` matches
+      the metadata string ``"220045"`` rather than rendering as ``"220045.0"``; non-integer
+      values keep their float rendering (``1.5`` renders as ``"1.5"``). Integer-valued floats
+      outside the ``Int64`` range render as null (and thus match nothing).
+
+    The returned expression preserves the column name (nulls stay null and never match under
+    the default ``join_nulls=False``).
+
+    Examples:
+        >>> df = pl.DataFrame({
+        ...     "i": [220045, 13, None],
+        ...     "f": [220045.0, 1.5, None],
+        ...     "s": ["220045", "01.90", None],
+        ... })
+        >>> df.select(
+        ...     normalize_join_key("i", df.schema["i"]),
+        ...     normalize_join_key("f", df.schema["f"]),
+        ...     normalize_join_key("s", df.schema["s"]),
+        ... )
+        shape: (3, 3)
+        ┌────────┬────────┬────────┐
+        │ i      ┆ f      ┆ s      │
+        │ ---    ┆ ---    ┆ ---    │
+        │ str    ┆ str    ┆ str    │
+        ╞════════╪════════╪════════╡
+        │ 220045 ┆ 220045 ┆ 220045 │
+        │ 13     ┆ 1.5    ┆ 01.90  │
+        │ null   ┆ null   ┆ null   │
+        └────────┴────────┴────────┘
+    """
+    expr = pl.col(col)
+    if dtype == pl.String:
+        return expr
+    if dtype.is_float():
+        return (
+            pl.when(expr == expr.round(0))
+            .then(expr.cast(pl.Int64, strict=False).cast(pl.String))
+            .otherwise(expr.cast(pl.String))
+            .alias(col)
+        )
+    return expr.cast(pl.String)
+
 
 def extract_metadata(
     metadata_df: pl.LazyFrame,
@@ -407,18 +467,26 @@ def main(cfg: DictConfig):
     all_data = pl.concat(all_event_dfs, how="diagonal_relaxed")
     all_codes = all_data.select(pl.col("code").unique()).collect().get_column("code").to_list()
 
-    # Build code_components mapping for partial metadata joins
+    # Build code_components mapping for partial metadata joins. The full output code is kept
+    # under the reserved FULL_CODE_COL alias so that unnesting the struct can never collide
+    # with it — a code expression may reference a source column literally named "code" (#110).
+    # source_block is carried along so each partial-match expansion can be scoped to the event
+    # that declared the _metadata block (#134).
     data_schema = all_data.collect_schema()
     if "code_components" in data_schema:
-        code_component_map = (
-            all_data.select("code", "code_components").unique().collect().unnest("code_components")
-        )
+        map_cols = [pl.col("code").alias(FULL_CODE_COL), pl.col("code_components")]
+        if "source_block" in data_schema:
+            map_cols.append(pl.col("source_block"))
+        code_component_map = all_data.select(*map_cols).unique().collect().unnest("code_components")
     else:
         code_component_map = None
 
     all_out_fps = []
-    # Collect _match_on columns per output file for use during reduction
-    match_on_by_fp: dict[Path, list[str]] = {}
+    # Explicit bookkeeping for partial-match outputs: out_fp -> (match_cols, source_block).
+    # The reducer is driven by this record rather than by sniffing output schemas — a partial
+    # output whose _match_on includes a column named "code" would otherwise be misclassified
+    # as full-match (#110).
+    partial_info: dict[Path, tuple[list[str], str | None]] = {}
     for input_prefix, event_metadata_cfgs in event_metadata_configs:
         event_metadata_cfgs = copy.deepcopy(event_metadata_cfgs)
 
@@ -436,6 +504,8 @@ def main(cfg: DictConfig):
             out_fp = partial_metadata_dir / f"{input_prefix}_{cfg_idx}.parquet"
             logger.info(f"Extracting metadata from {metadata_fps} and saving to {out_fp}")
 
+            source_block = event_cfg.pop("source_block", None)
+
             compute_fn = partial(
                 extract_all_metadata,
                 event_cfgs=[event_cfg],
@@ -452,12 +522,13 @@ def main(cfg: DictConfig):
             )
             all_out_fps.append(out_fp)
 
-            # Record _match_on columns for this shard so the reducer can use them explicitly
+            # Record _match_on columns and the declaring event's source_block for this shard
+            # so the reducer can classify and scope it explicitly.
             match_on = event_cfg.get("_metadata", {}).get("_match_on")
             if match_on is not None:
                 if isinstance(match_on, str):
                     match_on = [match_on]
-                match_on_by_fp[out_fp] = list(match_on)
+                partial_info[out_fp] = (list(match_on), source_block)
 
     logger.info("Extracted metadata for all events. Merging.")
 
@@ -472,27 +543,64 @@ def main(cfg: DictConfig):
     start = datetime.now(tz=UTC)
     logger.info("All map shards complete! Starting code metadata reduction computation.")
 
-    # Separate partial-match outputs (no "code" column) from full-match outputs
+    # Separate partial-match outputs from full-match outputs. Classification is driven by the
+    # explicit partial_info record from map time, never by output schemas — a partial output
+    # whose _match_on includes "code" carries a "code" column of raw component values and
+    # would be silently misclassified as full-match by schema sniffing (#110).
     full_match_dfs = []
     partial_match_dfs = []
     for fp in all_out_fps:
         df = pl.scan_parquet(fp, glob=False)
-        if "code" in df.collect_schema():
+        if fp in partial_info:
+            match_cols, source_block = partial_info[fp]
+            partial_match_dfs.append((fp, df, match_cols, source_block))
+        else:
             full_match_dfs.append(df)
-        elif fp in match_on_by_fp:
-            partial_match_dfs.append((df, match_on_by_fp[fp]))
 
     # Expand partial-match metadata to full codes via code_components
     if partial_match_dfs and code_component_map is not None:
-        for pdf, match_cols in partial_match_dfs:
-            pdf_cols = pdf.collect_schema().names()
-            metadata_cols_partial = [c for c in pdf_cols if c not in match_cols]
+        component_schema = code_component_map.schema
+        for fp, pdf, match_cols, source_block in partial_match_dfs:
+            pdf_schema = pdf.collect_schema()
+            metadata_cols_partial = [c for c in pdf_schema.names() if c not in match_cols]
+
+            missing = [c for c in match_cols if c not in component_schema]
+            if missing:
+                logger.warning(
+                    f"Partial-match metadata from {fp} (source block {source_block!r}) requires "
+                    f"component columns {missing} that are absent from the extracted data. Skipping."
+                )
+                continue
+
+            components = code_component_map.lazy()
+            # Scope the expansion to the event config that declared this _metadata block —
+            # other events may reference same-named component columns with colliding values,
+            # and must not receive this metadata (#134).
+            if source_block is not None and "source_block" in component_schema:
+                components = components.filter(pl.col("source_block") == source_block)
+
+            # Restrict the left side to exactly the full code and the join keys: any other
+            # component column sharing a name with a metadata output column would otherwise
+            # shadow it in the post-join select. Join keys are normalized to a canonical
+            # String rendering on both sides — components keep raw source dtypes while
+            # csv-sourced metadata keys are uniformly String (#135).
+            components = components.select(
+                FULL_CODE_COL,
+                *[normalize_join_key(c, component_schema[c]) for c in match_cols],
+            ).unique()
+            pdf = pdf.with_columns(normalize_join_key(c, pdf_schema[c]) for c in match_cols)
+
             expanded = (
-                code_component_map.lazy()
-                .join(pdf, on=match_cols, how="inner")
-                .select("code", *metadata_cols_partial)
+                components.join(pdf, on=match_cols, how="inner")
+                .select(pl.col(FULL_CODE_COL).alias("code"), *metadata_cols_partial)
+                .collect()
             )
-            full_match_dfs.append(expanded)
+            if expanded.is_empty():
+                logger.warning(
+                    f"Partial-match metadata from {fp} (source block {source_block!r}, "
+                    f"match columns {match_cols}) matched zero codes."
+                )
+            full_match_dfs.append(expanded.lazy())
     elif partial_match_dfs:
         logger.warning("Partial-match metadata found but no code_components in data. Skipping.")
 

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -1,23 +1,12 @@
-"""Regression test for issue #110 — ``extract_code_metadata`` DuplicateError.
+"""Stage-level tests for ``extract_code_metadata`` — end-to-end runs of the real stage.
 
-https://github.com/mmcdermott/MEDS_extract/issues/110
-
-When a ``code`` expression references a source column literally named ``code`` (idiomatic
-for ICD/OMOP vocabulary tables, e.g. ``code: f"ICD//{$code}"``), the ``code_components``
-struct that ``convert_to_MEDS_events`` attaches has a field named ``code``.
-``extract_code_metadata.main`` used to run::
-
-    code_component_map = (
-        all_data.select("code", "code_components").unique().collect().unnest("code_components")
-    )
-
-and the unnested ``code`` field collided with the existing output ``code`` column, raising
-``polars.exceptions.DuplicateError`` and aborting the whole stage. The fix keeps the full
-output code under a reserved internal alias inside the component map so the unnest can never
-collide.
-
-The first test establishes provenance (the struct really does carry a ``code`` field); the
-second drives the *real* stage end-to-end and asserts it completes with correct metadata.
+Covers behavior that needs the full mapper/reducer machinery rather than a single
+helper (those are doctested in place): here, codes built from a source column literally
+named ``code`` — the idiomatic ICD/OMOP vocabulary-table shape — must flow through the
+``code_components`` map build, full-match extraction, and reduction without colliding
+with the output ``code`` column (regression for
+https://github.com/mmcdermott/MEDS_extract/issues/110; the struct-shape provenance for
+that scenario is a doctest on ``EventConfig.extract``).
 """
 
 from __future__ import annotations
@@ -28,8 +17,6 @@ from pathlib import Path
 
 import polars as pl
 from omegaconf import OmegaConf
-
-from MEDS_extract.config import EventConfig
 
 # A diagnoses table whose code is built from a source column named ``code``, plus a
 # ``_metadata`` block so the stage runs past its "no metadata -> exit" early return.
@@ -128,21 +115,6 @@ def _run_extract_code_metadata(root: Path) -> Path:
     )
     ecm_stage.main_fn(cfg)
     return out_dir
-
-
-def test_convert_produces_code_components_with_a_code_field():
-    """Provenance: the real convert stage attaches a ``code_components`` struct whose field
-    is literally ``code`` when the code references a ``$code`` source column — this is what
-    makes the ``extract_code_metadata`` unnest collide.
-    """
-    raw = pl.DataFrame({"subject_id": [1], "code": ["250.00"], "ts": ["2020-01-01"]})
-    out = (
-        EventConfig.parse("dx", {"code": 'f"ICD//{$code}"', "time": '$ts::"%Y-%m-%d"'})
-        .extract(raw.lazy(), "diagnoses/dx")
-        .collect()
-    )
-    assert "code_components" in out.columns
-    assert "code" in [f.name for f in out.schema["code_components"].fields]
 
 
 def test_extract_code_metadata_handles_code_named_source_column():

--- a/tests/test_inprocess_pipeline.py
+++ b/tests/test_inprocess_pipeline.py
@@ -1290,3 +1290,274 @@ data:
         ecm_stage.main_fn(cfg)
         codes_df = pl.read_parquet(out_dir / "codes.parquet")
         assert len(codes_df) == 0
+
+
+# ── Partial-match correctness regressions (#110, #134, #135) ──
+
+
+def _run_ecm_scenario(
+    root: Path,
+    messy_yaml: str,
+    event_frames: dict[str, pl.DataFrame],
+    raw_files: dict[str, str],
+) -> pl.DataFrame:
+    """Run the extract_code_metadata stage over synthetic event shards and raw metadata files.
+
+    ``event_frames`` maps parquet basenames to frames of extra columns (code, code_components,
+    source_block, ...); the standard subject_id/time/numeric_value columns are added here.
+    ``raw_files`` maps raw metadata filenames to their text content. Returns the reduced
+    ``codes.parquet`` as a DataFrame.
+    """
+    from MEDS_extract.extract_code_metadata.extract_code_metadata import main as ecm_stage
+
+    events_dir = root / "events" / "train" / "0"
+    events_dir.mkdir(parents=True)
+    for basename, frame in event_frames.items():
+        n = len(frame)
+        frame.with_columns(
+            subject_id=pl.Series(range(1, n + 1), dtype=pl.Int64),
+            time=pl.lit(None, dtype=pl.Datetime("us")),
+            numeric_value=pl.lit(None, dtype=pl.Float32),
+        ).write_parquet(events_dir / f"{basename}.parquet")
+
+    raw_dir = root / "raw"
+    raw_dir.mkdir()
+    for fname, content in raw_files.items():
+        (raw_dir / fname).write_text(content)
+
+    event_cfg_fp = root / "event_cfgs.yaml"
+    event_cfg_fp.write_text(messy_yaml)
+    shards_fp = root / "metadata" / ".shards.json"
+    shards_fp.parent.mkdir(parents=True)
+    shards_fp.write_text(json.dumps({"train/0": [1]}))
+
+    out_dir = root / "metadata_out" / "metadata"
+    out_dir.mkdir(parents=True)
+
+    cfg = _make_cfg(
+        {
+            "input_dir": str(raw_dir),
+            "stage_cfg": {
+                "data_input_dir": str(root / "events"),
+                "output_dir": str(out_dir),
+                "metadata_input_dir": str(root / "empty_meta"),
+                "reducer_output_dir": str(out_dir),
+                "description_separator": "\n",
+            },
+            "event_conversion_config_fp": str(event_cfg_fp),
+            "shards_map_fp": str(shards_fp),
+        }
+    )
+    ecm_stage.main_fn(cfg)
+    return pl.read_parquet(out_dir / "codes.parquet")
+
+
+def test_partial_match_on_column_named_code_is_expanded_not_passed_through():
+    """Regression guard (#110): a partial output keyed on a column named ``code`` is partial.
+
+    ``_match_on: code`` makes the intermediate shard carry a ``code`` column of raw component
+    values (e.g. ``250.00``). The reducer used to classify shards by sniffing for a ``code``
+    column in the schema, misclassifying this shard as full-match and passing the raw
+    component values through as output codes — silently wrong codes.parquet. Classification
+    must come from explicit map-time bookkeeping instead.
+    """
+    messy = """\
+diagnoses:
+  dx:
+    code: 'f"ICD//{$code}"'
+    _metadata:
+      icd_meta:
+        _match_on: code
+        description: long_title
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "diagnoses": pl.DataFrame(
+                    {
+                        "code": ["ICD//250.00", "ICD//401.9"],
+                        "code_components": [{"code": "250.00"}, {"code": "401.9"}],
+                        "source_block": ["diagnoses/dx", "diagnoses/dx"],
+                    }
+                )
+            },
+            raw_files={"icd_meta.csv": "code,long_title\n250.00,Diabetes mellitus\n401.9,Hypertension\n"},
+        )
+
+        by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+        # Partial-match expansion: metadata lands on the FULL codes...
+        assert by_code.get("ICD//250.00") == "Diabetes mellitus"
+        assert by_code.get("ICD//401.9") == "Hypertension"
+        # ...and the raw component values are NOT passed through as codes (the old
+        # full-match misclassification symptom).
+        assert "250.00" not in by_code
+        assert "401.9" not in by_code
+
+
+def test_partial_match_scoped_to_declaring_event():
+    """Regression guard (#134): ``_match_on`` expansion is scoped to the declaring event.
+
+    Two events build codes from a same-named ``itemid`` component with colliding values, but
+    only the chartevents event declares the ``d_items`` metadata. The labevents code must NOT
+    receive that metadata, and no output row may carry the declaring config's code_template
+    as false provenance for a labevents code.
+    """
+    messy = """\
+chartevents:
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    _metadata:
+      d_items:
+        _match_on: itemid
+        description: label
+labevents:
+  lab:
+    code: 'f"LAB//{$itemid}"'
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "chartevents": pl.DataFrame(
+                    {
+                        "code": ["CHART//1"],
+                        "code_components": [{"itemid": "1"}],
+                        "source_block": ["chartevents/chart"],
+                    }
+                ),
+                "labevents": pl.DataFrame(
+                    {
+                        "code": ["LAB//1"],
+                        "code_components": [{"itemid": "1"}],
+                        "source_block": ["labevents/lab"],
+                    }
+                ),
+            },
+            raw_files={"d_items.csv": "itemid,label\n1,Heart Rate (chart)\n"},
+        )
+
+        chart_rows = codes_df.filter(pl.col("code") == "CHART//1")
+        assert chart_rows["description"].to_list() == ["Heart Rate (chart)"]
+        assert chart_rows["code_template"].to_list() == ['f"CHART//{$itemid}"']
+
+        # The labevents code must not receive the chartevents-declared metadata.
+        lab_rows = codes_df.filter(pl.col("code") == "LAB//1")
+        assert lab_rows["description"].drop_nulls().to_list() == [], (
+            f"LAB//1 must not receive metadata declared on the chartevents event.\n{codes_df}"
+        )
+        assert lab_rows["code_template"].drop_nulls().to_list() == [], (
+            f"LAB//1 must not be stamped with the chartevents code_template.\n{codes_df}"
+        )
+
+
+def test_partial_match_typed_int_components_join_csv_metadata():
+    """Regression guard (#135): typed ``Int64`` components join against all-String CSV keys.
+
+    CSV metadata sources are read with ``infer_schema=False`` (all-String), while code
+    components keep their raw source dtypes. The reducer join used to crash with
+    ``SchemaError: datatypes of join keys don't match``; join keys must be normalized to
+    String on both sides.
+    """
+    messy = """\
+chartevents:
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    _metadata:
+      d_items:
+        _match_on: itemid
+        description: label
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "chartevents": pl.DataFrame(
+                    {
+                        "code": ["CHART//220045", "CHART//220179"],
+                        "code_components": [{"itemid": 220045}, {"itemid": 220179}],
+                        "source_block": ["chartevents/chart", "chartevents/chart"],
+                    }
+                )
+            },
+            raw_files={"d_items.csv": "itemid,label\n220045,Heart Rate\n220179,NBP systolic\n"},
+        )
+
+        by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+        assert by_code.get("CHART//220045") == "Heart Rate"
+        assert by_code.get("CHART//220179") == "NBP systolic"
+
+
+def test_partial_match_integer_valued_float_components_join_csv_metadata():
+    """Regression guard (#135): integer-valued float components render as ``220045``.
+
+    A ``Float64`` component with value ``220045.0`` must match the metadata string
+    ``"220045"`` — a plain String cast would render ``"220045.0"`` and silently zero-match.
+    Non-integer float values keep their float rendering.
+    """
+    messy = """\
+chartevents:
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    _metadata:
+      d_items:
+        _match_on: itemid
+        description: label
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "chartevents": pl.DataFrame(
+                    {
+                        "code": ["CHART//220045", "CHART//1.5"],
+                        "code_components": [{"itemid": 220045.0}, {"itemid": 1.5}],
+                        "source_block": ["chartevents/chart", "chartevents/chart"],
+                    }
+                )
+            },
+            raw_files={"d_items.csv": "itemid,label\n220045,Heart Rate\n1.5,Half Item\n"},
+        )
+
+        by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+        assert by_code.get("CHART//220045") == "Heart Rate"
+        assert by_code.get("CHART//1.5") == "Half Item"
+
+
+def test_partial_match_zero_matches_warns(caplog):
+    """A partial-match join that matches zero codes emits a WARNING (minimal diagnostic).
+
+    Full match-coverage diagnostics are tracked in #138; this only guards the silent-miss case introduced
+    alongside the #135 dtype normalization.
+    """
+    messy = """\
+chartevents:
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    _metadata:
+      d_items:
+        _match_on: itemid
+        description: label
+"""
+    with tempfile.TemporaryDirectory() as d, caplog.at_level("WARNING"):
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "chartevents": pl.DataFrame(
+                    {
+                        "code": ["CHART//1"],
+                        "code_components": [{"itemid": "1"}],
+                        "source_block": ["chartevents/chart"],
+                    }
+                )
+            },
+            raw_files={"d_items.csv": "itemid,label\n999,No Such Item\n"},
+        )
+
+        assert len(codes_df.filter(pl.col("description").is_not_null())) == 0
+        assert "matched zero codes" in caplog.text

--- a/tests/test_issue_110_metadata_code_column.py
+++ b/tests/test_issue_110_metadata_code_column.py
@@ -1,0 +1,162 @@
+"""Demonstration / regression test for issue #110 — ``extract_code_metadata`` DuplicateError.
+
+https://github.com/mmcdermott/MEDS_extract/issues/110
+
+When a ``code`` expression references a source column literally named ``code`` (idiomatic
+for ICD/OMOP vocabulary tables, e.g. ``code: f"ICD//{$code}"``), the ``code_components``
+struct that ``convert_to_MEDS_events`` attaches has a field named ``code``.
+``extract_code_metadata.main`` then runs (unconditionally, whenever any ``_metadata`` block
+exists)::
+
+    code_component_map = (
+        all_data.select("code", "code_components").unique().collect().unnest("code_components")
+    )
+
+and the unnested ``code`` field collides with the existing output ``code`` column, raising
+``polars.exceptions.DuplicateError`` and aborting the whole stage.
+
+The first test establishes provenance (the struct really does carry a ``code`` field); the
+second drives the *real* stage and is ``xfail(strict, raises=DuplicateError)`` — it fails
+today via that exact exception, any *other* failure is a hard error rather than a silent
+xfail, and the fix turns it green (``strict=True`` then flags the stale marker).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import polars as pl
+import pytest
+from omegaconf import OmegaConf
+
+from MEDS_extract.config import EventConfig
+
+# A diagnoses table whose code is built from a source column named ``code``, plus a
+# ``_metadata`` block so the stage runs past its "no metadata -> exit" early return.
+_MESSY = """\
+diagnoses:
+  dx:
+    code: 'f"ICD//{$code}"'
+    _metadata:
+      icd_descriptions:
+        description: long_title
+"""
+
+
+def _make_cfg(overrides: dict) -> OmegaConf:
+    """Minimal DictConfig mimicking what MEDS-Transforms hands a stage (worker 0)."""
+    base = {
+        "do_overwrite": True,
+        "seed": 1,
+        "worker": 0,
+        "polling_time": 0.1,
+        "stage": "test",
+        "stage_cfg": {},
+        "etl_metadata": {
+            "dataset_name": "TEST",
+            "dataset_version": "1.0",
+            "package_name": "MEDS_extract",
+            "package_version": "0.0.0",
+        },
+    }
+    base.update(overrides)
+    cfg = OmegaConf.create(base)
+    OmegaConf.set_struct(cfg, False)
+    return cfg
+
+
+def _run_extract_code_metadata(root: Path) -> Path:
+    """Lay out a minimal extract_code_metadata invocation and run it; return the reducer dir.
+
+    The events parquet carries a ``code_components`` struct with a field named ``code`` —
+    exactly the shape ``convert_to_MEDS_events`` emits for ``code: f"ICD//{$code}"`` (proven
+    by ``test_convert_produces_code_components_with_a_code_field``).
+    """
+    from MEDS_extract.extract_code_metadata.extract_code_metadata import main as ecm_stage
+
+    events_dir = root / "events" / "train" / "0"
+    events_dir.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "subject_id": [1, 2],
+            "time": [None, None],
+            "code": ["ICD//250.00", "ICD//401.9"],
+            "code_components": [{"code": "250.00"}, {"code": "401.9"}],
+            "numeric_value": [None, None],
+        }
+    ).cast({"subject_id": pl.Int64, "time": pl.Datetime("us"), "numeric_value": pl.Float32}).write_parquet(
+        events_dir / "data.parquet"
+    )
+
+    raw_dir = root / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "icd_descriptions.csv").write_text(
+        "code,long_title\n250.00,Diabetes mellitus\n401.9,Essential hypertension\n"
+    )
+
+    metadata_in = root / "metadata_in" / "metadata"
+    metadata_in.mkdir(parents=True)
+    pl.DataFrame({"code": ["EXISTING"], "description": ["pre-existing code"]}).write_parquet(
+        metadata_in / "codes.parquet", use_pyarrow=True
+    )
+
+    event_cfg_fp = root / "messy.yaml"
+    event_cfg_fp.write_text(_MESSY)
+    shards_fp = root / "metadata" / ".shards.json"
+    shards_fp.parent.mkdir(parents=True)
+    shards_fp.write_text(json.dumps({"train/0": [1, 2]}))
+
+    out_dir = root / "metadata_out" / "metadata"
+    out_dir.mkdir(parents=True)
+
+    cfg = _make_cfg(
+        {
+            "input_dir": str(raw_dir),
+            "stage_cfg": {
+                "data_input_dir": str(root / "events"),
+                "output_dir": str(out_dir),
+                "metadata_input_dir": str(metadata_in),
+                "reducer_output_dir": str(out_dir),
+                "description_separator": "\n",
+            },
+            "event_conversion_config_fp": str(event_cfg_fp),
+            "shards_map_fp": str(shards_fp),
+        }
+    )
+    ecm_stage.main_fn(cfg)
+    return out_dir
+
+
+def test_convert_produces_code_components_with_a_code_field():
+    """Provenance: the real convert stage attaches a ``code_components`` struct whose field
+    is literally ``code`` when the code references a ``$code`` source column — this is what
+    makes the ``extract_code_metadata`` unnest collide.
+    """
+    raw = pl.DataFrame({"subject_id": [1], "code": ["250.00"], "ts": ["2020-01-01"]})
+    out = (
+        EventConfig.parse("dx", {"code": 'f"ICD//{$code}"', "time": '$ts::"%Y-%m-%d"'})
+        .extract(raw.lazy(), "diagnoses/dx")
+        .collect()
+    )
+    assert "code_components" in out.columns
+    assert "code" in [f.name for f in out.schema["code_components"].fields]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=pl.exceptions.DuplicateError,
+    reason="#110: extract_code_metadata unnests `code_components` (which has a `code` field) "
+    "alongside the existing `code` column, colliding -> DuplicateError aborts the stage.",
+)
+def test_extract_code_metadata_handles_code_named_source_column():
+    """The stage should run to completion when a ``code`` references a ``code`` column.
+
+    Today it raises ``DuplicateError`` at the ``code_components`` unnest. Scoping the marker
+    to ``raises=DuplicateError`` means a regression elsewhere surfaces as a real failure, and
+    the fix flips this to a passing regression test.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        out_dir = _run_extract_code_metadata(Path(d))
+        assert (out_dir / "codes.parquet").exists()  # reached only once the bug is fixed

--- a/tests/test_issue_110_metadata_code_column.py
+++ b/tests/test_issue_110_metadata_code_column.py
@@ -1,24 +1,23 @@
-"""Demonstration / regression test for issue #110 — ``extract_code_metadata`` DuplicateError.
+"""Regression test for issue #110 — ``extract_code_metadata`` DuplicateError.
 
 https://github.com/mmcdermott/MEDS_extract/issues/110
 
 When a ``code`` expression references a source column literally named ``code`` (idiomatic
 for ICD/OMOP vocabulary tables, e.g. ``code: f"ICD//{$code}"``), the ``code_components``
 struct that ``convert_to_MEDS_events`` attaches has a field named ``code``.
-``extract_code_metadata.main`` then runs (unconditionally, whenever any ``_metadata`` block
-exists)::
+``extract_code_metadata.main`` used to run::
 
     code_component_map = (
         all_data.select("code", "code_components").unique().collect().unnest("code_components")
     )
 
-and the unnested ``code`` field collides with the existing output ``code`` column, raising
-``polars.exceptions.DuplicateError`` and aborting the whole stage.
+and the unnested ``code`` field collided with the existing output ``code`` column, raising
+``polars.exceptions.DuplicateError`` and aborting the whole stage. The fix keeps the full
+output code under a reserved internal alias inside the component map so the unnest can never
+collide.
 
 The first test establishes provenance (the struct really does carry a ``code`` field); the
-second drives the *real* stage and is ``xfail(strict, raises=DuplicateError)`` — it fails
-today via that exact exception, any *other* failure is a hard error rather than a silent
-xfail, and the fix turns it green (``strict=True`` then flags the stale marker).
+second drives the *real* stage end-to-end and asserts it completes with correct metadata.
 """
 
 from __future__ import annotations
@@ -28,7 +27,6 @@ import tempfile
 from pathlib import Path
 
 import polars as pl
-import pytest
 from omegaconf import OmegaConf
 
 from MEDS_extract.config import EventConfig
@@ -84,6 +82,7 @@ def _run_extract_code_metadata(root: Path) -> Path:
             "time": [None, None],
             "code": ["ICD//250.00", "ICD//401.9"],
             "code_components": [{"code": "250.00"}, {"code": "401.9"}],
+            "source_block": ["diagnoses/dx", "diagnoses/dx"],
             "numeric_value": [None, None],
         }
     ).cast({"subject_id": pl.Int64, "time": pl.Datetime("us"), "numeric_value": pl.Float32}).write_parquet(
@@ -98,7 +97,9 @@ def _run_extract_code_metadata(root: Path) -> Path:
 
     metadata_in = root / "metadata_in" / "metadata"
     metadata_in.mkdir(parents=True)
-    pl.DataFrame({"code": ["EXISTING"], "description": ["pre-existing code"]}).write_parquet(
+    # A non-conflicting column name: how overlapping metadata columns merge with pre-existing
+    # metadata is orthogonal to #110 (the existing join suffixes duplicates as `_right`).
+    pl.DataFrame({"code": ["EXISTING"], "old_description": ["pre-existing code"]}).write_parquet(
         metadata_in / "codes.parquet", use_pyarrow=True
     )
 
@@ -144,19 +145,16 @@ def test_convert_produces_code_components_with_a_code_field():
     assert "code" in [f.name for f in out.schema["code_components"].fields]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=pl.exceptions.DuplicateError,
-    reason="#110: extract_code_metadata unnests `code_components` (which has a `code` field) "
-    "alongside the existing `code` column, colliding -> DuplicateError aborts the stage.",
-)
 def test_extract_code_metadata_handles_code_named_source_column():
-    """The stage should run to completion when a ``code`` references a ``code`` column.
+    """The stage runs to completion when a ``code`` expression references a ``code`` column.
 
-    Today it raises ``DuplicateError`` at the ``code_components`` unnest. Scoping the marker
-    to ``raises=DuplicateError`` means a regression elsewhere surfaces as a real failure, and
-    the fix flips this to a passing regression test.
+    Before the #110 fix this raised ``DuplicateError`` at the ``code_components`` unnest
+    (this test carried a strict xfail marker). Now it asserts the stage completes and the
+    full-match metadata lands on the reconstructed codes.
     """
     with tempfile.TemporaryDirectory() as d:
         out_dir = _run_extract_code_metadata(Path(d))
-        assert (out_dir / "codes.parquet").exists()  # reached only once the bug is fixed
+        codes_df = pl.read_parquet(out_dir / "codes.parquet")
+        by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+        assert by_code.get("ICD//250.00") == "Diabetes mellitus"
+        assert by_code.get("ICD//401.9") == "Essential hypertension"


### PR DESCRIPTION
## Summary

Fixes three verified defects in the partial-match (`_match_on`) component-join region of `extract_code_metadata`, which the issues flagged as needing to land together:

- **#110 — `DuplicateError` on a source column named `code` (+ silent misclassification):** the code-component map now keeps the fully-assembled output code under the reserved internal alias `__meds_full_code`, so unnesting the `code_components` struct can never collide with an output `code` column — even when a code expression references a source column literally named `code` (`code: 'f"ICD//{$code}"'`). The reducer's full-vs-partial classification is now driven by explicit map-time bookkeeping (`out_fp -> (match_cols, source_block)`) instead of sniffing output schemas for a `code` column, which misclassified a partial output whose `_match_on` includes `code` as full-match and passed raw component values through as output codes.
- **#134 — event-unscoped `_match_on` join:** `MessyConfig.events_by_metadata_prefix` now tags each entry with the declaring event's `source_block` (`{input_prefix}/{event_name}`, the same tag `EventConfig.extract` already stamps on every data row), the component map carries `source_block`, and each partial-match expansion filters the map to the declaring event before joining — so same-named component columns with colliding values on *other* events no longer receive the metadata or a false `code_template` provenance stamp. The expansion also selects the code alias + metadata columns explicitly, fixing the verified name-collision variant where a metadata column sharing a component column's name silently yielded the component values.
- **#135 — dtype-mismatch `SchemaError`:** partial-match join keys are normalized to one canonical String rendering on both sides via the new `normalize_join_key` helper (doctested): typed `Int64` components join all-String (`infer_schema=False`) CSV metadata keys, and integer-valued float components render as `220045`, not `220045.0` (via a lossless `Int64` cast; integer-valued floats outside `Int64` range render as null and match nothing, as documented). A WARNING is emitted when a partial join matches zero codes — the full match-coverage diagnostics remain tracked in #138.

Closes #110
Closes #134
Closes #135

**Supersedes and absorbs #114:** this branch was cut from `tests/issue-110-metadata-dup-code-demo`, so it carries that PR's demonstration test — now green, with its strict xfail marker removed per the test's own instructions and the assertions strengthened to check the reduced metadata contents.

## Test plan

- [x] PR #114's `test_extract_code_metadata_handles_code_named_source_column` flipped from strict-xfail to passing (asserts stage completion and correct full-match metadata on reconstructed codes)
- [x] New: `_match_on: code` misclassification regression — partial output keyed on a column named `code` produces partial-match expansion (`ICD//250.00`), not full-match passthrough of raw component values
- [x] New: #134 scoping regression from the issue's verified repro — `CHART//{$itemid}` and `LAB//{$itemid}` sharing itemid values, `d_items` declared only on the chartevents event: `LAB//1` receives no metadata and no false `code_template`
- [x] New: #135 dtype regressions — typed `Int64` itemid components join CSV metadata correctly; integer-valued float components match `220045` (and non-integer floats match their float rendering)
- [x] New: zero-match WARNING emitted when a partial join matches no codes
- [x] `normalize_join_key` and updated `events_by_metadata_prefix` covered by doctests
- [x] Full suite green: `uv run pytest -q` → 85 passed, 1 deselected
- [x] `uv run pre-commit run --all-files` stable (all hooks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)