### PR TITLE
extract_code_metadata: one component-join path for all metadata matching (#144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,8 @@ The event config includes `_metadata` blocks that link events to description fil
 Metadata joins the extracted codes on their raw code components: lab descriptions match
 on `test_name` (the code's only component), while medication descriptions use
 `_match_on` to narrow the join — the code is `f"{$medication_name}//{$dose}"` but the
-metadata only has `medication_name`:
+metadata only has `medication_name` (see
+[Metadata linking, in depth](#metadata-linking-in-depth) for a full walkthrough):
 
 ```python
 >>> codes = pl.read_parquet(output / "metadata" / "codes.parquet")
@@ -578,55 +579,567 @@ vitals:
 The join key may be a single shared column (`key: stay_id`) or asymmetric
 (`left_on:`/`right_on:`), and `cols` lists the columns to pull from the right table.
 
-### Metadata Linking
+### Metadata linking, in depth
 
-When your dataset has separate tables with code descriptions or other metadata,
-use `_metadata` blocks to link them. Each block names a metadata file prefix and
-maps output columns to source columns:
+Datasets usually ship dictionary tables alongside the event data — `d_items.csv`,
+`d_icd_diagnoses.csv`, a LOINC map. `_metadata` blocks link those tables to your
+extracted codes, producing `metadata/codes.parquet`. The mental model:
 
-```yaml
-lab_results:
-  lab:
-    code: $test_name
-    time: $timestamp
-    numeric_value: $result
-    _metadata:
-      lab_descriptions:           # Matches lab_descriptions.csv in your input dir
-        description: description  # Output "description" from source "description" column
+- Every extracted event row carries `code_components` — a struct of the **raw source
+    values** the code was built from — and `source_block`, the MESSY block that produced
+    it (see [Output Columns](#output-columns)).
+- The `extract_code_metadata` stage attaches metadata by **joining those raw component
+    values against raw metadata columns**, scoped to the event block that declared the
+    `_metadata` entry.
+- The assembled code *string* is never matched against. Your metadata tables keep their
+    raw values as-is — you never mirror the code expression's prefixes, separators,
+    casts, or `??` fallbacks inside a metadata table.
+
+The walkthrough below is executable (it runs in CI). Two helpers keep each example to
+its essentials: `extract_events` stands in for the `convert_to_MEDS_events` stage
+(extracting every event block of a MESSY snippet from in-memory raw tables), and
+`link_metadata` runs the real `extract_code_metadata` stage over those events plus
+metadata files, returning the reduced `metadata/codes.parquet`:
+
+```python
+>>> import yaml
+>>> from omegaconf import OmegaConf
+>>> from MEDS_extract.config import EventConfig
+>>> from MEDS_extract.extract_code_metadata.extract_code_metadata import (
+...     extract_metadata,
+...     main as ecm_stage,
+... )
+>>> def extract_events(messy: str, raw_tables: dict) -> pl.DataFrame:
+...     """What `convert_to_MEDS_events` emits: every MESSY event block, extracted."""
+...     frames = []
+...     for table, events in yaml.safe_load(messy).items():
+...         for name, event_cfg in events.items():
+...             ev = EventConfig.parse(name, event_cfg)
+...             frames.append(ev.extract(raw_tables[table].lazy(), f"{table}/{name}").collect())
+...     return pl.concat(frames, how="diagonal_relaxed")
+>>> def link_metadata(messy: str, events: pl.DataFrame, metadata_files: dict) -> pl.DataFrame:
+...     """Run the real `extract_code_metadata` stage; return `metadata/codes.parquet`."""
+...     root = Path(tempfile.mkdtemp())
+...     for d in ("events", "raw", "out"):
+...         (root / d).mkdir()
+...     events.write_parquet(root / "events" / "0.parquet")
+...     for fname, df in metadata_files.items():  # .parquet stays typed; .csv reads as String
+...         fp = root / "raw" / fname
+...         df.write_parquet(fp) if fname.endswith(".parquet") else df.write_csv(fp)
+...     (root / "messy.yaml").write_text(messy)
+...     cfg = OmegaConf.create({
+...         "do_overwrite": True, "worker": 0, "polling_time": 0.1,
+...         "input_dir": str(root / "raw"),
+...         "event_conversion_config_fp": str(root / "messy.yaml"),
+...         "stage_cfg": {
+...             "data_input_dir": str(root / "events"),
+...             "output_dir": str(root / "out"),
+...             "metadata_input_dir": str(root / "no_prior_metadata"),
+...             "reducer_output_dir": str(root / "out"),
+...             "description_separator": "; ",
+...         },
+...     })
+...     ecm_stage.main_fn(cfg)
+...     return pl.read_parquet(root / "out" / "codes.parquet")
+
 ```
 
-The `extract_code_metadata` stage reads the metadata file and joins it onto the
-extracted codes by their raw code components — here the metadata table's `test_name`
-column matches the `test_name` component each code was built from — to produce
-`metadata/codes.parquet`. Codes and metadata link exactly when a direct join between
-the raw source values and the metadata table's key columns would link them: null
-component values match null metadata keys (so vocabulary rows with a missing key column
-still attach to codes built with `??`-coalesced components), and the metadata table
-never needs to reproduce any transforms the code expression applies — it holds the raw,
-untransformed values. A `_metadata` block requires a code with at least one column
-reference; a literal code has no components to match metadata on.
+#### Full match: one code, one metadata row
 
-#### Narrowing the join with `_match_on`
+By default a `_metadata` entry joins on **every** source column the code references.
+Each block under `_metadata` names a metadata file prefix (here `lab_dictionary`
+matches `lab_dictionary.csv` in your input directory) and maps output columns to
+source columns:
 
-By default the join matches on every source column the code expression references. When
-the code is composite (e.g., `f"{$medication_name}//{$dose}"`) but your metadata table
-only has one of the components, use `_match_on` to join on that component alone. The
-metadata is broadcast to all codes sharing that component:
+```python
+>>> messy = """
+... labs:
+...   lab:
+...     code: f"LAB//{$test_name}//{$units}"
+...     time: $ts::"%Y-%m-%d %H:%M"
+...     numeric_value: $result
+...     _metadata:
+...       lab_dictionary:           # <input_dir>/lab_dictionary.csv
+...         description: label     # output column <- metadata source column
+... """
 
-```yaml
-medications:
-  med:
-    code: f"{$medication_name}//{$dose}"
-    time: $timestamp
-    _metadata:
-      medication_classes:
-        _match_on: medication_name   # Join on just this code component
-        description: drug_class      # "Metformin//500mg" gets "Antidiabetic"
+```
+
+Extracting events from a raw `labs` table shows what the join will run against — each
+row's `code_components` holds the raw `test_name` and `units` values, and
+`source_block` records the declaring MESSY block:
+
+```python
+>>> labs = pl.DataFrame({
+...     "subject_id": [1, 1, 2],
+...     "test_name": ["GLU", "CREAT", "GLU"],
+...     "units": ["mg/dL", "mg/dL", "mg/dL"],
+...     "ts": ["2024-01-01 09:30", "2024-01-01 09:35", "2024-03-02 14:00"],
+...     "result": [98.0, 1.1, 105.0],
+... })
+>>> events = extract_events(messy, {"labs": labs})
+>>> events.select("code", "code_components", "source_block")
+shape: (3, 3)
+┌───────────────────┬───────────────────┬──────────────┐
+│ code              ┆ code_components   ┆ source_block │
+│ ---               ┆ ---               ┆ ---          │
+│ str               ┆ struct[2]         ┆ str          │
+╞═══════════════════╪═══════════════════╪══════════════╡
+│ LAB//GLU//mg/dL   ┆ {"GLU","mg/dL"}   ┆ labs/lab     │
+│ LAB//CREAT//mg/dL ┆ {"CREAT","mg/dL"} ┆ labs/lab     │
+│ LAB//GLU//mg/dL   ┆ {"GLU","mg/dL"}   ┆ labs/lab     │
+└───────────────────┴───────────────────┴──────────────┘
+
+```
+
+The metadata table carries the same raw columns — `test_name` and `units`, exactly as
+they appear in the raw data, with no `LAB//` prefix or `//` separators:
+
+```python
+>>> lab_dictionary = pl.DataFrame({
+...     "test_name": ["GLU", "CREAT", "NA"],
+...     "units": ["mg/dL", "mg/dL", "mmol/L"],
+...     "label": ["Serum glucose", "Serum creatinine", "Serum sodium"],
+... })
+>>> lab_dictionary
+shape: (3, 3)
+┌───────────┬────────┬──────────────────┐
+│ test_name ┆ units  ┆ label            │
+│ ---       ┆ ---    ┆ ---              │
+│ str       ┆ str    ┆ str              │
+╞═══════════╪════════╪══════════════════╡
+│ GLU       ┆ mg/dL  ┆ Serum glucose    │
+│ CREAT     ┆ mg/dL  ┆ Serum creatinine │
+│ NA        ┆ mmol/L ┆ Serum sodium     │
+└───────────┴────────┴──────────────────┘
+
+```
+
+Linking joins each code's components `(test_name, units)` against the same-named
+metadata columns. The `NA` row matches no observed code, so it does not appear —
+`codes.parquet` describes the codes your data actually contains:
+
+```python
+>>> link_metadata(messy, events, {"lab_dictionary.csv": lab_dictionary})
+shape: (2, 3)
+┌───────────────────┬────────────────────────────────┬──────────────────┐
+│ code              ┆ code_template                  ┆ description      │
+│ ---               ┆ ---                            ┆ ---              │
+│ str               ┆ str                            ┆ str              │
+╞═══════════════════╪════════════════════════════════╪══════════════════╡
+│ LAB//CREAT//mg/dL ┆ f"LAB//{$test_name}//{$units}" ┆ Serum creatinine │
+│ LAB//GLU//mg/dL   ┆ f"LAB//{$test_name}//{$units}" ┆ Serum glucose    │
+└───────────────────┴────────────────────────────────┴──────────────────┘
+
+```
+
+#### `_match_on`: dictionaries keyed on one component
+
+When the code is composite but the dictionary is keyed on just one of its components,
+`_match_on` narrows the join to the named column(s); the metadata then broadcasts to
+**every** code sharing that component value. Here both dose-variants of Metformin get
+the drug class, from a dictionary that knows nothing about doses:
+
+```python
+>>> messy = """
+... medications:
+...   med:
+...     code: f"{$medication_name}//{$dose}"
+...     time:
+...     _metadata:
+...       med_classes:
+...         _match_on: medication_name   # join on this component alone
+...         description: drug_class
+... """
+>>> medications = pl.DataFrame({
+...     "subject_id": [1, 2, 3],
+...     "medication_name": ["Metformin", "Metformin", "Lisinopril"],
+...     "dose": ["500 mg", "1000 mg", "10 mg"],
+... })
+>>> events = extract_events(messy, {"medications": medications})
+>>> events.select("code", "code_components")
+shape: (3, 2)
+┌────────────────────┬─────────────────────────┐
+│ code               ┆ code_components         │
+│ ---                ┆ ---                     │
+│ str                ┆ struct[2]               │
+╞════════════════════╪═════════════════════════╡
+│ Metformin//500 mg  ┆ {"500 mg","Metformin"}  │
+│ Metformin//1000 mg ┆ {"1000 mg","Metformin"} │
+│ Lisinopril//10 mg  ┆ {"10 mg","Lisinopril"}  │
+└────────────────────┴─────────────────────────┘
+>>> med_classes = pl.DataFrame({
+...     "medication_name": ["Metformin", "Lisinopril"],
+...     "drug_class": ["Antidiabetic", "ACE inhibitor"],
+... })
+>>> link_metadata(messy, events, {"med_classes.csv": med_classes})
+shape: (3, 3)
+┌────────────────────┬────────────────────────────────┬───────────────┐
+│ code               ┆ code_template                  ┆ description   │
+│ ---                ┆ ---                            ┆ ---           │
+│ str                ┆ str                            ┆ str           │
+╞════════════════════╪════════════════════════════════╪═══════════════╡
+│ Lisinopril//10 mg  ┆ f"{$medication_name}//{$dose}" ┆ ACE inhibitor │
+│ Metformin//1000 mg ┆ f"{$medication_name}//{$dose}" ┆ Antidiabetic  │
+│ Metformin//500 mg  ┆ f"{$medication_name}//{$dose}" ┆ Antidiabetic  │
+└────────────────────┴────────────────────────────────┴───────────────┘
+
 ```
 
 Without `_match_on`, the metadata table would need both `medication_name` and `dose`
-columns to match the full code. With `_match_on`, only the specified column is
-needed. You can also specify multiple columns: `_match_on: [col_a, col_b]`.
+columns to match the full component set. Multiple columns also work:
+`_match_on: [col_a, col_b]`.
+
+#### Metadata is scoped to the declaring event
+
+Two events may reference same-named components with colliding values — an `itemid` in
+`vitals` and an unrelated `itemid` in `labs`. A `_metadata` block only ever attaches to
+codes from the event block that declared it (that is what `source_block` is for):
+
+```python
+>>> messy = """
+... vitals:
+...   vital:
+...     code: f"VITAL//{$itemid}"
+...     time:
+...     _metadata:
+...       d_vitals:
+...         description: label
+... labs:
+...   lab:
+...     code: f"LAB//{$itemid}"
+...     time:
+... """
+>>> vitals = pl.DataFrame({"subject_id": [1], "itemid": ["220045"]})
+>>> labs = pl.DataFrame({"subject_id": [1], "itemid": ["220045"]})
+>>> events = extract_events(messy, {"vitals": vitals, "labs": labs})
+>>> events.select("code", "code_components", "source_block")
+shape: (2, 3)
+┌───────────────┬─────────────────┬──────────────┐
+│ code          ┆ code_components ┆ source_block │
+│ ---           ┆ ---             ┆ ---          │
+│ str           ┆ struct[1]       ┆ str          │
+╞═══════════════╪═════════════════╪══════════════╡
+│ VITAL//220045 ┆ {"220045"}      ┆ vitals/vital │
+│ LAB//220045   ┆ {"220045"}      ┆ labs/lab     │
+└───────────────┴─────────────────┴──────────────┘
+>>> d_vitals = pl.DataFrame({"itemid": ["220045"], "label": ["Heart Rate"]})
+>>> link_metadata(messy, events, {"d_vitals.csv": d_vitals})
+shape: (1, 3)
+┌───────────────┬─────────────────────┬─────────────┐
+│ code          ┆ code_template       ┆ description │
+│ ---           ┆ ---                 ┆ ---         │
+│ str           ┆ str                 ┆ str         │
+╞═══════════════╪═════════════════════╪═════════════╡
+│ VITAL//220045 ┆ f"VITAL//{$itemid}" ┆ Heart Rate  │
+└───────────────┴─────────────────────┴─────────────┘
+
+```
+
+`LAB//220045` shares the component value but not the declaring block, so it receives
+nothing — vocabulary declared for one event never leaks onto another.
+
+#### Null components match null vocabulary keys
+
+A `??`-coalesced component (see [Null components in composite
+codes](#null-components-in-composite-codes)) keeps rows whose component is missing, and
+the *raw* null is preserved in `code_components` — the fallback literal appears only in
+the code string:
+
+```python
+>>> messy = """
+... labs:
+...   lab:
+...     code: 'f"{$test_name}//{$units ?? ''UNK''}"'
+...     time:
+...     _metadata:
+...       lab_dictionary:
+...         description: label
+... """
+>>> labs = pl.DataFrame({
+...     "subject_id": [1, 2],
+...     "test_name": ["GLU", "GLU"],
+...     "units": ["mg/dL", None],
+... })
+>>> events = extract_events(messy, {"labs": labs})
+>>> events.select("code", "code_components")
+shape: (2, 2)
+┌────────────┬─────────────────┐
+│ code       ┆ code_components │
+│ ---        ┆ ---             │
+│ str        ┆ struct[2]       │
+╞════════════╪═════════════════╡
+│ GLU//mg/dL ┆ {"GLU","mg/dL"} │
+│ GLU//UNK   ┆ {"GLU",null}    │
+└────────────┴─────────────────┘
+
+```
+
+The join treats null as an ordinary key value: a vocabulary row whose `units` cell is
+empty describes *specifically* the unit-less variant. Note the dictionary says `UNK`
+nowhere — it holds raw values, and the raw value here is null:
+
+```python
+>>> lab_dictionary = pl.DataFrame({
+...     "test_name": ["GLU", "GLU"],
+...     "units": ["mg/dL", None],
+...     "label": ["Glucose (serum)", "Glucose (no unit given)"],
+... })
+>>> link_metadata(messy, events, {"lab_dictionary.csv": lab_dictionary}).select(
+...     "code", "description"
+... )
+shape: (2, 2)
+┌────────────┬─────────────────────────┐
+│ code       ┆ description             │
+│ ---        ┆ ---                     │
+│ str        ┆ str                     │
+╞════════════╪═════════════════════════╡
+│ GLU//UNK   ┆ Glucose (no unit given) │
+│ GLU//mg/dL ┆ Glucose (serum)         │
+└────────────┴─────────────────────────┘
+
+```
+
+A null key is **not** a wildcard: the null-keyed row attached only to `GLU//UNK`, not
+to `GLU//mg/dL`. If you instead want one description across *all* unit-variants of a
+test, that is exactly the `_match_on` narrowing:
+
+```python
+>>> messy = """
+... labs:
+...   lab:
+...     code: 'f"{$test_name}//{$units ?? ''UNK''}"'
+...     time:
+...     _metadata:
+...       lab_dictionary:
+...         _match_on: test_name
+...         description: label
+... """
+>>> broadcast_dictionary = pl.DataFrame({"test_name": ["GLU"], "label": ["Blood glucose"]})
+>>> link_metadata(messy, events, {"lab_dictionary.csv": broadcast_dictionary}).select(
+...     "code", "description"
+... )
+shape: (2, 2)
+┌────────────┬───────────────┐
+│ code       ┆ description   │
+│ ---        ┆ ---           │
+│ str        ┆ str           │
+╞════════════╪═══════════════╡
+│ GLU//UNK   ┆ Blood glucose │
+│ GLU//mg/dL ┆ Blood glucose │
+└────────────┴───────────────┘
+
+```
+
+#### Typed metadata joins string components
+
+Component dtypes come from your raw event files and metadata dtypes from the metadata
+files, and they routinely disagree: csv-sourced events carry String components while a
+parquet dictionary types `itemid` as an integer — or as a float, the classic
+pandas-heritage shape where a nullable integer column became `220045.0`. Both sides of
+the join are normalized through one canonical String rendering (integer-valued floats
+render via `Int64`, so `220045.0` matches `"220045"`):
+
+```python
+>>> messy = """
+... vitals:
+...   vital:
+...     code: f"VITAL//{$itemid}"
+...     time:
+...     _metadata:
+...       d_items:
+...         description: label
+... """
+>>> vitals = pl.DataFrame({"subject_id": [1, 2], "itemid": ["220045", "220179"]})
+>>> events = extract_events(messy, {"vitals": vitals})
+>>> d_items = pl.DataFrame({"itemid": [220045.0, 220179.0], "label": ["Heart Rate", "NBP systolic"]})
+>>> d_items
+shape: (2, 2)
+┌──────────┬──────────────┐
+│ itemid   ┆ label        │
+│ ---      ┆ ---          │
+│ f64      ┆ str          │
+╞══════════╪══════════════╡
+│ 220045.0 ┆ Heart Rate   │
+│ 220179.0 ┆ NBP systolic │
+└──────────┴──────────────┘
+>>> link_metadata(messy, events, {"d_items.parquet": d_items})
+shape: (2, 3)
+┌───────────────┬─────────────────────┬──────────────┐
+│ code          ┆ code_template       ┆ description  │
+│ ---           ┆ ---                 ┆ ---          │
+│ str           ┆ str                 ┆ str          │
+╞═══════════════╪═════════════════════╪══════════════╡
+│ VITAL//220045 ┆ f"VITAL//{$itemid}" ┆ Heart Rate   │
+│ VITAL//220179 ┆ f"VITAL//{$itemid}" ┆ NBP systolic │
+└───────────────┴─────────────────────┴──────────────┘
+
+```
+
+Non-integer floats keep their float rendering (`1.5` only matches `"1.5"`); see
+`normalize_join_key` in `extract_code_metadata` for the exact rules.
+
+#### Transforms in the code never touch the join
+
+A code expression may transform its components — casts, `substring`, arithmetic. The
+join still runs on the **raw** component values, so the vocabulary stays keyed on what
+the raw data contains, not on what the code displays. Here the code keeps only the
+3-character ICD-9 category, yet the full raw `icd_code` is what matches:
+
+```python
+>>> messy = """
+... diagnoses:
+...   dx:
+...     code: f"ICD9//{substring($icd_code, 0, 3)}"
+...     time:
+...     _metadata:
+...       d_icd:
+...         description: long_title
+... """
+>>> diagnoses = pl.DataFrame({"subject_id": [1], "icd_code": ["25000"]})
+>>> events = extract_events(messy, {"diagnoses": diagnoses})
+>>> events.select("code", "code_components")
+shape: (1, 2)
+┌───────────┬─────────────────┐
+│ code      ┆ code_components │
+│ ---       ┆ ---             │
+│ str       ┆ struct[1]       │
+╞═══════════╪═════════════════╡
+│ ICD9//250 ┆ {"25000"}       │
+└───────────┴─────────────────┘
+>>> d_icd = pl.DataFrame({
+...     "icd_code": ["25000", "250"],
+...     "long_title": ["Diabetes mellitus", "Should never match"],
+... })
+>>> link_metadata(messy, events, {"d_icd.csv": d_icd}).select("code", "description")
+shape: (1, 2)
+┌───────────┬───────────────────┐
+│ code      ┆ description       │
+│ ---       ┆ ---               │
+│ str       ┆ str               │
+╞═══════════╪═══════════════════╡
+│ ICD9//250 ┆ Diabetes mellitus │
+└───────────┴───────────────────┘
+
+```
+
+The row keyed on `"250"` — the *transformed* value that appears in the code string —
+matched nothing. You never replicate a code expression's transforms in a metadata
+table.
+
+#### What errors, and why
+
+Metadata linking is validated at configuration time, in every worker, before any data
+is joined. A `_metadata` block on a **literal** code is rejected — a literal references
+no source columns, so there are no components to match on:
+
+```python
+>>> extract_metadata(
+...     pl.DataFrame({"label": ["Birth"]}),
+...     {"code": "MEDS_BIRTH", "_metadata": {"description": "label"}},
+... )
+Traceback (most recent call last):
+    ...
+ValueError: The code expression 'MEDS_BIRTH' is a literal: it references no source columns, ...
+
+```
+
+A `_match_on` column must be one of the code's components:
+
+```python
+>>> extract_metadata(
+...     pl.DataFrame({"medication_name": ["Metformin"], "drug_class": ["Antidiabetic"]}),
+...     {"code": "$medication_name",
+...      "_metadata": {"_match_on": "medication", "description": "drug_class"}},
+... )
+Traceback (most recent call last):
+    ...
+KeyError: "_match_on columns ['medication'] are not referenced by the code expression
+'$medication_name'. Valid columns: ['medication_name']"
+
+```
+
+And a match column may not double as a `_metadata` output expression — join keys are
+always raw metadata columns, never derived or renamed ones:
+
+```python
+>>> extract_metadata(
+...     pl.DataFrame({"itemid_alias": ["220045"], "label": ["Heart Rate"]}),
+...     {"code": 'f"CHART//{$itemid}"',
+...      "_metadata": {"_match_on": "itemid", "itemid": "itemid_alias", "description": "label"}},
+... )
+Traceback (most recent call last):
+    ...
+ValueError: Match column(s) ['itemid'] may not also be declared as _metadata output ...
+
+```
+
+#### The shape of `codes.parquet`
+
+The reduced output has a canonical, data-independent shape. One event may declare
+several `_metadata` entries (and several codes can collapse onto one metadata row), so
+every column is aggregated per code:
+
+- **`description`**: a single String — distinct values from all sources, joined with
+    the stage's `description_separator` in config order.
+- **`parent_codes`**: `List(String)` of distinct `vocabulary/code` strings.
+- **`code_template`**: a single String (one code, one template — see
+    [Output Columns](#output-columns)).
+- **any other column** (extras like `loinc` below): `List(String)` of distinct values,
+    sorted. Missing values are null, never `[]` or `""`.
+
+Here a local dictionary (two rows for `GLU`, i.e. non-unique by key) and a LOINC
+ontology both describe the same code; note `parent_codes` built with the
+`"LOINC/{loinc_code}"` interpolation form:
+
+```python
+>>> messy = """
+... labs:
+...   lab:
+...     code: $test_name
+...     time:
+...     _metadata:
+...       local_dictionary:
+...         description: label
+...         loinc: loinc_code
+...       loinc_ontology:
+...         description: long_name
+...         parent_codes: LOINC/{loinc_code}
+... """
+>>> events = extract_events(messy, {"labs": pl.DataFrame({"subject_id": [1], "test_name": ["GLU"]})})
+>>> local_dictionary = pl.DataFrame({
+...     "test_name": ["GLU", "GLU"],
+...     "label": ["Serum glucose", "Serum glucose"],
+...     "loinc_code": ["2345-7", "2339-0"],
+... })
+>>> loinc_ontology = pl.DataFrame({
+...     "test_name": ["GLU"],
+...     "long_name": ["Glucose [Mass/vol] in Serum"],
+...     "loinc_code": ["2345-7"],
+... })
+>>> out = link_metadata(
+...     messy, events,
+...     {"local_dictionary.csv": local_dictionary, "loinc_ontology.csv": loinc_ontology},
+... )
+>>> with pl.Config(fmt_str_lengths=60, tbl_width_chars=120):
+...     print(out)
+shape: (1, 5)
+┌──────┬───────────────┬────────────────────────────────────────────┬──────────────────────┬──────────────────┐
+│ code ┆ code_template ┆ description                                ┆ loinc                ┆ parent_codes     │
+│ ---  ┆ ---           ┆ ---                                        ┆ ---                  ┆ ---              │
+│ str  ┆ str           ┆ str                                        ┆ list[str]            ┆ list[str]        │
+╞══════╪═══════════════╪════════════════════════════════════════════╪══════════════════════╪══════════════════╡
+│ GLU  ┆ $test_name    ┆ Serum glucose; Glucose [Mass/vol] in Serum ┆ ["2339-0", "2345-7"] ┆ ["LOINC/2345-7"] │
+└──────┴───────────────┴────────────────────────────────────────────┴──────────────────────┴──────────────────┘
+>>> out.schema
+Schema({'code': String, 'code_template': String, 'description': String,
+        'loinc': List(String), 'parent_codes': List(String)})
+
+```
+
+If a pre-existing `metadata/codes.parquet` is present (e.g. hand-curated metadata for
+literal codes), the reduced output is merged with it: freshly extracted values take
+precedence per code, pre-existing values survive wherever nothing was re-extracted.
 
 ### Output Columns
 

--- a/README.md
+++ b/README.md
@@ -1131,9 +1131,9 @@ shape: (1, 5)
 ╞══════╪═══════════════╪════════════════════════════════════════════╪══════════════════════╪══════════════════╡
 │ GLU  ┆ $test_name    ┆ Serum glucose; Glucose [Mass/vol] in Serum ┆ ["2339-0", "2345-7"] ┆ ["LOINC/2345-7"] │
 └──────┴───────────────┴────────────────────────────────────────────┴──────────────────────┴──────────────────┘
->>> out.schema
-Schema({'code': String, 'code_template': String, 'description': String,
-        'loinc': List(String), 'parent_codes': List(String)})
+>>> dict(out.schema)
+{'code': String, 'code_template': String, 'description': String,
+ 'loinc': List(String), 'parent_codes': List(String)}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -673,200 +673,147 @@ extracted codes, producing `metadata/codes.parquet`. The mental model:
     raw values as-is — you never mirror the code expression's prefixes, separators,
     casts, or `??` fallbacks inside a metadata table.
 
-The walkthrough below is executable (it runs in CI). Two helpers keep each example to
-its essentials: `extract_events` stands in for the `convert_to_MEDS_events` stage
-(extracting every event block of a MESSY snippet from in-memory raw tables), and
-`link_metadata` runs the real `extract_code_metadata` stage over those events plus
-metadata files, returning the reduced `metadata/codes.parquet`:
+Every example below is executable (it runs in CI): `yaml_disk` writes a small raw
+dataset plus its MESSY file to disk, then the **real extraction pipeline** runs over it
+— the same invocation as the [End-to-End Example](#-end-to-end-example) — and the
+frames shown are read back from the files the pipeline produced:
 
 ```python
->>> import yaml
->>> from omegaconf import OmegaConf
->>> from MEDS_extract.config import EventConfig
->>> from MEDS_extract.extract_code_metadata.extract_code_metadata import (
-...     extract_metadata,
-...     main as ecm_stage,
-... )
->>> def extract_events(messy: str, raw_tables: dict) -> pl.DataFrame:
-...     """What `convert_to_MEDS_events` emits: every MESSY event block, extracted."""
-...     frames = []
-...     for table, events in yaml.safe_load(messy).items():
-...         for name, event_cfg in events.items():
-...             ev = EventConfig.parse(name, event_cfg)
-...             frames.append(ev.extract(raw_tables[table].lazy(), f"{table}/{name}").collect())
-...     return pl.concat(frames, how="diagonal_relaxed")
->>> def link_metadata(messy: str, events: pl.DataFrame, metadata_files: dict) -> pl.DataFrame:
-...     """Run the real `extract_code_metadata` stage; return `metadata/codes.parquet`."""
-...     root = Path(tempfile.mkdtemp())
-...     for d in ("events", "raw", "out"):
-...         (root / d).mkdir()
-...     events.write_parquet(root / "events" / "0.parquet")
-...     for fname, df in metadata_files.items():  # .parquet stays typed; .csv reads as String
-...         fp = root / "raw" / fname
-...         df.write_parquet(fp) if fname.endswith(".parquet") else df.write_csv(fp)
-...     (root / "messy.yaml").write_text(messy)
-...     cfg = OmegaConf.create({
-...         "do_overwrite": True, "worker": 0, "polling_time": 0.1,
-...         "input_dir": str(root / "raw"),
-...         "event_conversion_config_fp": str(root / "messy.yaml"),
-...         "stage_cfg": {
-...             "data_input_dir": str(root / "events"),
-...             "output_dir": str(root / "out"),
-...             "metadata_input_dir": str(root / "no_prior_metadata"),
-...             "reducer_output_dir": str(root / "out"),
-...             "description_separator": "; ",
-...         },
-...     })
-...     ecm_stage.main_fn(cfg)
-...     return pl.read_parquet(root / "out" / "codes.parquet")
+>>> def run_extraction(root: Path) -> None:
+...     """Run the standard extraction pipeline over `root/raw` per `root/messy.yaml`."""
+...     result = subprocess.run(
+...         f"MEDS_transform-pipeline pkg://MEDS_extract.configs._extract.yaml --overrides "
+...         f"input_dir={root}/raw output_dir={root}/output "
+...         f"event_conversion_config_fp={root}/messy.yaml dataset.name=DEMO dataset.version=1.0",
+...         shell=True, capture_output=True,
+...     )
+...     assert result.returncode == 0, result.stderr.decode()[-1000:]
 
 ```
 
-#### Full match: one code, one metadata row
+#### A worked dataset: full matches, `_match_on`, and null components
 
-By default a `_metadata` entry joins on **every** source column the code references.
-Each block under `_metadata` names a metadata file prefix (here `lab_dictionary`
-matches `lab_dictionary.csv` in your input directory) and maps output columns to
-source columns:
+One dataset, two event tables, two dictionaries. `lab_dictionary` carries **both** of
+the lab code's components (`test_name`, `units`) — including a row whose `units` cell
+is null. `med_classes` is keyed on `medication_name` alone, so its `_metadata` entry
+narrows the join with `_match_on`:
 
 ```python
->>> messy = """
-... labs:
-...   lab:
-...     code: f"LAB//{$test_name}//{$units}"
-...     time: $ts::"%Y-%m-%d %H:%M"
-...     numeric_value: $result
-...     _metadata:
-...       lab_dictionary:           # <input_dir>/lab_dictionary.csv
-...         description: label     # output column <- metadata source column
-... """
+>>> root = yaml_disk('''
+... raw/:
+...   labs.csv:
+...     subject_id: [1, 1, 2, 3]
+...     test_name: [GLU, CREAT, GLU, GLU]
+...     units: [mg/dL, mg/dL, mg/dL, null]
+...     ts: ["2024-01-01 09:30", "2024-01-01 09:35", "2024-03-02 14:00", "2024-04-01 08:15"]
+...     result: [98.0, 1.1, 105.0, 6.1]
+...   medications.csv:
+...     subject_id: [1, 2, 3]
+...     medication_name: [Metformin, Metformin, Lisinopril]
+...     dose: [500 mg, 1000 mg, 10 mg]
+...     ts: ["2024-02-01 08:00", "2024-03-05 09:00", "2024-04-02 09:00"]
+...   lab_dictionary.csv:
+...     test_name: [GLU, GLU, CREAT, NA]
+...     units: [mg/dL, null, mg/dL, mmol/L]
+...     label: [Glucose (serum), Glucose (no unit given), Creatinine (serum), Sodium (serum)]
+...   med_classes.csv:
+...     medication_name: [Metformin, Lisinopril]
+...     drug_class: [Antidiabetic, ACE inhibitor]
+... messy.yaml:
+...   labs:
+...     lab:
+...       code: 'f"LAB//{$test_name}//{$units ?? ''UNK''}"'
+...       time: '$ts::"%Y-%m-%d %H:%M"'
+...       numeric_value: $result
+...       _metadata:
+...         lab_dictionary:
+...           description: label
+...   medications:
+...     med:
+...       code: 'f"{$medication_name}//{$dose}"'
+...       time: '$ts::"%Y-%m-%d %H:%M"'
+...       _metadata:
+...         med_classes:
+...           _match_on: medication_name
+...           description: drug_class
+... ''', Path(tempfile.mkdtemp()))
+>>> run_extraction(root)
 
 ```
 
-Extracting events from a raw `labs` table shows what the join will run against — each
-row's `code_components` holds the raw `test_name` and `units` values, and
-`source_block` records the declaring MESSY block:
+The extracted events carry the raw component values the join will run against.
+Unnesting `code_components` for the lab rows shows the `?? 'UNK'` fallback appearing
+*only* in the code string — the raw null survives in the components:
 
 ```python
->>> labs = pl.DataFrame({
-...     "subject_id": [1, 1, 2],
-...     "test_name": ["GLU", "CREAT", "GLU"],
-...     "units": ["mg/dL", "mg/dL", "mg/dL"],
-...     "ts": ["2024-01-01 09:30", "2024-01-01 09:35", "2024-03-02 14:00"],
-...     "result": [98.0, 1.1, 105.0],
-... })
->>> events = extract_events(messy, {"labs": labs})
->>> events.select("code", "code_components", "source_block")
+>>> data = pl.read_parquet(f"{root}/output/data/**/*.parquet")
+>>> labs = data.filter(pl.col("source_block") == "labs/lab")
+>>> labs.unnest("code_components").select("code", "test_name", "units").sort("code")
+shape: (4, 3)
+┌───────────────────┬───────────┬───────┐
+│ code              ┆ test_name ┆ units │
+│ ---               ┆ ---       ┆ ---   │
+│ str               ┆ str       ┆ str   │
+╞═══════════════════╪═══════════╪═══════╡
+│ LAB//CREAT//mg/dL ┆ CREAT     ┆ mg/dL │
+│ LAB//GLU//UNK     ┆ GLU       ┆ null  │
+│ LAB//GLU//mg/dL   ┆ GLU       ┆ mg/dL │
+│ LAB//GLU//mg/dL   ┆ GLU       ┆ mg/dL │
+└───────────────────┴───────────┴───────┘
+>>> meds = data.filter(pl.col("source_block") == "medications/med")
+>>> meds.unnest("code_components").select("code", "medication_name", "dose").sort("code")
 shape: (3, 3)
-┌───────────────────┬───────────────────┬──────────────┐
-│ code              ┆ code_components   ┆ source_block │
-│ ---               ┆ ---               ┆ ---          │
-│ str               ┆ struct[2]         ┆ str          │
-╞═══════════════════╪═══════════════════╪══════════════╡
-│ LAB//GLU//mg/dL   ┆ {"GLU","mg/dL"}   ┆ labs/lab     │
-│ LAB//CREAT//mg/dL ┆ {"CREAT","mg/dL"} ┆ labs/lab     │
-│ LAB//GLU//mg/dL   ┆ {"GLU","mg/dL"}   ┆ labs/lab     │
-└───────────────────┴───────────────────┴──────────────┘
+┌────────────────────┬─────────────────┬─────────┐
+│ code               ┆ medication_name ┆ dose    │
+│ ---                ┆ ---             ┆ ---     │
+│ str                ┆ str             ┆ str     │
+╞════════════════════╪═════════════════╪═════════╡
+│ Lisinopril//10 mg  ┆ Lisinopril      ┆ 10 mg   │
+│ Metformin//1000 mg ┆ Metformin       ┆ 1000 mg │
+│ Metformin//500 mg  ┆ Metformin       ┆ 500 mg  │
+└────────────────────┴─────────────────┴─────────┘
 
 ```
 
-The metadata table carries the same raw columns — `test_name` and `units`, exactly as
-they appear in the raw data, with no `LAB//` prefix or `//` separators:
+And the linked `metadata/codes.parquet`:
 
 ```python
->>> lab_dictionary = pl.DataFrame({
-...     "test_name": ["GLU", "CREAT", "NA"],
-...     "units": ["mg/dL", "mg/dL", "mmol/L"],
-...     "label": ["Serum glucose", "Serum creatinine", "Serum sodium"],
-... })
->>> lab_dictionary
-shape: (3, 3)
-┌───────────┬────────┬──────────────────┐
-│ test_name ┆ units  ┆ label            │
-│ ---       ┆ ---    ┆ ---              │
-│ str       ┆ str    ┆ str              │
-╞═══════════╪════════╪══════════════════╡
-│ GLU       ┆ mg/dL  ┆ Serum glucose    │
-│ CREAT     ┆ mg/dL  ┆ Serum creatinine │
-│ NA        ┆ mmol/L ┆ Serum sodium     │
-└───────────┴────────┴──────────────────┘
-
-```
-
-Linking joins each code's components `(test_name, units)` against the same-named
-metadata columns. The `NA` row matches no observed code, so it does not appear —
-`codes.parquet` describes the codes your data actually contains:
-
-```python
->>> link_metadata(messy, events, {"lab_dictionary.csv": lab_dictionary})
-shape: (2, 3)
-┌───────────────────┬────────────────────────────────┬──────────────────┐
-│ code              ┆ code_template                  ┆ description      │
-│ ---               ┆ ---                            ┆ ---              │
-│ str               ┆ str                            ┆ str              │
-╞═══════════════════╪════════════════════════════════╪══════════════════╡
-│ LAB//CREAT//mg/dL ┆ f"LAB//{$test_name}//{$units}" ┆ Serum creatinine │
-│ LAB//GLU//mg/dL   ┆ f"LAB//{$test_name}//{$units}" ┆ Serum glucose    │
-└───────────────────┴────────────────────────────────┴──────────────────┘
-
-```
-
-#### `_match_on`: dictionaries keyed on one component
-
-When the code is composite but the dictionary is keyed on just one of its components,
-`_match_on` narrows the join to the named column(s); the metadata then broadcasts to
-**every** code sharing that component value. Here both dose-variants of Metformin get
-the drug class, from a dictionary that knows nothing about doses:
-
-```python
->>> messy = """
-... medications:
-...   med:
-...     code: f"{$medication_name}//{$dose}"
-...     time:
-...     _metadata:
-...       med_classes:
-...         _match_on: medication_name   # join on this component alone
-...         description: drug_class
-... """
->>> medications = pl.DataFrame({
-...     "subject_id": [1, 2, 3],
-...     "medication_name": ["Metformin", "Metformin", "Lisinopril"],
-...     "dose": ["500 mg", "1000 mg", "10 mg"],
-... })
->>> events = extract_events(messy, {"medications": medications})
->>> events.select("code", "code_components")
-shape: (3, 2)
+>>> codes = pl.read_parquet(f"{root}/output/metadata/codes.parquet")
+>>> codes.select("code", "description").sort("code")
+shape: (6, 2)
 ┌────────────────────┬─────────────────────────┐
-│ code               ┆ code_components         │
+│ code               ┆ description             │
 │ ---                ┆ ---                     │
-│ str                ┆ struct[2]               │
+│ str                ┆ str                     │
 ╞════════════════════╪═════════════════════════╡
-│ Metformin//500 mg  ┆ {"500 mg","Metformin"}  │
-│ Metformin//1000 mg ┆ {"1000 mg","Metformin"} │
-│ Lisinopril//10 mg  ┆ {"10 mg","Lisinopril"}  │
+│ LAB//CREAT//mg/dL  ┆ Creatinine (serum)      │
+│ LAB//GLU//UNK      ┆ Glucose (no unit given) │
+│ LAB//GLU//mg/dL    ┆ Glucose (serum)         │
+│ Lisinopril//10 mg  ┆ ACE inhibitor           │
+│ Metformin//1000 mg ┆ Antidiabetic            │
+│ Metformin//500 mg  ┆ Antidiabetic            │
 └────────────────────┴─────────────────────────┘
->>> med_classes = pl.DataFrame({
-...     "medication_name": ["Metformin", "Lisinopril"],
-...     "drug_class": ["Antidiabetic", "ACE inhibitor"],
-... })
->>> link_metadata(messy, events, {"med_classes.csv": med_classes})
-shape: (3, 3)
-┌────────────────────┬────────────────────────────────┬───────────────┐
-│ code               ┆ code_template                  ┆ description   │
-│ ---                ┆ ---                            ┆ ---           │
-│ str                ┆ str                            ┆ str           │
-╞════════════════════╪════════════════════════════════╪═══════════════╡
-│ Lisinopril//10 mg  ┆ f"{$medication_name}//{$dose}" ┆ ACE inhibitor │
-│ Metformin//1000 mg ┆ f"{$medication_name}//{$dose}" ┆ Antidiabetic  │
-│ Metformin//500 mg  ┆ f"{$medication_name}//{$dose}" ┆ Antidiabetic  │
-└────────────────────┴────────────────────────────────┴───────────────┘
 
 ```
 
-Without `_match_on`, the metadata table would need both `medication_name` and `dose`
-columns to match the full component set. Multiple columns also work:
-`_match_on: [col_a, col_b]`.
+Everything in this frame follows from the component join:
+
+- **Full match** (labs, no `_match_on`): each code's `(test_name, units)` components
+    matched the same-named `lab_dictionary` columns. The `NA` dictionary row matched no
+    observed code, so it does not appear — `codes.parquet` describes the codes your data
+    actually contains.
+- **`_match_on` narrowing** (medications): both dose-variants of Metformin got
+    `Antidiabetic` from a dictionary that knows nothing about doses — the metadata
+    broadcasts to every code sharing the matched component. Without `_match_on`, the
+    join would have required `med_classes` to carry both `medication_name` *and* `dose`
+    columns. Multiple columns also work: `_match_on: [col_a, col_b]`.
+- **Null components** (the `LAB//GLU//UNK` row): the join treats null as an ordinary
+    key value, so the dictionary row whose `units` cell is null describes *specifically*
+    the unit-less variant. Note the dictionary says `UNK` nowhere — it holds raw values,
+    and the raw value here is null. A null key is **not** a wildcard: that row attached
+    only to `LAB//GLU//UNK`, never to `LAB//GLU//mg/dL`. (If you instead want one
+    description across *all* unit-variants of a test, that is exactly
+    `_match_on: test_name`.)
 
 #### Metadata is scoped to the declaring event
 
@@ -875,243 +822,160 @@ Two events may reference same-named components with colliding values — an `ite
 codes from the event block that declared it (that is what `source_block` is for):
 
 ```python
->>> messy = """
-... vitals:
-...   vital:
-...     code: f"VITAL//{$itemid}"
-...     time:
-...     _metadata:
-...       d_vitals:
-...         description: label
-... labs:
-...   lab:
-...     code: f"LAB//{$itemid}"
-...     time:
-... """
->>> vitals = pl.DataFrame({"subject_id": [1], "itemid": ["220045"]})
->>> labs = pl.DataFrame({"subject_id": [1], "itemid": ["220045"]})
->>> events = extract_events(messy, {"vitals": vitals, "labs": labs})
->>> events.select("code", "code_components", "source_block")
-shape: (2, 3)
-┌───────────────┬─────────────────┬──────────────┐
-│ code          ┆ code_components ┆ source_block │
-│ ---           ┆ ---             ┆ ---          │
-│ str           ┆ struct[1]       ┆ str          │
-╞═══════════════╪═════════════════╪══════════════╡
-│ VITAL//220045 ┆ {"220045"}      ┆ vitals/vital │
-│ LAB//220045   ┆ {"220045"}      ┆ labs/lab     │
-└───────────────┴─────────────────┴──────────────┘
->>> d_vitals = pl.DataFrame({"itemid": ["220045"], "label": ["Heart Rate"]})
->>> link_metadata(messy, events, {"d_vitals.csv": d_vitals})
-shape: (1, 3)
-┌───────────────┬─────────────────────┬─────────────┐
-│ code          ┆ code_template       ┆ description │
-│ ---           ┆ ---                 ┆ ---         │
-│ str           ┆ str                 ┆ str         │
-╞═══════════════╪═════════════════════╪═════════════╡
-│ VITAL//220045 ┆ f"VITAL//{$itemid}" ┆ Heart Rate  │
-└───────────────┴─────────────────────┴─────────────┘
+>>> root = yaml_disk('''
+... raw/:
+...   vitals.csv:
+...     subject_id: [1, 2, 3]
+...     itemid: [220045, 220045, 220179]
+...   labs.csv:
+...     subject_id: [1, 2, 3]
+...     itemid: [220045, 220045, 220045]
+...   d_vitals.csv:
+...     itemid: [220045, 220179]
+...     label: [Heart Rate, NBP systolic]
+... messy.yaml:
+...   vitals:
+...     vital:
+...       code: 'f"VITAL//{$itemid}"'
+...       time:
+...       _metadata:
+...         d_vitals:
+...           description: label
+...   labs:
+...     lab:
+...       code: 'f"LAB//{$itemid}"'
+...       time:
+... ''', Path(tempfile.mkdtemp()))
+>>> run_extraction(root)
+>>> data = pl.read_parquet(f"{root}/output/data/**/*.parquet")
+>>> data.unnest("code_components").select("code", "itemid", "source_block").unique().sort("code")
+shape: (3, 3)
+┌───────────────┬────────┬──────────────┐
+│ code          ┆ itemid ┆ source_block │
+│ ---           ┆ ---    ┆ ---          │
+│ str           ┆ i64    ┆ str          │
+╞═══════════════╪════════╪══════════════╡
+│ LAB//220045   ┆ 220045 ┆ labs/lab     │
+│ VITAL//220045 ┆ 220045 ┆ vitals/vital │
+│ VITAL//220179 ┆ 220179 ┆ vitals/vital │
+└───────────────┴────────┴──────────────┘
+>>> pl.read_parquet(f"{root}/output/metadata/codes.parquet").select("code", "description").sort("code")
+shape: (2, 2)
+┌───────────────┬──────────────┐
+│ code          ┆ description  │
+│ ---           ┆ ---          │
+│ str           ┆ str          │
+╞═══════════════╪══════════════╡
+│ VITAL//220045 ┆ Heart Rate   │
+│ VITAL//220179 ┆ NBP systolic │
+└───────────────┴──────────────┘
 
 ```
 
 `LAB//220045` shares the component value but not the declaring block, so it receives
 nothing — vocabulary declared for one event never leaks onto another.
 
-#### Null components match null vocabulary keys
+#### Raw values, not rendered values
 
-A `??`-coalesced component (see [Null components in composite
-codes](#null-components-in-composite-codes)) keeps rows whose component is missing, and
-the *raw* null is preserved in `code_components` — the fallback literal appears only in
-the code string:
+Two things routinely differ between what a code *displays* and what the raw data
+*contains*, and the join always sides with the raw data:
+
+1. **Dtypes.** Component dtypes come from your raw event files and metadata dtypes
+    from the metadata files. Below, the csv `itemid` infers as an integer while the
+    parquet dictionary types it as a float — the classic pandas-heritage shape where a
+    nullable integer column became `220045.0`. Both sides of the join are normalized
+    through one canonical String rendering (integer-valued floats render via `Int64`,
+    so `220045.0` matches `220045`; non-integer floats keep their float rendering —
+    `1.5` only matches `"1.5"`).
+2. **Transforms.** A code expression may transform its components — casts,
+    `substring`, arithmetic. The join still runs on the raw component values, so the
+    dictionary stays keyed on what the raw data contains, not on what the code shows.
+    Below, the code keeps only the 3-character ICD-10 category, yet the full raw
+    `icd_code` is what matches.
 
 ```python
->>> messy = """
-... labs:
-...   lab:
-...     code: 'f"{$test_name}//{$units ?? ''UNK''}"'
-...     time:
-...     _metadata:
-...       lab_dictionary:
-...         description: label
-... """
->>> labs = pl.DataFrame({
-...     "subject_id": [1, 2],
-...     "test_name": ["GLU", "GLU"],
-...     "units": ["mg/dL", None],
-... })
->>> events = extract_events(messy, {"labs": labs})
->>> events.select("code", "code_components")
-shape: (2, 2)
-┌────────────┬─────────────────┐
-│ code       ┆ code_components │
-│ ---        ┆ ---             │
-│ str        ┆ struct[2]       │
-╞════════════╪═════════════════╡
-│ GLU//mg/dL ┆ {"GLU","mg/dL"} │
-│ GLU//UNK   ┆ {"GLU",null}    │
-└────────────┴─────────────────┘
+>>> root = yaml_disk('''
+... raw/:
+...   vitals.csv:
+...     subject_id: [1, 2, 3]
+...     itemid: [220045, 220179, 220045]
+...   diagnoses.csv:
+...     subject_id: [1, 2, 3]
+...     icd_code: [E119, I10, E119]
+...   d_items.parquet:
+...     itemid: [220045.0, 220179.0]
+...     label: [Heart Rate, NBP systolic]
+...   d_icd.csv:
+...     icd_code: [E119, I10, E11]
+...     long_title: [Type 2 diabetes, Essential hypertension, Should never match]
+... messy.yaml:
+...   vitals:
+...     vital:
+...       code: 'f"VITAL//{$itemid}"'
+...       time:
+...       _metadata:
+...         d_items:
+...           description: label
+...   diagnoses:
+...     dx:
+...       code: 'f"DX//{substring($icd_code, 0, 3)}"'
+...       time:
+...       _metadata:
+...         d_icd:
+...           description: long_title
+... ''', Path(tempfile.mkdtemp()))
+>>> run_extraction(root)
 
 ```
 
-The join treats null as an ordinary key value: a vocabulary row whose `units` cell is
-empty describes *specifically* the unit-less variant. Note the dictionary says `UNK`
-nowhere — it holds raw values, and the raw value here is null:
+The components keep their raw dtypes and raw values — `itemid` is an `Int64` and
+`icd_code` holds the full, untruncated code:
 
 ```python
->>> lab_dictionary = pl.DataFrame({
-...     "test_name": ["GLU", "GLU"],
-...     "units": ["mg/dL", None],
-...     "label": ["Glucose (serum)", "Glucose (no unit given)"],
-... })
->>> link_metadata(messy, events, {"lab_dictionary.csv": lab_dictionary}).select(
-...     "code", "description"
-... )
-shape: (2, 2)
-┌────────────┬─────────────────────────┐
-│ code       ┆ description             │
-│ ---        ┆ ---                     │
-│ str        ┆ str                     │
-╞════════════╪═════════════════════════╡
-│ GLU//UNK   ┆ Glucose (no unit given) │
-│ GLU//mg/dL ┆ Glucose (serum)         │
-└────────────┴─────────────────────────┘
+>>> data = pl.read_parquet(f"{root}/output/data/**/*.parquet")
+>>> data.schema["code_components"]
+Struct({'icd_code': String, 'itemid': Int64})
+>>> data.unnest("code_components").select("code", "itemid", "icd_code").unique().sort("code")
+shape: (4, 3)
+┌───────────────┬────────┬──────────┐
+│ code          ┆ itemid ┆ icd_code │
+│ ---           ┆ ---    ┆ ---      │
+│ str           ┆ i64    ┆ str      │
+╞═══════════════╪════════╪══════════╡
+│ DX//E11       ┆ null   ┆ E119     │
+│ DX//I10       ┆ null   ┆ I10      │
+│ VITAL//220045 ┆ 220045 ┆ null     │
+│ VITAL//220179 ┆ 220179 ┆ null     │
+└───────────────┴────────┴──────────┘
+>>> pl.read_parquet(f"{root}/output/metadata/codes.parquet").select("code", "description").sort("code")
+shape: (4, 2)
+┌───────────────┬────────────────────────┐
+│ code          ┆ description            │
+│ ---           ┆ ---                    │
+│ str           ┆ str                    │
+╞═══════════════╪════════════════════════╡
+│ DX//E11       ┆ Type 2 diabetes        │
+│ DX//I10       ┆ Essential hypertension │
+│ VITAL//220045 ┆ Heart Rate             │
+│ VITAL//220179 ┆ NBP systolic           │
+└───────────────┴────────────────────────┘
 
 ```
 
-A null key is **not** a wildcard: the null-keyed row attached only to `GLU//UNK`, not
-to `GLU//mg/dL`. If you instead want one description across *all* unit-variants of a
-test, that is exactly the `_match_on` narrowing:
-
-```python
->>> messy = """
-... labs:
-...   lab:
-...     code: 'f"{$test_name}//{$units ?? ''UNK''}"'
-...     time:
-...     _metadata:
-...       lab_dictionary:
-...         _match_on: test_name
-...         description: label
-... """
->>> broadcast_dictionary = pl.DataFrame({"test_name": ["GLU"], "label": ["Blood glucose"]})
->>> link_metadata(messy, events, {"lab_dictionary.csv": broadcast_dictionary}).select(
-...     "code", "description"
-... )
-shape: (2, 2)
-┌────────────┬───────────────┐
-│ code       ┆ description   │
-│ ---        ┆ ---           │
-│ str        ┆ str           │
-╞════════════╪═══════════════╡
-│ GLU//UNK   ┆ Blood glucose │
-│ GLU//mg/dL ┆ Blood glucose │
-└────────────┴───────────────┘
-
-```
-
-#### Typed metadata joins string components
-
-Component dtypes come from your raw event files and metadata dtypes from the metadata
-files, and they routinely disagree: csv-sourced events carry String components while a
-parquet dictionary types `itemid` as an integer — or as a float, the classic
-pandas-heritage shape where a nullable integer column became `220045.0`. Both sides of
-the join are normalized through one canonical String rendering (integer-valued floats
-render via `Int64`, so `220045.0` matches `"220045"`):
-
-```python
->>> messy = """
-... vitals:
-...   vital:
-...     code: f"VITAL//{$itemid}"
-...     time:
-...     _metadata:
-...       d_items:
-...         description: label
-... """
->>> vitals = pl.DataFrame({"subject_id": [1, 2], "itemid": ["220045", "220179"]})
->>> events = extract_events(messy, {"vitals": vitals})
->>> d_items = pl.DataFrame({"itemid": [220045.0, 220179.0], "label": ["Heart Rate", "NBP systolic"]})
->>> d_items
-shape: (2, 2)
-┌──────────┬──────────────┐
-│ itemid   ┆ label        │
-│ ---      ┆ ---          │
-│ f64      ┆ str          │
-╞══════════╪══════════════╡
-│ 220045.0 ┆ Heart Rate   │
-│ 220179.0 ┆ NBP systolic │
-└──────────┴──────────────┘
->>> link_metadata(messy, events, {"d_items.parquet": d_items})
-shape: (2, 3)
-┌───────────────┬─────────────────────┬──────────────┐
-│ code          ┆ code_template       ┆ description  │
-│ ---           ┆ ---                 ┆ ---          │
-│ str           ┆ str                 ┆ str          │
-╞═══════════════╪═════════════════════╪══════════════╡
-│ VITAL//220045 ┆ f"VITAL//{$itemid}" ┆ Heart Rate   │
-│ VITAL//220179 ┆ f"VITAL//{$itemid}" ┆ NBP systolic │
-└───────────────┴─────────────────────┴──────────────┘
-
-```
-
-Non-integer floats keep their float rendering (`1.5` only matches `"1.5"`); see
-`normalize_join_key` in `extract_code_metadata` for the exact rules.
-
-#### Transforms in the code never touch the join
-
-A code expression may transform its components — casts, `substring`, arithmetic. The
-join still runs on the **raw** component values, so the vocabulary stays keyed on what
-the raw data contains, not on what the code displays. Here the code keeps only the
-3-character ICD-9 category, yet the full raw `icd_code` is what matches:
-
-```python
->>> messy = """
-... diagnoses:
-...   dx:
-...     code: f"ICD9//{substring($icd_code, 0, 3)}"
-...     time:
-...     _metadata:
-...       d_icd:
-...         description: long_title
-... """
->>> diagnoses = pl.DataFrame({"subject_id": [1], "icd_code": ["25000"]})
->>> events = extract_events(messy, {"diagnoses": diagnoses})
->>> events.select("code", "code_components")
-shape: (1, 2)
-┌───────────┬─────────────────┐
-│ code      ┆ code_components │
-│ ---       ┆ ---             │
-│ str       ┆ struct[1]       │
-╞═══════════╪═════════════════╡
-│ ICD9//250 ┆ {"25000"}       │
-└───────────┴─────────────────┘
->>> d_icd = pl.DataFrame({
-...     "icd_code": ["25000", "250"],
-...     "long_title": ["Diabetes mellitus", "Should never match"],
-... })
->>> link_metadata(messy, events, {"d_icd.csv": d_icd}).select("code", "description")
-shape: (1, 2)
-┌───────────┬───────────────────┐
-│ code      ┆ description       │
-│ ---       ┆ ---               │
-│ str       ┆ str               │
-╞═══════════╪═══════════════════╡
-│ ICD9//250 ┆ Diabetes mellitus │
-└───────────┴───────────────────┘
-
-```
-
-The row keyed on `"250"` — the *transformed* value that appears in the code string —
-matched nothing. You never replicate a code expression's transforms in a metadata
-table.
+The float-typed `220045.0` dictionary row linked to `VITAL//220045`, and `DX//E11` got
+its description from the row keyed on the raw `E119` — while the decoy row keyed on
+`E11`, the *transformed* value that appears in the code string, matched nothing. You
+never replicate a code expression's transforms in a metadata table.
 
 #### What errors, and why
 
 Metadata linking is validated at configuration time, in every worker, before any data
-is joined. A `_metadata` block on a **literal** code is rejected — a literal references
-no source columns, so there are no components to match on:
+is joined (the checks live in `extract_metadata`, the stage's per-table mapper). A
+`_metadata` block on a **literal** code is rejected — a literal references no source
+columns, so there are no components to match on:
 
 ```python
+>>> from MEDS_extract.extract_code_metadata.extract_code_metadata import extract_metadata
 >>> extract_metadata(
 ...     pl.DataFrame({"label": ["Birth"]}),
 ...     {"code": "MEDS_BIRTH", "_metadata": {"description": "label"}},
@@ -1155,11 +1019,11 @@ ValueError: Match column(s) ['itemid'] may not also be declared as _metadata out
 #### The shape of `codes.parquet`
 
 The reduced output has a canonical, data-independent shape. One event may declare
-several `_metadata` entries (and several codes can collapse onto one metadata row), so
+several `_metadata` entries (and several metadata rows can collapse onto one code), so
 every column is aggregated per code:
 
 - **`description`**: a single String — distinct values from all sources, joined with
-    the stage's `description_separator` in config order.
+    the stage's `description_separator` (default: newline) in config order.
 - **`parent_codes`**: `List(String)` of distinct `vocabulary/code` strings.
 - **`code_template`**: a single String (one code, one template — see
     [Output Columns](#output-columns)).
@@ -1171,49 +1035,54 @@ ontology both describe the same code; note `parent_codes` built with the
 `"LOINC/{loinc_code}"` interpolation form:
 
 ```python
->>> messy = """
-... labs:
-...   lab:
-...     code: $test_name
-...     time:
-...     _metadata:
-...       local_dictionary:
-...         description: label
-...         loinc: loinc_code
-...       loinc_ontology:
-...         description: long_name
-...         parent_codes: LOINC/{loinc_code}
-... """
->>> events = extract_events(messy, {"labs": pl.DataFrame({"subject_id": [1], "test_name": ["GLU"]})})
->>> local_dictionary = pl.DataFrame({
-...     "test_name": ["GLU", "GLU"],
-...     "label": ["Serum glucose", "Serum glucose"],
-...     "loinc_code": ["2345-7", "2339-0"],
-... })
->>> loinc_ontology = pl.DataFrame({
-...     "test_name": ["GLU"],
-...     "long_name": ["Glucose [Mass/vol] in Serum"],
-...     "loinc_code": ["2345-7"],
-... })
->>> out = link_metadata(
-...     messy, events,
-...     {"local_dictionary.csv": local_dictionary, "loinc_ontology.csv": loinc_ontology},
-... )
+>>> root = yaml_disk('''
+... raw/:
+...   labs.csv:
+...     subject_id: [1, 2, 3]
+...     test_name: [GLU, GLU, GLU]
+...   local_dictionary.csv:
+...     test_name: [GLU, GLU]
+...     label: [Serum glucose, Serum glucose]
+...     loinc_code: [2345-7, 2339-0]
+...   loinc_ontology.csv:
+...     test_name: [GLU]
+...     long_name: [Glucose in Serum or Plasma]
+...     loinc_code: [2345-7]
+... messy.yaml:
+...   labs:
+...     lab:
+...       code: $test_name
+...       time:
+...       _metadata:
+...         local_dictionary:
+...           description: label
+...           loinc: loinc_code
+...         loinc_ontology:
+...           description: long_name
+...           parent_codes: LOINC/{loinc_code}
+... ''', Path(tempfile.mkdtemp()))
+>>> run_extraction(root)
+>>> codes = pl.read_parquet(f"{root}/output/metadata/codes.parquet")
 >>> with pl.Config(fmt_str_lengths=60, tbl_width_chars=120):
-...     print(out)
+...     print(codes)
 shape: (1, 5)
-┌──────┬───────────────┬────────────────────────────────────────────┬──────────────────────┬──────────────────┐
-│ code ┆ code_template ┆ description                                ┆ loinc                ┆ parent_codes     │
-│ ---  ┆ ---           ┆ ---                                        ┆ ---                  ┆ ---              │
-│ str  ┆ str           ┆ str                                        ┆ list[str]            ┆ list[str]        │
-╞══════╪═══════════════╪════════════════════════════════════════════╪══════════════════════╪══════════════════╡
-│ GLU  ┆ $test_name    ┆ Serum glucose; Glucose [Mass/vol] in Serum ┆ ["2339-0", "2345-7"] ┆ ["LOINC/2345-7"] │
-└──────┴───────────────┴────────────────────────────────────────────┴──────────────────────┴──────────────────┘
->>> dict(out.schema)
-{'code': String, 'code_template': String, 'description': String,
- 'loinc': List(String), 'parent_codes': List(String)}
+┌──────┬────────────────────────────┬──────────────────┬───────────────┬──────────────────────┐
+│ code ┆ description                ┆ parent_codes     ┆ code_template ┆ loinc                │
+│ ---  ┆ ---                        ┆ ---              ┆ ---           ┆ ---                  │
+│ str  ┆ str                        ┆ list[str]        ┆ str           ┆ list[str]            │
+╞══════╪════════════════════════════╪══════════════════╪═══════════════╪══════════════════════╡
+│ GLU  ┆ Serum glucose              ┆ ["LOINC/2345-7"] ┆ $test_name    ┆ ["2339-0", "2345-7"] │
+│      ┆ Glucose in Serum or Plasma ┆                  ┆               ┆                      │
+└──────┴────────────────────────────┴──────────────────┴───────────────┴──────────────────────┘
+>>> dict(codes.schema)
+{'code': String, 'description': String, 'parent_codes': List(String),
+ 'code_template': String, 'loinc': List(String)}
 
 ```
+
+The two `loinc` values from the non-unique dictionary rows aggregated into one sorted
+list, both sources' descriptions joined in config order, and the single template landed
+as a plain String.
 
 If a pre-existing `metadata/codes.parquet` is present (e.g. hand-curated metadata for
 literal codes), the reduced output is merged with it: freshly extracted values take

--- a/README.md
+++ b/README.md
@@ -322,9 +322,10 @@ The metadata directory contains a dataset descriptor, code metadata, and subject
 ```
 
 The event config includes `_metadata` blocks that link events to description files.
-Lab descriptions use full matching (the metadata table has the same `test_name` column
-as the code). Medication descriptions use **partial matching** via `_match_on` — the
-code is `f"{$medication_name}//{$dose}"` but the metadata only has `medication_name`:
+Metadata joins the extracted codes on their raw code components: lab descriptions match
+on `test_name` (the code's only component), while medication descriptions use
+`_match_on` to narrow the join — the code is `f"{$medication_name}//{$dose}"` but the
+metadata only has `medication_name`:
 
 ```python
 >>> codes = pl.read_parquet(output / "metadata" / "codes.parquet")
@@ -592,14 +593,23 @@ lab_results:
         description: description  # Output "description" from source "description" column
 ```
 
-The `extract_code_metadata` stage reads the metadata file, reconstructs the code using
-the same expression, and joins it to produce `metadata/codes.parquet`.
+The `extract_code_metadata` stage reads the metadata file and joins it onto the
+extracted codes by their raw code components — here the metadata table's `test_name`
+column matches the `test_name` component each code was built from — to produce
+`metadata/codes.parquet`. Codes and metadata link exactly when a direct join between
+the raw source values and the metadata table's key columns would link them: null
+component values match null metadata keys (so vocabulary rows with a missing key column
+still attach to codes built with `??`-coalesced components), and the metadata table
+never needs to reproduce any transforms the code expression applies — it holds the raw,
+untransformed values. A `_metadata` block requires a code with at least one column
+reference; a literal code has no components to match metadata on.
 
-#### Partial matching with `_match_on`
+#### Narrowing the join with `_match_on`
 
-When the code is composite (e.g., `f"{$medication_name}//{$dose}"`) but your metadata
-table only has one of the components, use `_match_on` to join on that component alone.
-The metadata is broadcast to all codes sharing that component:
+By default the join matches on every source column the code expression references. When
+the code is composite (e.g., `f"{$medication_name}//{$dose}"`) but your metadata table
+only has one of the components, use `_match_on` to join on that component alone. The
+metadata is broadcast to all codes sharing that component:
 
 ```yaml
 medications:
@@ -613,7 +623,7 @@ medications:
 ```
 
 Without `_match_on`, the metadata table would need both `medication_name` and `dose`
-columns to reconstruct the full code. With `_match_on`, only the specified column is
+columns to match the full code. With `_match_on`, only the specified column is
 needed. You can also specify multiple columns: `_match_on: [col_a, col_b]`.
 
 ### Output Columns

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 # ``"diagnoses/dx"``. Note this is finer-grained than a source *table*: two events in
 # one table carry distinct source_blocks. Stamped unconditionally by
 # :meth:`EventConfig.extract`; consumed by ``extract_code_metadata`` to scope
-# partial-match metadata joins to their declaring event (without it, one event's
-# metadata would attach to other events' codes sharing a component value).
+# metadata joins to their declaring event (without it, one event's metadata
+# would attach to other events' codes sharing a component value).
 SOURCE_BLOCK_COL = "source_block"
 
 
@@ -1168,8 +1168,8 @@ class MessyConfig:
         parsed node otherwise. The ``source_block`` value is the
         ``{input_prefix}/{event_name}`` tag that :meth:`EventConfig.extract`
         stamps on every output row — ``extract_code_metadata`` uses it to
-        scope partial-match (``_match_on``) expansions to the event that
-        declared the ``_metadata`` block.
+        scope metadata joins to the event that declared the ``_metadata``
+        block.
 
         Used by ``extract_code_metadata``.
 

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import polars as pl
 from dftly import Parser
+from dftly.nodes.base import NodeBase
 from meds import CodeMetadataSchema
 from MEDS_transforms.mapreduce.rwlock import is_complete_parquet_file, rwlock_wrap
 from MEDS_transforms.parser import cfg_to_expr
@@ -43,19 +44,17 @@ def normalize_join_key(expr: pl.Expr, dtype: pl.DataType) -> pl.Expr:
     Code components keep their raw source dtypes (an ``Int64`` ``itemid``, say), while
     csv-sourced metadata keys are uniformly ``String`` (they are read with
     ``infer_schema=False``). Joining the two directly is a ``SchemaError``, so both sides
-    of the partial-match join are normalized through this single canonical string
-    rendering:
+    of the component join are normalized through this single canonical string rendering:
 
     - String expressions pass through unchanged.
     - Non-float expressions cast directly: ``220045`` renders as ``"220045"``.
     - Float expressions render integer-valued entries via ``Int64`` so that ``220045.0``
       matches the metadata string ``"220045"`` rather than rendering as ``"220045.0"``;
       non-integer values keep their float rendering (``1.5`` renders as ``"1.5"``).
-      Integer-valued floats outside the ``Int64`` range render as null (and thus match
-      nothing).
+      Integer-valued floats outside the ``Int64`` range render as null.
 
-    The output keeps the input expression's root name (nulls stay null and never match
-    under the default ``join_nulls=False``).
+    The output keeps the input expression's root name. Nulls stay null — the component
+    join passes ``nulls_equal=True``, so a null key matches exactly a null component.
 
     Examples:
         >>> df = pl.DataFrame({
@@ -96,14 +95,14 @@ def validate_event_data_schema(data_schema: pl.Schema) -> bool:
 
     ``code_components`` is only attached by ``EventConfig.extract`` when a code expression
     references at least one source column — a dataset whose codes are all literals
-    legitimately has no components (and therefore nothing to partial-match on), so its
+    legitimately has no components (and therefore nothing to join metadata onto), so its
     absence is allowed and reported as ``False``.
 
     When components ARE present, ``source_block`` must be too: ``EventConfig.extract``
     stamps it on every row unconditionally, so its absence means the events were produced
-    by a pre-0.7 extraction pipeline — and without it, partial-match metadata cannot be
-    scoped to the event that declared it (one event's metadata would silently attach to
-    other events' codes sharing a component value).
+    by a pre-0.7 extraction pipeline — and without it, metadata joins cannot be scoped to
+    the event that declared them (one event's metadata would silently attach to other
+    events' codes sharing a component value).
 
     Examples:
         >>> validate_event_data_schema(pl.Schema({"code": pl.String}))
@@ -133,16 +132,135 @@ def validate_event_data_schema(data_schema: pl.Schema) -> bool:
     return True
 
 
-def extract_metadata(
-    metadata_df: pl.LazyFrame,
-    event_cfg: dict[str, str | None],
-    allowed_codes: list | None = None,
-) -> pl.LazyFrame:
-    """Extracts a single metadata dataframe block for an event configuration from the raw metadata.
+def _parse_code(code_value: str | NodeBase) -> tuple[NodeBase, str]:
+    """Return the parsed dftly node and template string for a ``code`` config value.
+
+    ``code`` may be either a raw dftly string (direct-call/doctest path) or a pre-parsed
+    node (when dispatched from ``MessyConfig.events_by_metadata_prefix`` for an event
+    whose raw expression string was not retained).
+    """
+    if isinstance(code_value, NodeBase):
+        return code_value, repr(code_value)
+    code_template_str = str(code_value)
+    return Parser()(code_template_str), code_template_str
+
+
+def resolve_match_columns(event_cfg: dict) -> list[str]:
+    """Derive the code-component columns a ``_metadata`` entry joins on.
+
+    Every metadata join is a component join: the metadata table's join keys are raw
+    metadata columns whose names match source columns referenced by the code expression.
+    By default an entry matches on *all* code-referenced columns (a full match). An
+    optional ``_match_on`` narrows the key set to a subset of those columns, broadcasting
+    the metadata to every code sharing the named component values.
 
     Args:
-        df: The raw metadata DataFrame. Mandatory columns are determined by the `event_cfg` configuration
-            dictionary.
+        event_cfg: A mapping carrying the entry's ``code`` (a raw dftly string or a
+            pre-parsed node) and its ``_metadata`` block. Not mutated.
+
+    Returns:
+        The join-key column names: ``_match_on`` in declared order when given, otherwise
+        all code-referenced columns in sorted order.
+
+    Raises:
+        ValueError: If the code expression is a literal (it references no source columns,
+            so there are no components to match metadata on), or if a match column is also
+            declared as a ``_metadata`` output expression.
+        KeyError: If a ``_match_on`` column is not referenced by the code expression.
+
+    Examples:
+        >>> resolve_match_columns({
+        ...     "code": 'f"LAB//{$itemid}//{$valueuom}"',
+        ...     "_metadata": {"description": "label"},
+        ... })
+        ['itemid', 'valueuom']
+        >>> resolve_match_columns({
+        ...     "code": 'f"LAB//{$itemid}//{$valueuom}"',
+        ...     "_metadata": {"_match_on": "itemid", "description": "label"},
+        ... })
+        ['itemid']
+
+        A literal code has no components to match metadata on:
+
+        >>> resolve_match_columns({"code": "MEDS_BIRTH", "_metadata": {"description": "label"}})
+        Traceback (most recent call last):
+            ...
+        ValueError: The code expression 'MEDS_BIRTH' is a literal: it references no source columns, ...
+
+        ``_match_on`` columns must be referenced by the code expression:
+
+        >>> resolve_match_columns({
+        ...     "code": "$medication_name",
+        ...     "_metadata": {"_match_on": "typo_column", "description": "desc"},
+        ... })
+        Traceback (most recent call last):
+            ...
+        KeyError: "_match_on columns ['typo_column'] are not referenced by the code expression
+        '$medication_name'. Valid columns: ['medication_name']"
+
+        A match column may not also be a ``_metadata`` output expression — join keys are
+        raw metadata columns, never derived ones:
+
+        >>> resolve_match_columns({
+        ...     "code": 'f"CHART//{$itemid}"',
+        ...     "_metadata": {"_match_on": "itemid", "itemid": "itemid_alias", "description": "label"},
+        ... })
+        Traceback (most recent call last):
+            ...
+        ValueError: Match column(s) ['itemid'] may not also be declared as _metadata output ...
+    """
+    code_node, code_template_str = _parse_code(event_cfg["code"])
+    referenced_cols = set(code_node.referenced_columns)
+
+    if not referenced_cols:
+        raise ValueError(
+            f"The code expression {code_template_str!r} is a literal: it references no source "
+            "columns, so a literal code has no components to match metadata on. Add static "
+            "metadata for literal codes to a pre-existing codes.parquet instead of a _metadata "
+            "block."
+        )
+
+    metadata_cfg = event_cfg["_metadata"]
+    match_on = metadata_cfg.get("_match_on")
+    if match_on is None:
+        return sorted(referenced_cols)
+
+    if isinstance(match_on, str):
+        match_on = [match_on]
+    match_on = list(match_on)
+
+    invalid_match_cols = sorted(set(match_on) - referenced_cols)
+    if invalid_match_cols:
+        raise KeyError(
+            f"_match_on columns {invalid_match_cols} are not referenced by the code expression "
+            f"'{code_template_str}'. Valid columns: {sorted(referenced_cols)}"
+        )
+
+    aliased = sorted(set(match_on) & {k for k in metadata_cfg if k != "_match_on"})
+    if aliased:
+        raise ValueError(
+            f"Match column(s) {aliased} may not also be declared as _metadata output "
+            "expressions. Join keys must be raw metadata columns whose names match the "
+            "code components they join against."
+        )
+
+    return match_on
+
+
+def extract_metadata(metadata_df: pl.LazyFrame, event_cfg: dict[str, str | None]) -> pl.LazyFrame:
+    """Extracts a single metadata dataframe block for an event configuration from the raw metadata.
+
+    Every metadata join is a component join, so this function never assembles a ``code``
+    column. It emits the entry's match-key columns verbatim (all code-referenced columns
+    by default, or the ``_match_on`` narrowing — see ``resolve_match_columns``), a
+    ``code_template`` provenance column, and the configured metadata output columns. The
+    reducer joins the keys against the observed ``code_components`` map — scoped to the
+    declaring event, with null keys matching null components — to attach the metadata to
+    full codes.
+
+    Args:
+        metadata_df: The raw metadata DataFrame. Mandatory columns are determined by the `event_cfg`
+            configuration dictionary.
         event_cfg: A dictionary containing the configuration for the event. This must contain the critical
             `"code"` key alongside a mandatory `_metadata` block, which must contain some columns that should
             be extracted from the metadata to link to the code.
@@ -150,83 +268,84 @@ def extract_metadata(
             (e.g., ``'"MY_CODE"'``), column references use ``$`` prefix (e.g., ``$col``),
             and interpolation uses f-strings (e.g., ``f"PREFIX//{$col}"``).
 
-
     Returns:
-        A DataFrame containing the metadata extracted and linked to appropriately constructed code strings for
-        the event configuration. The output DataFrame will contain at least two columns: `"code"` and whatever
-        metadata column is specified for extraction in the metadata block. The output dataframe will not
-        necessarily be unique by code if the input metadata is not unique by code.
+        A DataFrame containing the match-key columns, the ``code_template`` column, and whatever metadata
+        columns are specified for extraction in the metadata block. The output dataframe will not
+        necessarily be unique by key if the input metadata is not unique by key.
 
     Raises:
-        KeyError: If the event configuration dictionary is missing the `"code"` or `"_metadata"` keys or if
-            the `"_metadata_"` key is empty or if columns referenced by the event configuration dictionary are
-            not found in the raw metadata.
+        KeyError: If the event configuration dictionary is missing the `"code"` or `"_metadata"` keys, or if
+            columns referenced by the event configuration dictionary are not found in the raw metadata.
+        ValueError: If the code expression is a literal (nothing to match metadata on), or if a reserved or
+            match-column name is redefined as a metadata output.
+        TypeError: If the event configuration is not a dictionary.
 
     Examples:
         >>> extract_metadata(pl.DataFrame(), {})
         Traceback (most recent call last):
             ...
         KeyError: "Event configuration dictionary must contain 'code' key. Got: []."
-        >>> extract_metadata(pl.DataFrame(), {"code": "test"})
+        >>> extract_metadata(pl.DataFrame(), {"code": "$test"})
         Traceback (most recent call last):
             ...
         KeyError: "Event configuration dictionary must contain a non-empty '_metadata' key. Got: [code]."
+
+        By default an entry matches on every code-referenced column, in sorted order. The
+        output carries the raw key columns (never an assembled ``code``), the template,
+        and the metadata outputs. Rows whose outputs are all null are dropped; rows with
+        null *keys* are retained — the reducer's component join matches them against null
+        components:
+
         >>> raw_metadata = pl.DataFrame({
-        ...     "code": ["A", "B", "C", "D", "E"],
-        ...     "code_modifier": ["1", "2", "3", "4", "5"],
-        ...     "name": ["Code A-1", "B-2", "C with 3", "D, but 4", None],
-        ...     "priority": [1, 2, 3, 4, 5],
+        ...     "itemid": ["A", "B", "C", None],
+        ...     "modifier": ["1", "2", "3", "4"],
+        ...     "name": ["Code A-1", "B-2", None, "Null-key row"],
         ... })
         >>> event_cfg = {
-        ...     "code": 'f"FOO//{$code}//{$code_modifier}"',
+        ...     "code": 'f"FOO//{$itemid}//{$modifier}"',
         ...     "_metadata": {"desc": "name"},
         ... }
         >>> extract_metadata(raw_metadata, event_cfg)
-        shape: (4, 3)
-        ┌───────────┬─────────────────────────────────┬──────────┐
-        │ code      ┆ code_template                   ┆ desc     │
-        │ ---       ┆ ---                             ┆ ---      │
-        │ str       ┆ str                             ┆ str      │
-        ╞═══════════╪═════════════════════════════════╪══════════╡
-        │ FOO//A//1 ┆ f"FOO//{$code}//{$code_modifie… ┆ Code A-1 │
-        │ FOO//B//2 ┆ f"FOO//{$code}//{$code_modifie… ┆ B-2      │
-        │ FOO//C//3 ┆ f"FOO//{$code}//{$code_modifie… ┆ C with 3 │
-        │ FOO//D//4 ┆ f"FOO//{$code}//{$code_modifie… ┆ D, but 4 │
-        └───────────┴─────────────────────────────────┴──────────┘
-        >>> extract_metadata(raw_metadata, event_cfg, allowed_codes=["FOO//A//1", "FOO//C//3"])
-        shape: (2, 3)
-        ┌───────────┬─────────────────────────────────┬──────────┐
-        │ code      ┆ code_template                   ┆ desc     │
-        │ ---       ┆ ---                             ┆ ---      │
-        │ str       ┆ str                             ┆ str      │
-        ╞═══════════╪═════════════════════════════════╪══════════╡
-        │ FOO//A//1 ┆ f"FOO//{$code}//{$code_modifie… ┆ Code A-1 │
-        │ FOO//C//3 ┆ f"FOO//{$code}//{$code_modifie… ┆ C with 3 │
-        └───────────┴─────────────────────────────────┴──────────┘
+        shape: (3, 4)
+        ┌────────┬──────────┬────────────────────────────────┬──────────────┐
+        │ itemid ┆ modifier ┆ code_template                  ┆ desc         │
+        │ ---    ┆ ---      ┆ ---                            ┆ ---          │
+        │ str    ┆ str      ┆ str                            ┆ str          │
+        ╞════════╪══════════╪════════════════════════════════╪══════════════╡
+        │ A      ┆ 1        ┆ f"FOO//{$itemid}//{$modifier}" ┆ Code A-1     │
+        │ B      ┆ 2        ┆ f"FOO//{$itemid}//{$modifier}" ┆ B-2          │
+        │ null   ┆ 4        ┆ f"FOO//{$itemid}//{$modifier}" ┆ Null-key row │
+        └────────┴──────────┴────────────────────────────────┴──────────────┘
 
-        Referencing a metadata column that doesn't exist in the table raises, naming the
-        missing column and the columns that were available:
+        Match columns must exist in the metadata table:
 
-        >>> extract_metadata(raw_metadata.drop("code_modifier"), event_cfg)
+        >>> extract_metadata(raw_metadata.drop("modifier"), event_cfg)
         Traceback (most recent call last):
             ...
-        KeyError: "Columns {'code_modifier'} not found in metadata columns: ['code', 'name', 'priority']"
+        KeyError: "Match column(s) ['modifier'] not found in metadata columns: ['itemid', 'name']"
 
-    A ``_match_on`` column may not also be a ``_metadata`` output expression — join keys
-    are raw metadata columns (key sourcing/renaming belongs to the planned dftly metadata
-    block):
+        ...and referencing a metadata column that doesn't exist in the table raises, naming the
+        missing column and the columns that were available:
+
         >>> extract_metadata(
-        ...     pl.DataFrame({"itemid_alias": ["220045"], "label": ["Heart Rate"]}),
-        ...     {
-        ...         "code": 'f"CHART//{$itemid}"',
-        ...         "_metadata": {"_match_on": "itemid", "itemid": "itemid_alias", "description": "label"},
-        ...     },
+        ...     raw_metadata,
+        ...     {"code": 'f"FOO//{$itemid}//{$modifier}"', "_metadata": {"desc": "nonexistent_col"}},
         ... )
         Traceback (most recent call last):
             ...
-        ValueError: _match_on columns ['itemid'] may not also be declared as _metadata output ...
+        KeyError: "Columns {'nonexistent_col'} not found in metadata columns: ['itemid', 'modifier', 'name']"
 
-    Multi-column ``_match_on`` keys are all carried through, ahead of the metadata outputs:
+        A ``_metadata`` block on a literal code is rejected — there are no components to
+        match metadata on:
+
+        >>> extract_metadata(raw_metadata, {"code": "MEDS_BIRTH", "_metadata": {"desc": "name"}})
+        Traceback (most recent call last):
+            ...
+        ValueError: The code expression 'MEDS_BIRTH' is a literal: it references no source columns, ...
+
+        ``_match_on`` narrows the key set to a subset of the code-referenced columns; the
+        metadata table then only needs the named columns. Multi-column ``_match_on`` keys
+        are all carried through, ahead of the metadata outputs:
 
         >>> raw_metadata = pl.DataFrame({"a": ["X", "Y"], "b": ["1", "2"], "desc": ["X-1", "Y-2"]})
         >>> event_cfg = {
@@ -244,8 +363,23 @@ def extract_metadata(
         │ Y   ┆ 2   ┆ f"{$a}//{$b}//{$c}" ┆ Y-2         │
         └─────┴─────┴─────────────────────┴─────────────┘
 
-    ``_match_on`` validation errors name the offending column. A ``_match_on`` column must be
-    referenced by the code expression:
+        A match column may not also be a ``_metadata`` output expression — join keys are
+        raw metadata columns (key sourcing/renaming belongs to the planned dftly metadata
+        block):
+
+        >>> extract_metadata(
+        ...     pl.DataFrame({"itemid_alias": ["220045"], "label": ["Heart Rate"]}),
+        ...     {
+        ...         "code": 'f"CHART//{$itemid}"',
+        ...         "_metadata": {"_match_on": "itemid", "itemid": "itemid_alias", "description": "label"},
+        ...     },
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: Match column(s) ['itemid'] may not also be declared as _metadata output ...
+
+        ``_match_on`` validation errors name the offending column. A ``_match_on`` column must be
+        referenced by the code expression:
 
         >>> extract_metadata(
         ...     pl.DataFrame({"medication_name": ["X"], "desc": ["Y"]}),
@@ -254,10 +388,10 @@ def extract_metadata(
         ... )
         Traceback (most recent call last):
             ...
-        KeyError: "_match_on columns {'typo_column'} are not referenced by the code expression
-        '$medication_name'. Valid columns: {'medication_name'}"
+        KeyError: "_match_on columns ['typo_column'] are not referenced by the code expression
+        '$medication_name'. Valid columns: ['medication_name']"
 
-    ...must exist in the metadata table:
+        ...must exist in the metadata table:
 
         >>> extract_metadata(
         ...     pl.DataFrame({"dose": ["500mg"], "desc": ["some desc"]}),
@@ -266,9 +400,9 @@ def extract_metadata(
         ... )
         Traceback (most recent call last):
             ...
-        KeyError: "_match_on columns {'medication_name'} not found in metadata columns: ['dose', 'desc']"
+        KeyError: "Match column(s) ['medication_name'] not found in metadata columns: ['dose', 'desc']"
 
-    ...and metadata output columns must exist even in partial-match mode:
+        ...and metadata output columns must exist even under a ``_match_on`` narrowing:
 
         >>> extract_metadata(
         ...     pl.DataFrame({"medication_name": ["X"]}),
@@ -285,7 +419,9 @@ def extract_metadata(
         TypeError: Event configuration must be a dictionary. Got: <class 'list'> ['foo'].
 
     You can also manipulate the columns in more complex ways when assigning metadata from the input source,
-    and mandatory MEDS metadata columns will be cast to the correct types:
+    and mandatory MEDS metadata columns will be cast to the correct types. Note that the ``code`` column
+    below carries the raw source values of the component literally named ``code`` (the idiomatic ICD/OMOP
+    vocabulary shape) — it is a join key, not the assembled MEDS code, which never appears in mapper output:
         >>> raw_metadata = pl.DataFrame({
         ...     "code": ["A", "A", "C", "D"],
         ...     "code_modifier": ["1", "1", "2", "3"],
@@ -307,7 +443,18 @@ def extract_metadata(
         ...         ],
         ...     },
         ... }
-        >>> extract_metadata(raw_metadata, event_cfg)  # doctest: +SKIP
+        >>> extract_metadata(raw_metadata, event_cfg)
+        shape: (4, 5)
+        ┌──────┬───────────────┬─────────────────────────────────┬─────────────┬─────────────────────┐
+        │ code ┆ code_modifier ┆ code_template                   ┆ description ┆ parent_codes        │
+        │ ---  ┆ ---           ┆ ---                             ┆ ---         ┆ ---                 │
+        │ str  ┆ str           ┆ str                             ┆ str         ┆ list[str]           │
+        ╞══════╪═══════════════╪═════════════════════════════════╪═════════════╪═════════════════════╡
+        │ A    ┆ 1             ┆ f"FOO//{$code}//{$code_modifie… ┆ used        ┆ null                │
+        │ A    ┆ 1             ┆ f"FOO//{$code}//{$code_modifie… ┆ A-1-2       ┆ ["OUT_VAL/1/2"]     │
+        │ C    ┆ 2             ┆ f"FOO//{$code}//{$code_modifie… ┆ C-2-3       ┆ ["OUT_VAL_for_3/2"] │
+        │ D    ┆ 3             ┆ f"FOO//{$code}//{$code_modifie… ┆ null        ┆ ["expanded form"]   │
+        └──────┴───────────────┴─────────────────────────────────┴─────────────┴─────────────────────┘
     """
     event_cfg = copy.deepcopy(event_cfg)
 
@@ -324,8 +471,11 @@ def extract_metadata(
             f"Got: [{', '.join(event_cfg.keys())}]."
         )
 
+    match_cols = resolve_match_columns(event_cfg)
+    _, code_template_str = _parse_code(event_cfg["code"])
+
     metadata_cfg = dict(event_cfg["_metadata"])
-    match_on = metadata_cfg.pop("_match_on", None)
+    metadata_cfg.pop("_match_on", None)
 
     # ``code`` and ``code_template`` are pipeline-generated output columns with mandated
     # meanings; a ``_metadata`` block may not redefine them.
@@ -345,85 +495,23 @@ def extract_metadata(
         final_cols.append(out_col)
         needed_cols.update(needed)
 
-    # code may be either a raw dftly string (direct-call/doctest path) or a
-    # pre-parsed NodeBase (when dispatched from `MessyConfig.events_by_metadata_prefix`).
-    from dftly.nodes.base import NodeBase
-
-    code_value = event_cfg.pop("code")
-    if isinstance(code_value, NodeBase):
-        code_node = code_value
-        code_template_str = repr(code_node)
-    else:
-        code_template_str = str(code_value)
-        code_node = Parser()(code_template_str)
-    code_expr = code_node.polars_expr
-    code_referenced_cols = code_node.referenced_columns
-
     columns = metadata_df.collect_schema().names()
 
-    if match_on is not None:
-        # Partial matching: join metadata on specific code component columns rather than the full code.
-        # The metadata table only needs the _match_on columns, not all code columns.
-        if isinstance(match_on, str):
-            match_on = [match_on]
+    missing_match_cols = sorted(set(match_cols) - set(columns))
+    if missing_match_cols:
+        raise KeyError(f"Match column(s) {missing_match_cols} not found in metadata columns: {columns}")
 
-        invalid_match_cols = set(match_on) - code_referenced_cols
-        if invalid_match_cols:
-            raise KeyError(
-                f"_match_on columns {invalid_match_cols} are not referenced by the code expression "
-                f"'{code_template_str}'. Valid columns: {code_referenced_cols}"
-            )
+    missing_metadata_cols = needed_cols - set(columns) - set(final_cols)
+    if missing_metadata_cols:
+        raise KeyError(f"Columns {missing_metadata_cols} not found in metadata columns: {columns}")
 
-        # A _match_on column must be a raw metadata column, never also a _metadata output
-        # expression: key renaming/normalization through shadowing output expressions is
-        # deliberately unsupported (the planned dftly metadata block is the designed home
-        # for sourcing or transforming join keys).
-        aliased = sorted(set(match_on) & set(final_cols))
-        if aliased:
-            raise ValueError(
-                f"_match_on columns {aliased} may not also be declared as _metadata output "
-                "expressions. Join keys must be raw metadata columns whose names match the "
-                "code components they join against."
-            )
+    for col in match_cols:
+        if col not in df_select_exprs:
+            df_select_exprs[col] = pl.col(col)
 
-        missing_match_cols = set(match_on) - set(columns)
-        if missing_match_cols:
-            raise KeyError(f"_match_on columns {missing_match_cols} not found in metadata columns: {columns}")
-
-        missing_metadata_cols = needed_cols - set(columns) - set(final_cols)
-        if missing_metadata_cols:
-            raise KeyError(f"Columns {missing_metadata_cols} not found in metadata columns: {columns}")
-
-        for col in match_on:
-            if col not in df_select_exprs:
-                df_select_exprs[col] = pl.col(col)
-
-        metadata_df = metadata_df.select(**df_select_exprs).with_columns(
-            code_template=pl.lit(code_template_str),
-        )
-
-        if allowed_codes is not None:
-            # For partial matching, we can't filter by exact code — we broadcast metadata to all
-            # matching codes. allowed_codes filtering happens after the join in the reducer.
-            pass
-
-    else:
-        # Full matching: reconstruct the complete code from the metadata table
-        missing_cols = (needed_cols | code_referenced_cols) - set(columns) - set(final_cols)
-        if missing_cols:
-            raise KeyError(f"Columns {missing_cols} not found in metadata columns: {columns}")
-
-        for col in code_referenced_cols:
-            if col not in df_select_exprs:
-                df_select_exprs[col] = pl.col(col)
-
-        metadata_df = metadata_df.select(**df_select_exprs).with_columns(
-            code=code_expr,
-            code_template=pl.lit(code_template_str),
-        )
-
-        if allowed_codes:
-            metadata_df = metadata_df.filter(pl.col("code").is_in(allowed_codes))
+    metadata_df = metadata_df.select(**df_select_exprs).with_columns(
+        code_template=pl.lit(code_template_str),
+    )
 
     metadata_df = metadata_df.filter(~pl.all_horizontal(*[pl.col(c).is_null() for c in final_cols]))
 
@@ -435,62 +523,7 @@ def extract_metadata(
             logger.warning(f"Metadata column '{mandatory_col}' must be of type {mandatory_type}. Casting.")
             metadata_df = metadata_df.with_columns(pl.col(mandatory_col).cast(mandatory_type, strict=False))
 
-    if match_on is not None:
-        return metadata_df.unique(maintain_order=True).select(*match_on, "code_template", *final_cols)
-    else:
-        return metadata_df.unique(maintain_order=True).select("code", "code_template", *final_cols)
-
-
-def extract_all_metadata(
-    metadata_df: pl.LazyFrame, event_cfgs: list[dict], allowed_codes: list | None = None
-) -> pl.LazyFrame:
-    """Extracts all metadata for a list of event configurations.
-
-    Args:
-        metadata_df: The raw metadata DataFrame. Mandatory columns are determined by the `event_cfg`
-            configurations.
-        event_cfgs: A list of event configuration dictionaries. Each dictionary must contain the code
-            and metadata elements.
-        allowed_codes: A list of codes to allow in the output metadata. If None, all codes are allowed.
-
-    Returns:
-        A unified DF containing all metadata for all event configurations.
-
-    Examples:
-        >>> raw_metadata = pl.DataFrame({
-        ...     "code": ["A", "B", "C", "D"],
-        ...     "code_modifier": ["1", "2", "3", "4"],
-        ...     "name": ["Code A-1", "B-2", "C with 3", "D, but 4"],
-        ...     "priority": [1, 2, 3, 4],
-        ... })
-        >>> event_cfg_1 = {
-        ...     "code": 'f"FOO//{$code}//{$code_modifier}"',
-        ...     "_metadata": {"desc": "name"},
-        ... }
-        >>> event_cfg_2 = {
-        ...     "code": 'f"BAR//{$code}//{$code_modifier}"',
-        ...     "_metadata": {"desc2": "name"},
-        ... }
-        >>> event_cfgs = [event_cfg_1, event_cfg_2]
-        >>> extract_all_metadata(
-        ...     raw_metadata, event_cfgs, allowed_codes=["FOO//A//1", "BAR//B//2"]
-        ... )
-        shape: (2, 4)
-        ┌───────────┬─────────────────────────────────┬──────────┬───────┐
-        │ code      ┆ code_template                   ┆ desc     ┆ desc2 │
-        │ ---       ┆ ---                             ┆ ---      ┆ ---   │
-        │ str       ┆ str                             ┆ str      ┆ str   │
-        ╞═══════════╪═════════════════════════════════╪══════════╪═══════╡
-        │ FOO//A//1 ┆ f"FOO//{$code}//{$code_modifie… ┆ Code A-1 ┆ null  │
-        │ BAR//B//2 ┆ f"BAR//{$code}//{$code_modifie… ┆ null     ┆ B-2   │
-        └───────────┴─────────────────────────────────┴──────────┴───────┘
-    """
-
-    all_metadata = []
-    for event_cfg in event_cfgs:
-        all_metadata.append(extract_metadata(metadata_df, event_cfg, allowed_codes=allowed_codes))
-
-    return pl.concat(all_metadata, how="diagonal_relaxed").unique(maintain_order=True)
+    return metadata_df.unique(maintain_order=True).select(*match_cols, "code_template", *final_cols)
 
 
 def atomic_write_parquet(df: pl.LazyFrame | pl.DataFrame, out_fp: Path) -> None:
@@ -563,6 +596,12 @@ def main(cfg: DictConfig):
     parsing DSL that is specified in the `event_conversion_config_fp` file. See `parser.py` for more details
     on this DSL.
 
+    Metadata is attached to codes through one join path: each ``_metadata`` entry's match
+    columns (all code-referenced columns by default, or the ``_match_on`` narrowing) are
+    joined against the observed ``code_components`` map, scoped to the declaring event
+    block, with null keys matching null components. Because that map is built from the
+    observed data, the join inherently restricts the output to observed codes.
+
     Note that there are two sentinel columns in the output metadata that have certain mandates for MEDS
     compliance: The `description` column and the `parent_codes` column. The `description` column must be a
     string, and if there are multiple matches in the extracted metadata for a code, in this script they will
@@ -606,16 +645,15 @@ def main(cfg: DictConfig):
     event_metadata_configs = list(events_and_metadata_by_metadata_fp.items())
     random.shuffle(event_metadata_configs)
 
-    # Load all codes and code_components from extracted data, handling heterogeneous schemas
-    # (some event files have code_components and others don't).
+    # Load the extracted event data, handling heterogeneous schemas (files whose codes
+    # reference source columns carry code_components; all-literal files don't).
     event_parquet_files = list(Path(stage_input_dir).rglob("*.parquet"))
     all_event_dfs = [pl.scan_parquet(fp, glob=False) for fp in event_parquet_files]
     all_data = pl.concat(all_event_dfs, how="diagonal_relaxed")
-    all_codes = all_data.select(pl.col("code").unique()).collect().get_column("code").to_list()
 
-    # Build the code_components mapping for partial metadata joins: full code (under the
+    # Build the code_components map every metadata join runs against: full code (under the
     # reserved collision-proof alias), unnested component columns, and the declaring
-    # source_block so each expansion joins only against its own event's codes.
+    # source_block so each join attaches only to its own event's codes.
     if validate_event_data_schema(all_data.collect_schema()):
         code_component_map = (
             all_data.select(pl.col("code").alias(FULL_CODE_COL), "code_components", SOURCE_BLOCK_COL)
@@ -632,11 +670,11 @@ def main(cfg: DictConfig):
     # Record the canonical (metadata_prefix, cfg_idx) key for every output file so the
     # reducer can sort frames back into config order before concatenating.
     out_fp_keys: dict[Path, tuple[str, int]] = {}
-    # Explicit bookkeeping for partial-match outputs: out_fp -> (match_cols, source_block).
-    # The reducer is driven by this record rather than by sniffing output schemas — a partial
-    # output whose _match_on includes a column named "code" would otherwise be misclassified
-    # as full-match and land raw source codes in codes.parquet.
-    partial_info: dict[Path, tuple[list[str], str]] = {}
+    # Explicit join bookkeeping: out_fp -> (match_cols, source_block). The reducer is
+    # driven by this record rather than by sniffing output schemas — a match column named
+    # "code" (the idiomatic ICD/OMOP vocabulary shape) carries raw component values that
+    # schema sniffing could mistake for assembled output codes.
+    join_info: dict[Path, tuple[list[str], str]] = {}
     for input_prefix, event_metadata_cfgs in event_metadata_configs:
         event_metadata_cfgs = copy.deepcopy(event_metadata_cfgs)
 
@@ -648,9 +686,9 @@ def main(cfg: DictConfig):
         def read_fn(fps):
             return scan_source(fps, infer_schema=False)
 
-        # Write one output file per individual event config so each is unambiguously
-        # full-match or partial-match. A single metadata prefix can be referenced by
-        # multiple event configs with different match modes.
+        # Write one output file per individual event config: entries sharing a metadata
+        # prefix can join on different match columns and are scoped to different declaring
+        # events.
         for cfg_idx, event_cfg in enumerate(event_metadata_cfgs):
             out_fp = partial_metadata_dir / f"{input_prefix}_{cfg_idx}.parquet"
             logger.info(f"Extracting metadata from {metadata_fps} and saving to {out_fp}")
@@ -659,30 +697,22 @@ def main(cfg: DictConfig):
             # SOURCE_BLOCK_COL in config.py); a KeyError here means that contract broke.
             source_block = event_cfg.pop(SOURCE_BLOCK_COL)
 
-            compute_fn = partial(
-                extract_all_metadata,
-                event_cfgs=[event_cfg],
-                allowed_codes=all_codes,
-            )
+            # Derive and validate the join keys up front so configuration errors (a
+            # literal code with a _metadata block, a bad _match_on) surface in every
+            # worker even when the output shard already exists and the compute is skipped.
+            match_cols = resolve_match_columns(event_cfg)
 
             rwlock_wrap(
                 metadata_fps,
                 out_fp,
                 read_fn,
                 atomic_write_parquet,
-                compute_fn,
+                partial(extract_metadata, event_cfg=event_cfg),
                 do_overwrite=cfg.do_overwrite,
             )
             all_out_fps.append(out_fp)
             out_fp_keys[out_fp] = (input_prefix, cfg_idx)
-
-            # Record _match_on columns and the declaring event's source_block for this shard
-            # so the reducer can classify and scope it explicitly.
-            match_on = event_cfg.get("_metadata", {}).get("_match_on")
-            if match_on is not None:
-                if isinstance(match_on, str):
-                    match_on = [match_on]
-                partial_info[out_fp] = (list(match_on), source_block)
+            join_info[out_fp] = (match_cols, source_block)
 
     logger.info("Extracted metadata for all events. Merging.")
 
@@ -697,47 +727,40 @@ def main(cfg: DictConfig):
     start = datetime.now(tz=UTC)
     logger.info("All map shards complete! Starting code metadata reduction computation.")
 
-    # Separate partial-match outputs from full-match outputs. Classification is driven by the
-    # explicit partial_info record from map time, never by output schemas — a partial output
-    # whose _match_on includes "code" carries a "code" column of raw component values and
-    # would be silently misclassified as full-match by schema sniffing.
+    # Expand every metadata file to full codes through one component join, scoped to the
+    # declaring event and keyed on the recorded match columns.
     #
-    # Frames are concatenated in canonical (metadata_prefix, cfg_idx) order so the
-    # reduction (concat order, and with it description join order and list-aggregation
-    # order) is identical across runs. This sort happens ONLY here, in worker 0's
-    # reduction over already-written partial files — the mappers' per-worker
-    # random.shuffle above is untouched, so map-phase lock contention and runtime
-    # spreading are unaffected.
-    full_match_dfs = []
-    partial_match_dfs = []
-    for fp in sorted(all_out_fps, key=out_fp_keys.__getitem__):
-        df = pl.scan_parquet(fp, glob=False)
-        if fp in partial_info:
-            match_cols, source_block = partial_info[fp]
-            partial_match_dfs.append((fp, df, match_cols, source_block))
-        else:
-            full_match_dfs.append(df)
-
-    # Expand partial-match metadata to full codes via code_components
-    if partial_match_dfs and code_component_map is not None:
+    # Frames are processed in canonical (metadata_prefix, cfg_idx) order so the reduction
+    # (concat order, and with it description join order and list-aggregation order) is
+    # identical across runs. This sort happens ONLY here, in worker 0's reduction over
+    # already-written partial files — the mappers' per-worker random.shuffle above is
+    # untouched, so map-phase lock contention and runtime spreading are unaffected.
+    expanded_dfs = []
+    if code_component_map is None:
+        logger.warning(
+            "Extracted metadata found but the event data carries no code_components; "
+            "there is nothing to join metadata onto. Writing an empty metadata table."
+        )
+    else:
         component_schema = code_component_map.schema
-        for fp, pdf, match_cols, source_block in partial_match_dfs:
+        for fp in sorted(all_out_fps, key=out_fp_keys.__getitem__):
+            pdf = pl.scan_parquet(fp, glob=False)
+            match_cols, source_block = join_info[fp]
             pdf_schema = pdf.collect_schema()
-            metadata_cols_partial = [c for c in pdf_schema.names() if c not in match_cols]
+            metadata_cols = [c for c in pdf_schema.names() if c not in match_cols]
 
             missing = [c for c in match_cols if c not in component_schema]
             if missing:
                 logger.warning(
-                    f"Partial-match metadata from {fp} (source block {source_block!r}) requires "
-                    f"component columns {missing} that are absent from the extracted data. Skipping."
+                    f"Metadata from {fp} (source block {source_block!r}) requires component "
+                    f"columns {missing} that are absent from the extracted data. Skipping."
                 )
                 continue
 
-            components = code_component_map.lazy()
-            # Scope the expansion to the event config that declared this _metadata block —
-            # other events may reference same-named component columns with colliding values,
-            # and must not receive this metadata.
-            components = components.filter(pl.col(SOURCE_BLOCK_COL) == source_block)
+            # Scope the join to the event config that declared this _metadata block —
+            # other events may reference same-named component columns with colliding
+            # values, and must not receive this metadata.
+            components = code_component_map.lazy().filter(pl.col(SOURCE_BLOCK_COL) == source_block)
 
             # Restrict the left side to exactly the full code and the join keys: any other
             # component column sharing a name with a metadata output column would otherwise
@@ -750,25 +773,28 @@ def main(cfg: DictConfig):
             ).unique()
             pdf = pdf.with_columns(normalize_join_key(pl.col(c), pdf_schema[c]) for c in match_cols)
 
+            # ``nulls_equal=True`` is a deliberate semantic choice: a null join key on the
+            # metadata side matches exactly the data rows whose (``??``-coalesced)
+            # component is null — e.g. a vocabulary row keyed on a null unit attaches to
+            # the code that a ``{$valueuom ?? 'UNK'}`` component rendered for unit-less
+            # data rows.
             expanded = (
-                components.join(pdf, on=match_cols, how="inner")
-                .select(pl.col(FULL_CODE_COL).alias("code"), *metadata_cols_partial)
+                components.join(pdf, on=match_cols, how="inner", nulls_equal=True)
+                .select(pl.col(FULL_CODE_COL).alias("code"), *metadata_cols)
                 .collect()
             )
             if expanded.is_empty():
                 logger.warning(
-                    f"Partial-match metadata from {fp} (source block {source_block!r}, "
+                    f"Metadata from {fp} (source block {source_block!r}, "
                     f"match columns {match_cols}) matched zero codes."
                 )
-            full_match_dfs.append(expanded.lazy())
-    elif partial_match_dfs:
-        logger.warning("Partial-match metadata found but no code_components in data. Skipping.")
+            expanded_dfs.append(expanded.lazy())
 
-    if not full_match_dfs:
+    if not expanded_dfs:
         logger.info("No metadata to reduce. Writing empty metadata file.")
         reduced = pl.DataFrame({"code": []}).cast({"code": pl.String}).lazy()
     else:
-        reduced = pl.concat(full_match_dfs, how="diagonal_relaxed").unique(maintain_order=True)
+        reduced = pl.concat(expanded_dfs, how="diagonal_relaxed").unique(maintain_order=True)
 
     join_cols = ["code", *cfg.get("code_modifier_cols", [])]
     reduced_cols = reduced.collect_schema().names()

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -222,7 +222,21 @@ diagnoses_icd:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"diagnoses_icd": pl.DataFrame({"code": ["ICD9//25000", "ICD10//E119"]})},
+            event_frames={
+                "diagnoses_icd": pl.DataFrame(
+                    {
+                        "code": ["ICD9//25000", "ICD10//E119"],
+                        # String components (as CSV-sourced events carry) against the
+                        # typed Int64 parquet metadata below — the join's canonical
+                        # String normalization must bridge the two.
+                        "code_components": [
+                            {"icd_code": "25000", "icd_version": "9"},
+                            {"icd_code": "E119", "icd_version": "10"},
+                        ],
+                        "source_block": ["diagnoses_icd/diagnosis"] * 2,
+                    }
+                )
+            },
             raw_files={
                 "d_icd_diagnoses.parquet": pl.DataFrame(
                     {

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -1,14 +1,17 @@
 """Stage-level tests for ``extract_code_metadata`` — end-to-end runs of the real stage.
 
-Single-function behavior (code construction, ``_match_on`` validation, null-component
-rendering) is doctested on the helpers themselves (``extract_metadata``,
-``EventConfig.extract``). This file covers behavior that needs the full mapper/reducer
-machinery: joining extracted metadata onto codes, partial-match (``_match_on``)
-expansion and its per-event scoping, reducer determinism and the canonical output
-schema, merging with a pre-existing ``codes.parquet``, and reducer/worker concurrency.
+Single-function behavior (code construction, match-column derivation, ``_match_on``
+validation) is doctested on the helpers themselves (``extract_metadata``,
+``resolve_match_columns``, ``EventConfig.extract``). This file covers behavior that
+needs the full mapper/reducer machinery: the component join that attaches extracted
+metadata onto codes (including null-key matching and ``_match_on`` narrowing), its
+per-event scoping, reducer determinism and the canonical output schema, merging with a
+pre-existing ``codes.parquet``, and reducer/worker concurrency.
 
 Most tests run through :func:`_run_ecm_scenario`, which lays out synthetic event shards
-and raw metadata files and invokes the stage's ``main_fn`` as worker 0.
+and raw metadata files and invokes the stage's ``main_fn`` as worker 0. Event frames
+carry the ``code_components`` struct and ``source_block`` tag exactly as
+``convert_to_MEDS_events`` emits them — the component join runs against those columns.
 """
 
 from __future__ import annotations
@@ -122,7 +125,23 @@ def _run_ecm_scenario(
     return pl.read_parquet(codes_fp) if codes_fp.exists() else None
 
 
-# ── Full-match basics: joining metadata onto extracted codes ──
+def _bare_code_events(code_col: str, codes: list[str], source_block: str) -> pl.DataFrame:
+    """Event frame as ``convert_to_MEDS_events`` emits for a bare-column code (``$<code_col>``).
+
+    The code string equals the single component value, the ``code_components`` struct
+    carries that value under the source column's name, and every row is stamped with the
+    declaring ``source_block``.
+    """
+    return pl.DataFrame(
+        {
+            "code": codes,
+            "code_components": [{code_col: c} for c in codes],
+            "source_block": [source_block] * len(codes),
+        }
+    )
+
+
+# ── Metadata joining basics: attaching metadata onto extracted codes ──
 
 
 def test_extract_code_metadata_with_existing_codes():
@@ -139,7 +158,7 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR", "TEMP"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR", "TEMP"], "data/measurement")},
             raw_files={
                 "lab_meta.csv": "lab_code,title,loinc\nHR,Heart Rate,8867-4\nTEMP,Temperature,8310-5\n"
             },
@@ -168,7 +187,7 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR", "TEMP"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR", "TEMP"], "data/measurement")},
             # Two CSV files in a sub-sharded `lab_meta/` directory — triggers multi-file concat.
             raw_files={
                 "lab_meta/part1.csv": "lab_code,title\nHR,Heart Rate\n",
@@ -201,7 +220,7 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={
                 "source_a.csv": "lab_code,title_a\nHR,Heart Rate\n",
                 "source_b.csv": "lab_code,title_b\nHR,Pulse Rate\n",
@@ -234,7 +253,7 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={
                 "source_a.csv": "lab_code,val_a\nHR,value_1\n",
                 "source_b.csv": "lab_code,val_b\nHR,value_2\n",
@@ -267,7 +286,7 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={
                 "source_a.csv": "lab_code,title_a\nHR,Heart Rate\n",
                 "source_b.csv": "lab_code,title_b\nHR,Pulse Rate\n",
@@ -284,7 +303,7 @@ def test_extract_code_metadata_handles_code_named_source_column():
     """Codes built from a source column literally named ``code`` flow through the full stage.
 
     The idiomatic ICD/OMOP vocabulary-table shape — ``code: f"ICD//{$code}"`` — must flow
-    through the ``code_components`` map build, full-match extraction, and reduction without
+    through the ``code_components`` map build, metadata extraction, and reduction without
     colliding with the output ``code`` column (regression for
     https://github.com/mmcdermott/MEDS_extract/issues/110). Before the fix this raised
     ``DuplicateError`` at the ``code_components`` unnest (this test carried a strict xfail
@@ -346,17 +365,17 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={},
         )
     assert codes_df is None
 
 
-def test_partial_match_without_code_components_in_events():
-    """Partial-match metadata with no code_components in the event data yields an empty output.
+def test_metadata_without_code_components_in_events():
+    """Metadata with no code_components in the event data yields an empty output.
 
-    Covers the warning path: the stage completes without error, but partial-match rows
-    cannot be expanded without component provenance.
+    Covers the warning path: the stage completes without error, but metadata cannot be
+    joined onto codes without component provenance in the extracted data.
     """
     messy = """\
 data:
@@ -364,15 +383,14 @@ data:
     code: $lab_code
     _metadata:
       lab_meta:
-        _match_on: lab_code
         description: title
 """
     with tempfile.TemporaryDirectory() as d:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            # Event file WITHOUT code_components (literal code via $col).
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            # Event file WITHOUT code_components (pre-component extraction shape).
+            event_frames={"data": pl.DataFrame({"code": ["HR"], "source_block": ["data/measurement"]})},
             raw_files={"lab_meta.csv": "lab_code,title\nHR,Heart Rate\n"},
         )
     assert len(codes_df) == 0
@@ -392,13 +410,13 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={"lab_meta.csv": "lab_code,title\nNONEXISTENT,No Match\n"},
         )
     assert len(codes_df) == 0
 
 
-# ── Mixed-schema and mixed-mode mapper/reducer regressions ──
+# ── Mixed-schema and multi-config mapper/reducer regressions ──
 
 
 def test_mixed_schema_parquet_scan_with_and_without_code_components():
@@ -447,7 +465,7 @@ admissions:
 
 
 def test_partial_match_join_key_not_inferred_from_schema_intersection():
-    """Regression guard: partial-match join keys must use explicit _match_on, not schema intersection.
+    """Regression guard: narrowed join keys come from explicit _match_on, not schema intersection.
 
     If a metadata output column shares a name with a code component column, it must not be treated
     as a join key. Only the explicit _match_on columns should be used. Previously the reducer
@@ -489,7 +507,7 @@ data:
 
     # The "item" column should be present in the output — it's a metadata output column.
     assert "item" in codes_df.columns, (
-        f"Expected 'item' column in output (metadata output from partial match), "
+        f"Expected 'item' column in output (metadata output under _match_on narrowing), "
         f"but columns are: {codes_df.columns}.\nFull output:\n{codes_df}"
     )
     codes_with_item = codes_df.filter(pl.col("item").is_not_null())
@@ -504,16 +522,16 @@ data:
 
 
 def test_mixed_full_and_partial_match_from_same_metadata_prefix():
-    """Regression guard: mixed full-match and partial-match configs sharing a metadata prefix.
+    """Regression guard: configs with different match-column sets sharing a metadata prefix.
 
-    A single metadata file prefix can be referenced by multiple event configs with different
-    match modes. Each must be written to a separate intermediate shard so the reducer can
-    classify and expand them independently. Previously all configs for one prefix were
-    concatenated into one shard, and the reducer treated the whole shard as full-match
-    (because "code" was in the schema), silently dropping partial-match rows.
+    A single metadata file prefix can be referenced by multiple event configs whose joins
+    use different match columns and are scoped to different declaring events. Each must be
+    written to a separate intermediate shard so the reducer can expand them independently
+    (historically, all configs for one prefix were concatenated into one shard and rows
+    from all but one config were silently dropped).
 
     This test uses "shared_meta" referenced by a full-match config (code: $lab_code) and a
-    partial-match config (code: f"{$category}//{$item}", _match_on: category).
+    narrowed config (code: f"{$category}//{$item}", _match_on: category).
     """
     messy = """\
 labs:
@@ -535,9 +553,9 @@ products:
             Path(d),
             messy,
             event_frames={
-                # Lab events (full match — code is a simple column ref, no code_components).
-                "labs": pl.DataFrame({"code": ["HR"], "source_block": ["labs/measurement"]}),
-                # Product events (partial match — dynamic code with code_components).
+                # Lab events: full match on the single referenced column.
+                "labs": _bare_code_events("lab_code", ["HR"], "labs/measurement"),
+                # Product events: _match_on narrows a composite code to one component.
                 "products": pl.DataFrame(
                     {
                         "code": ["Drug//Aspirin", "Drug//Ibuprofen"],
@@ -549,8 +567,8 @@ products:
                     }
                 ),
             },
-            # Shared metadata file: "HR" matches full-match via lab_code; "Drug" matches
-            # partial-match via category.
+            # Shared metadata file: "HR" matches on lab_code (all components); "Drug"
+            # matches on category (_match_on narrowing).
             raw_files={"shared_meta.csv": "lab_code,category,desc\nHR,Drug,Shared description\n"},
         )
 
@@ -568,17 +586,17 @@ products:
     )
 
 
-# ── Partial-match correctness regressions ──
+# ── Component-join correctness regressions ──
 
 
 def test_partial_match_on_column_named_code_is_expanded_not_passed_through():
-    """Regression guard: a partial output keyed on a column named ``code`` stays partial-match.
+    """Regression guard: a metadata shard keyed on a column named ``code`` is still expanded.
 
     ``_match_on: code`` makes the intermediate shard carry a ``code`` column of raw component
-    values (e.g. ``250.00``). The reducer used to classify shards by sniffing for a ``code``
-    column in the schema, misclassifying this shard as full-match and passing the raw
-    component values through as output codes — silently wrong codes.parquet. Classification
-    must come from explicit map-time bookkeeping instead.
+    values (e.g. ``250.00``). The reducer historically classified shards by sniffing for a
+    ``code`` column in the schema and passed such raw component values straight through as
+    output codes — silently wrong codes.parquet. The join must be driven by explicit
+    map-time bookkeeping instead.
     """
     messy = """\
 diagnoses:
@@ -610,7 +628,7 @@ diagnoses:
         assert by_code.get("ICD//250.00") == "Diabetes mellitus"
         assert by_code.get("ICD//401.9") == "Hypertension"
         # ...and the raw component values are NOT passed through as codes (the old
-        # full-match misclassification symptom).
+        # schema-sniffing misclassification symptom).
         assert "250.00" not in by_code
         assert "401.9" not in by_code
 
@@ -747,8 +765,117 @@ chartevents:
         assert by_code.get("CHART//1.5") == "Half Item"
 
 
+def test_null_component_matches_null_metadata_key():
+    """A null metadata join key matches the code a coalesced null component produced.
+
+    The labevents code coalesces a null ``valueuom`` to ``UNK``, so the data row with no
+    unit emits ``LAB//51463//UNK`` while its ``valueuom`` component stays null. The
+    vocabulary row for itemid 51463 also has no unit (a null key). The component join
+    treats null keys as equal to null components, so the label lands on the ``UNK`` code;
+    the real-unit row keeps matching its real-unit metadata.
+    """
+    messy = """\
+labevents:
+  lab:
+    code: |-
+      f"LAB//{$itemid}//{$valueuom ?? 'UNK'}"
+    _metadata:
+      d_labitems:
+        description: label
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "labevents": pl.DataFrame(
+                    {
+                        "code": ["LAB//51463//UNK", "LAB//50912//mg/dL"],
+                        "code_components": [
+                            {"itemid": "51463", "valueuom": None},
+                            {"itemid": "50912", "valueuom": "mg/dL"},
+                        ],
+                        "source_block": ["labevents/lab", "labevents/lab"],
+                    }
+                )
+            },
+            # The 51463 row's empty valueuom field reads as null under infer_schema=False.
+            raw_files={"d_labitems.csv": "itemid,valueuom,label\n51463,,Chloride\n50912,mg/dL,Creatinine\n"},
+        )
+
+    by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+    assert by_code.get("LAB//51463//UNK") == "Chloride"
+    assert by_code.get("LAB//50912//mg/dL") == "Creatinine"
+
+
+def test_transformed_code_matches_raw_component_values():
+    """A code transforming a component still matches metadata holding the RAW value.
+
+    The code truncates ``icd_code`` to its first three characters, so the emitted code is
+    ``DX//250`` while the component retains the raw ``250.00``. Matching happens in raw
+    component space, so a vocabulary table keyed on the untransformed ``250.00`` links —
+    the metadata table is never re-rendered through the code expression, and the transform
+    cannot be applied twice.
+    """
+    messy = """\
+diagnoses:
+  dx:
+    code: 'f"DX//{$icd_code[0:3]}"'
+    _metadata:
+      icd_meta:
+        description: long_title
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "diagnoses": pl.DataFrame(
+                    {
+                        "code": ["DX//250"],
+                        "code_components": [{"icd_code": "250.00"}],
+                        "source_block": ["diagnoses/dx"],
+                    }
+                )
+            },
+            raw_files={"icd_meta.csv": "icd_code,long_title\n250.00,Diabetes mellitus\n"},
+        )
+
+    by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+    assert by_code.get("DX//250") == "Diabetes mellitus"
+
+
+def test_literal_code_with_metadata_block_errors():
+    """A ``_metadata`` block on a literal code raises a clear config error.
+
+    A literal code references no source columns, so there are no components to match metadata on; the stage
+    rejects the config at map time rather than degenerately matching.
+    """
+    messy = """\
+admissions:
+  admit:
+    code: ADMISSION
+    time: null
+    _metadata:
+      adm_meta:
+        description: title
+"""
+    with (
+        tempfile.TemporaryDirectory() as d,
+        pytest.raises(ValueError, match="literal code has no components to match metadata on"),
+    ):
+        _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "admissions": pl.DataFrame({"code": ["ADMISSION"], "source_block": ["admissions/admit"]})
+            },
+            raw_files={"adm_meta.csv": "x,title\n1,t\n"},
+        )
+
+
 def test_partial_match_zero_matches_warns(caplog):
-    """A partial-match join that matches zero codes emits a WARNING (minimal diagnostic).
+    """A metadata join that matches zero codes emits a WARNING (minimal diagnostic).
 
     Full match-coverage diagnostics are a tracked follow-up; this only guards the silent-miss case the dtype
     normalization could otherwise introduce.
@@ -798,7 +925,7 @@ data:
         vocab: vocab_b
 """
 
-_TWO_SOURCE_EVENTS = {"data": pl.DataFrame({"code": ["HR", "TEMP"]})}
+_TWO_SOURCE_EVENTS = {"data": _bare_code_events("lab_code", ["HR", "TEMP"], "data/measurement")}
 
 _TWO_SOURCE_RAW = {
     "source_a.csv": "lab_code,title_a,vocab_a\nHR,Heart Rate,LOINC\nTEMP,Temperature,LOINC\n",
@@ -862,7 +989,7 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={"lab_meta.csv": "lab_code,title,vocab\nHR,Heart Rate,LOINC\n"},
         )
 
@@ -908,7 +1035,7 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR", "NEW"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR", "NEW"], "data/measurement")},
             raw_files={"lab_meta.csv": "lab_code,title\nHR,Fresh heart rate\nNEW,A new code\n"},
             existing_codes=pl.DataFrame(
                 {
@@ -946,7 +1073,7 @@ data:
         _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={"lab_meta.csv": "lab_code,title,vocab\nHR,Heart Rate,LOINC\n"},
             # Pre-existing `vocab` is String; the extracted canonical form is List(String).
             existing_codes=pl.DataFrame({"code": ["HR"], "vocab": ["OLD"]}),
@@ -976,7 +1103,7 @@ data:
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={
                 "dup_a.csv": "lab_code,title_a,vocab_a\nHR,Heart Rate,LOINC\n",
                 "dup_b.csv": "lab_code,title_b,vocab_b\nHR,Heart Rate,LOINC\n",
@@ -1017,8 +1144,8 @@ b_tbl:
             Path(d),
             messy,
             event_frames={
-                "a_tbl": pl.DataFrame({"code": ["HR"]}),
-                "b_tbl": pl.DataFrame({"code": ["HR"]}),
+                "a_tbl": _bare_code_events("lab_code", ["HR"], "a_tbl/m"),
+                "b_tbl": _bare_code_events("med_code", ["HR"], "b_tbl/m"),
             },
             raw_files={
                 "src_a.csv": "lab_code,title_a\nHR,From A\n",
@@ -1050,7 +1177,7 @@ data:
         _run_ecm_scenario(
             Path(d),
             messy,
-            event_frames={"data": pl.DataFrame({"code": ["HR"]})},
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={
                 "mixed_meta/[0-1).csv": "lab_code,title\nHR,Heart Rate\n",
                 "mixed_meta/[1-2).parquet": pl.DataFrame({"lab_code": ["TEMP"], "title": ["Body Temp"]}),


### PR DESCRIPTION
Closes #144

## Design

The full-match / partial-match split in `extract_code_metadata` is gone: **every `_metadata` join is a component join** against the observed `code_components` map, and a full match is just the special case of matching on all code-referenced columns. This implements the policy decided in #144:

> If you were to do a direct, real join between this input data and this metadata table on the raw values, you'd get this metadata — and that's what the stage grabs for you. If the raw representations don't actually agree in the source data, you cast them (via dftly expressions) or need fuzzy matching, which is (for now) out of scope.

Concretely (options A + C + D of #144):

- **Mapper** (`extract_metadata`): the metadata-side code-expression re-evaluation is deleted. Each entry emits its match columns — all code-referenced columns by default, or the `_match_on` narrowing (still validated as a subset of the referenced columns, still barred from doubling as a `_metadata` output name) — plus `code_template` and the configured metadata outputs. No `code` column is ever produced by the mapper. Match-column derivation/validation lives in the new `resolve_match_columns` helper, shared by mapper and reducer bookkeeping so the two can't drift.
- **Reducer**: one join path for every partial file — scope the component map to the declaring `source_block`, `normalize_join_key` both sides, inner-join with `nulls_equal=True`, and alias the full code back out. The `partial_info` classification bookkeeping is replaced by uniform `join_info` recorded at map time (never schema sniffing, preserving the `_match_on: code` regression guarantees).
- **`allowed_codes` deleted wholesale**, including the per-worker all-codes collect (a known inefficiency) and the now-degenerate `extract_all_metadata` wrapper (it only ever received a single config since per-config output shards): the component map is built from observed data, so joining against it inherently restricts output to observed codes.
- **Unchanged**: the reduction semantics (canonical order, dedupe, scalar `code_template` + conflict error, coalescing merge with a pre-existing `codes.parquet`, reserved names), the `parent_codes` machinery (verified independent of the deleted rendering — it is `cfg_to_expr` over metadata rows; its doctest is now executed rather than skipped), and the mixed-format prefix error.

Option B1 (raw/uncast component values) rides #143 separately; the config-surface redesign of the `_metadata` block is #146.

## Behavior changes

1. **Matching moves from rendered-string space to raw component space.** A code with a string transform over a component (e.g. `f"DX//{$icd_code[0:3]}"`) now matches a vocabulary table holding the RAW value, and the old double-transform quirk (metadata tables holding already-transformed values being transformed again) is gone. Test: `test_transformed_code_matches_raw_component_values`.
2. **Null keys match null components** (`nulls_equal=True`, the #136 residual): a metadata row keyed on a null column attaches to the code a `?? 'UNK'`-coalesced component produced for null-valued data rows. Test: `test_null_component_matches_null_metadata_key` (the MIMIC `LAB//{$itemid}//{$valueuom ?? 'UNK'}` shape). Mapper-side, all-null-key rows are no longer dropped (only all-null-*output* rows are).
3. **`_metadata` on a literal code errors** with "a literal code has no components to match metadata on" (previously it degenerately full-matched). Test: `test_literal_code_with_metadata_block_errors` + doctests on `resolve_match_columns` / `extract_metadata`.
4. **Error-surface wording**: missing join-key columns now read `Match column(s) [...] not found in metadata columns: [...]` (formerly the full-match path reported them as generic missing metadata columns, and the `_match_on` path as `_match_on columns {...} not found`); the key/output-name collision error reads `Match column(s) [...] may not also be declared as _metadata output expressions`. Doctests updated accordingly.

`_match_on` subset narrowing and its per-event scoping are unchanged and still covered (`test_partial_match_scoped_to_declaring_event`, `test_partial_match_join_key_not_inferred_from_schema_intersection`, `test_mixed_full_and_partial_match_from_same_metadata_prefix`).

## polars null-join parameter

polars is pinned `>=1.26`; verified empirically that the parameter is named `nulls_equal` (renamed from `join_nulls`) at exactly 1.26.0 as well as at the currently-resolved 1.39.3, and that it behaves as needed (`null` joins `null`, non-null keys unaffected). **Null-join handling needed nothing beyond this one join argument** — key normalization already passes nulls through unchanged.

## Test plan

- Full suite green: `uv run pytest -q` → **104 passed, 1 deselected** (includes `--doctest-modules` and README doctests); `uv run pre-commit run --all-files` stable.
- `extract_metadata` doctests rewritten for the new output shape (match cols + `code_template` + outputs; no `code`), plus new `resolve_match_columns` doctests and a now-executed `parent_codes` doctest.
- Existing stage-level tests stay green through the component join; event-frame fixtures now carry `code_components`/`source_block` exactly as `convert_to_MEDS_events` emits them (added via the `_bare_code_events` helper), since the component join is the only join. No committed example fixtures (`examples/default`, pipeline scenarios) needed regeneration — bare-column full-match codes produce identical `codes.parquet` via the component join.
- New tests: null-key matching (flagship `nulls_equal` case), transform-vs-raw matching, literal-code error.
- No stale wording: comments/docstrings no longer reference the deleted full-match machinery (README's metadata-linking sections updated to the raw-component-join model).

Refs #146 #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)