### PR TITLE
extract_code_metadata: unify null-component code rendering between data and metadata sides (#136)

### DIFF
--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -57,6 +57,55 @@ def _null_safe_code_expr(code_node: NodeBase) -> pl.Expr:
     return code_node.polars_expr.cast(pl.Utf8, strict=False).fill_null(pl.lit("UNK"))
 
 
+def compiled_code_expr(code_node: NodeBase) -> pl.Expr:
+    """Compile a ``code`` node into the one canonical rendering shared by data and metadata sides.
+
+    This is the single source of truth for how a MESSY ``code`` expression is rendered:
+
+    - Composite codes (nodes referencing source columns that are not a bare ``Column``) render
+      each null component as the literal ``"UNK"`` via :func:`_null_safe_code_expr`.
+    - Bare ``Column`` codes and pure literals compile to their raw, null-propagating
+      expression. For bare-``Column`` codes callers must drop null-code rows afterwards
+      (:meth:`EventConfig.extract` filters on the source column; ``extract_metadata`` filters
+      on the rendered ``code``) — a null bare-column code is a meaningless key, not an
+      ``UNK``-renderable component.
+
+    Both :meth:`EventConfig.extract` (the data side) and
+    ``extract_code_metadata.extract_metadata`` (the metadata side, in full-match mode) MUST
+    compile codes through this function so that a metadata row with a null code component
+    reconstructs exactly the code the data emits — e.g. a mapping row with a null unit links
+    to the ``...//UNK`` code the data side produces (see issue #136). Note this deliberately
+    centralizes the null-rendering policy: if the default rendering changes (see issue #126),
+    both sides change together and linkage is preserved.
+
+    Examples:
+        A composite code with a null component renders that component as ``"UNK"``, whereas
+        the raw dftly expression null-propagates — the two renderings disagree exactly on
+        null-component rows:
+
+        >>> node = Parser()('f"LAB//RESULT//{$itemid}//{$valueuom}"')
+        >>> row = pl.DataFrame(
+        ...     {"itemid": ["51463"], "valueuom": [None]},
+        ...     schema={"itemid": pl.String, "valueuom": pl.String},
+        ... )
+        >>> row.select(code=compiled_code_expr(node))["code"].to_list()
+        ['LAB//RESULT//51463//UNK']
+        >>> row.select(code=node.polars_expr)["code"].to_list()
+        [None]
+
+        A bare-``Column`` code keeps null-propagation (callers drop the null rows):
+
+        >>> node = Parser()("$icd_code")
+        >>> pl.DataFrame({"icd_code": ["I10", None]}).select(
+        ...     code=compiled_code_expr(node)
+        ... )["code"].to_list()
+        ['I10', None]
+    """
+    if code_node.referenced_columns and type(code_node).__name__ != "Column":
+        return _null_safe_code_expr(code_node)
+    return code_node.polars_expr
+
+
 # ── JoinConfig ───────────────────────────────────────────────────────
 
 
@@ -443,11 +492,9 @@ class EventConfig:
         exprs: dict[str, pl.Expr] = {"subject_id": pl.col("subject_id")}
 
         # A composite code renders each null component as "UNK" (see issue #109); a bare-column
-        # or literal code is used as-is.
-        if self.code_source_columns and type(self.columns["code"]).__name__ != "Column":
-            exprs["code"] = _null_safe_code_expr(self.columns["code"])
-        else:
-            exprs["code"] = self.polars_exprs["code"]
+        # or literal code is used as-is. This shared helper is also what the metadata side uses
+        # to reconstruct codes, so both sides always agree on the rendering (see issue #136).
+        exprs["code"] = compiled_code_expr(self.columns["code"])
         if self.code_source_columns:
             # Raw, typed component values (unaffected by the "UNK" rendering above).
             exprs["code_components"] = pl.struct(

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -18,7 +18,7 @@ from omegaconf import DictConfig
 from upath import UPath
 
 from .._stage_example import MEDSExtractStageExample
-from ..config import MessyConfig
+from ..config import MessyConfig, compiled_code_expr
 from ..io import resolve_source_files, scan_source
 
 logger = logging.getLogger(__name__)
@@ -115,6 +115,16 @@ def extract_metadata(
         metadata column is specified for extraction in the metadata block. The output dataframe will not
         necessarily be unique by code if the input metadata is not unique by code.
 
+        In full-match mode, codes are reconstructed with the SAME rendering the data side uses
+        (both compile through `MEDS_extract.config.compiled_code_expr`; see issue #136): a
+        composite code renders each null component as the literal `"UNK"`, and a bare-column
+        code null-propagates with null-code rows dropped (mirroring the data side's null-row
+        drop). Residual asymmetry (documented here, not fixed): a metadata row with a null
+        component full-matches only the `...//UNK` code the data emits for null components —
+        it can never full-match a data row carrying a *real* value for that component. Linking
+        a null-component mapping row to all observed values of that component requires partial
+        matching via `_match_on`.
+
     Raises:
         KeyError: If the event configuration dictionary is missing the `"code"` or `"_metadata"` keys or if
             the `"_metadata_"` key is empty or if columns referenced by the event configuration dictionary are
@@ -162,6 +172,44 @@ def extract_metadata(
         │ FOO//C//3 ┆ f"FOO//{$code}//{$code_modifie… ┆ C with 3 │
         └───────────┴─────────────────────────────────┴──────────┘
         >>> extract_metadata(raw_metadata.drop("code_modifier"), event_cfg)  # doctest: +SKIP
+
+    A null component in a composite code renders as ``"UNK"``, exactly matching the code the
+    data side emits for null components (issue #136):
+        >>> raw_metadata = pl.DataFrame({
+        ...     "itemid": ["51463"],
+        ...     "valueuom": [None],
+        ...     "label": ["Yeast [Presence] in Urine"],
+        ... }, schema={"itemid": pl.String, "valueuom": pl.String, "label": pl.String})
+        >>> event_cfg = {
+        ...     "code": 'f"LAB//RESULT//{$itemid}//{$valueuom}"',
+        ...     "_metadata": {"description": "label"},
+        ... }
+        >>> extract_metadata(raw_metadata, event_cfg).select("code", "description")
+        shape: (1, 2)
+        ┌─────────────────────────┬───────────────────────────┐
+        │ code                    ┆ description               │
+        │ ---                     ┆ ---                       │
+        │ str                     ┆ str                       │
+        ╞═════════════════════════╪═══════════════════════════╡
+        │ LAB//RESULT//51463//UNK ┆ Yeast [Presence] in Urine │
+        └─────────────────────────┴───────────────────────────┘
+
+    A bare-column code keeps null-propagation, and null-code rows are dropped (mirroring the
+    data side's null-row drop for bare-column codes):
+        >>> raw_metadata = pl.DataFrame({
+        ...     "icd": ["I10", None],
+        ...     "long_title": ["Hypertension", "orphan row"],
+        ... })
+        >>> extract_metadata(raw_metadata, {"code": "$icd", "_metadata": {"description": "long_title"}})
+        shape: (1, 3)
+        ┌──────┬───────────────┬──────────────┐
+        │ code ┆ code_template ┆ description  │
+        │ ---  ┆ ---           ┆ ---          │
+        │ str  ┆ str           ┆ str          │
+        ╞══════╪═══════════════╪══════════════╡
+        │ I10  ┆ $icd          ┆ Hypertension │
+        └──────┴───────────────┴──────────────┘
+
         >>> extract_metadata(raw_metadata, ['foo'])
         Traceback (most recent call last):
             ...
@@ -230,7 +278,11 @@ def extract_metadata(
     else:
         code_template_str = str(code_value)
         code_node = Parser()(code_template_str)
-    code_expr = code_node.polars_expr
+    # Compile the code through the SAME shared helper the data side uses, so both sides agree
+    # on null-component rendering: a mapping row with a null component reconstructs the
+    # ``...//UNK`` code the data actually emits, instead of null-propagating to an
+    # unlinkable null code (see issue #136).
+    code_expr = compiled_code_expr(code_node)
     code_referenced_cols = code_node.referenced_columns
 
     columns = metadata_df.collect_schema().names()
@@ -283,6 +335,12 @@ def extract_metadata(
             code=code_expr,
             code_template=pl.lit(code_template_str),
         )
+
+        # Mirror the data side's null-row drop (`EventConfig.extract` filters bare-`Column`
+        # code rows on the source column being non-null): a null code is a meaningless key.
+        # Composite codes are never null under `compiled_code_expr`, so this only affects
+        # bare-column (and degenerate) codes.
+        metadata_df = metadata_df.filter(pl.col("code").is_not_null())
 
         if allowed_codes:
             metadata_df = metadata_df.filter(pl.col("code").is_in(allowed_codes))

--- a/tests/test_inprocess_pipeline.py
+++ b/tests/test_inprocess_pipeline.py
@@ -1561,3 +1561,92 @@ chartevents:
 
         assert len(codes_df.filter(pl.col("description").is_not_null())) == 0
         assert "matched zero codes" in caplog.text
+
+
+# ── Full-match null-component rendering asymmetry regressions (#136) ──
+
+
+def test_full_match_null_component_metadata_links_to_unk_code():
+    """Regression guard (#136): a null-component mapping row links to the ``UNK`` code.
+
+    The data side renders a labevents row with ``itemid=51463`` and null ``valueuom`` as
+    ``LAB//RESULT//51463//UNK``. The metadata side used to reconstruct codes with the raw
+    null-propagating dftly expression, so the matching mapping row (itemid ``51463``, null
+    ``valueuom``) evaluated to a null code and was silently dropped — the ``UNK`` code could
+    never receive its metadata. Both sides must share one compiled code rendering.
+    """
+    messy = """\
+labevents:
+  lab:
+    code: 'f"LAB//RESULT//{$itemid}//{$valueuom}"'
+    _metadata:
+      d_labitems_to_loinc:
+        description: label
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "labevents": pl.DataFrame(
+                    {
+                        "code": ["LAB//RESULT//51463//UNK", "LAB//RESULT//51464//mg/dL"],
+                        "code_components": [
+                            {"itemid": "51463", "valueuom": None},
+                            {"itemid": "51464", "valueuom": "mg/dL"},
+                        ],
+                        "source_block": ["labevents/lab", "labevents/lab"],
+                    }
+                )
+            },
+            raw_files={
+                "d_labitems_to_loinc.csv": (
+                    "itemid,valueuom,label\n51463,,Yeast [Presence] in Urine\n51464,mg/dL,Bilirubin Total\n"
+                )
+            },
+        )
+
+        by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+        # The null-valueuom mapping row must land on the UNK code the data actually emits.
+        assert by_code.get("LAB//RESULT//51463//UNK") == "Yeast [Presence] in Urine", (
+            f"Null-component mapping row failed to link to the UNK code.\n{codes_df}"
+        )
+        # Fully-populated mapping rows keep linking as before.
+        assert by_code.get("LAB//RESULT//51464//mg/dL") == "Bilirubin Total"
+
+
+def test_full_match_bare_column_code_drops_null_metadata_keys():
+    """Regression guard (#136): bare-column codes drop null metadata keys, mirroring the data side.
+
+    A bare-column code null-propagates on both sides; the data side drops null-code rows (no identifier means
+    no event), so the metadata side must likewise drop mapping rows whose key column is null — not crash and
+    not emit a null code.
+    """
+    messy = """\
+diagnoses:
+  dx:
+    code: $icd_code
+    _metadata:
+      icd_meta:
+        description: long_title
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "diagnoses": pl.DataFrame(
+                    {
+                        "code": ["I10"],
+                        "code_components": [{"icd_code": "I10"}],
+                        "source_block": ["diagnoses/dx"],
+                    }
+                )
+            },
+            raw_files={"icd_meta.csv": "icd_code,long_title\nI10,Hypertension\n,orphan row\n"},
+        )
+
+        by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+        assert by_code.get("I10") == "Hypertension"
+        # The null-key mapping row is dropped, never emitted as a null code.
+        assert None not in by_code, f"Null metadata key must be dropped, not emitted.\n{codes_df}"


### PR DESCRIPTION
## Summary

Fixes the null-component rendering asymmetry between the data and metadata sides of `extract_code_metadata` (issue #136) — the single largest cause of MIMIC metadata that never links.

- **The defect:** the data side (`EventConfig.extract`) renders composite codes with each null component as the literal `"UNK"` (`_null_safe_code_expr`, #109), but `extract_metadata`'s full-match mode reconstructed codes with the raw null-propagating dftly expression. A mapping row with a null component (e.g. `d_labitems_to_loinc` itemid `51463`, null `valueuom`) evaluated to a NULL code and was silently dropped — it could never link to the `LAB//RESULT//51463//UNK` code the data actually emits.
- **The fix:** the rendering selection ("null-safe for composite codes; raw null-propagating expression for bare `Column` codes and literals") is promoted into one shared helper, `config.compiled_code_expr`, called by **both** `EventConfig.extract` and `extract_metadata`. The null-rendering policy now lives in exactly one place, so a future default change (#126 / #121) moves both sides together and cannot re-break linkage — the `UNK` hardcoding is not duplicated.
- **Bare-`Column` codes** keep null-propagation on the metadata side, with a `.filter(pl.col("code").is_not_null())` mirroring the data side's null-row drop (a null bare-column code is a meaningless key, not an `UNK`-renderable component).
- **Residual (documented, not fixed here):** a mapping row with a null component full-matches only the `...//UNK` code — it can never full-match a data row carrying a *real* value for that component. That case genuinely needs `_match_on` partial matching, and is now documented in the `extract_metadata` docstring.

**MIMIC magnitude** (real mimic-code v2.4.0 files, from the issue's verified investigation): `d_labitems_to_loinc` has **1018/1630 rows (62%)** with null/blank `valueuom` (feeding `LAB//RESULT//{itemid}//{valueuom}` codes); `outputevents_to_loinc` has **927/999 rows (93%)** with null `unitname`. All of these were previously unlinkable in full-match mode.

Closes #136

> **Stacked PR:** this branch is cut from and targets `fix/110-134-135-partial-match` (#139), which reworked the partial-match join path — this change targets the FULL-match path and composes with it. It will auto-retarget to `dev` when #139 merges.

## Test plan

- [x] Doctests on `compiled_code_expr` contrasting the shared rendering (`LAB//RESULT//51463//UNK`) with the raw null-propagating expression (`None`) on the same null-component row, plus the bare-`Column` null-propagation contract
- [x] Doctests on `extract_metadata`: null `valueuom` mapping row reconstructs the `UNK` code with its description; bare-column config drops the null-key row
- [x] New pipeline regression: `test_full_match_null_component_metadata_links_to_unk_code` — mirrors the issue's evidence (itemid `51463`, null `valueuom`); the data-side `LAB//RESULT//51463//UNK` code RECEIVES its description in `codes.parquet`, and fully-populated mapping rows keep linking
- [x] New pipeline regression: `test_full_match_bare_column_code_drops_null_metadata_keys` — a null metadata key row is dropped, not crashed on and not emitted as a null code
- [x] Data side unchanged: existing suite untouched and green — `uv run pytest -q` → 88 passed, 1 deselected (85 inherited from #139 + 3 new)
- [x] `uv run pre-commit run --all-files` stable (all hooks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)