### PR TITLE
extract_code_metadata: choose reader kwargs per metadata prefix — parquet sources crashed on csv-only infer_schema (#148)

### DIFF
--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -19,7 +19,7 @@ from upath import UPath
 
 from .._stage_example import MEDSExtractStageExample
 from ..config import SOURCE_BLOCK_COL, MessyConfig
-from ..io import resolve_source_files, scan_source
+from ..io import _format_family, resolve_source_files, scan_source
 
 logger = logging.getLogger(__name__)
 
@@ -642,11 +642,15 @@ def main(cfg: DictConfig):
 
         metadata_fps = resolve_source_files(raw_input_dir, input_prefix)
 
-        # ``infer_schema=False`` gives csv sources a uniform all-String schema. Format
-        # dispatch happens per file inside ``scan_source`` (csv-only kwargs are dropped for
-        # parquet chunks), so a prefix mixing csv and parquet chunks reads cleanly.
-        def read_fn(fps):
-            return scan_source(fps, infer_schema=False)
+        # Reader kwargs are chosen per resolved prefix: csv-family sources read with
+        # ``infer_schema=False`` for a uniform all-String schema, while parquet sources
+        # keep their intrinsic types (``infer_schema`` is csv-only and would crash
+        # ``scan_parquet``). Deciding from the first file is sound because
+        # ``scan_source`` enforces format homogeneity across a multi-file source.
+        read_kwargs = {} if _format_family(metadata_fps[0]) == "parquet" else {"infer_schema": False}
+
+        def read_fn(fps, read_kwargs=read_kwargs):
+            return scan_source(fps, **read_kwargs)
 
         # Write one output file per individual event config so each is unambiguously
         # full-match or partial-match. A single metadata prefix can be referenced by

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -188,7 +188,7 @@ def test_extract_code_metadata_parquet_source():
     ``infer_schema=False`` (all-String), while parquet sources take no reader kwargs and
     keep their intrinsic types. An unconditional ``infer_schema=False`` used to crash
     ``pl.scan_parquet`` with ``TypeError: ... unexpected keyword argument 'infer_schema'``
-    (https://github.com/Medical-Event-Data-Standard/MEDS_extract/issues/148). Mirrors
+    (https://github.com/mmcdermott/MEDS_extract/issues/148). Mirrors
     MIMIC-IV's pre-MEDS ``hosp/d_icd_diagnoses.parquet`` shape.
     """
     messy = """\

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -181,6 +181,48 @@ data:
     assert by_code["TEMP"] == "Body Temperature"
 
 
+def test_extract_code_metadata_parquet_source():
+    """Regression guard: a ``_metadata`` prefix resolving to a parquet file must read cleanly.
+
+    Reader kwargs are chosen per metadata prefix: csv sources get the csv-only
+    ``infer_schema=False`` (all-String), while parquet sources take no reader kwargs and
+    keep their intrinsic types. An unconditional ``infer_schema=False`` used to crash
+    ``pl.scan_parquet`` with ``TypeError: ... unexpected keyword argument 'infer_schema'``
+    (https://github.com/Medical-Event-Data-Standard/MEDS_extract/issues/148). Mirrors
+    MIMIC-IV's pre-MEDS ``hosp/d_icd_diagnoses.parquet`` shape.
+    """
+    messy = """\
+diagnoses_icd:
+  diagnosis:
+    code: 'f"ICD{$icd_version}//{$icd_code}"'
+    _metadata:
+      d_icd_diagnoses:
+        description: long_title
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={"diagnoses_icd": pl.DataFrame({"code": ["ICD9//25000", "ICD10//E119"]})},
+            raw_files={
+                "d_icd_diagnoses.parquet": pl.DataFrame(
+                    {
+                        "icd_code": ["25000", "E119"],
+                        "icd_version": [9, 10],
+                        "long_title": [
+                            "Diabetes mellitus without mention of complication",
+                            "Type 2 diabetes mellitus without complications",
+                        ],
+                    }
+                )
+            },
+        )
+
+    by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+    assert by_code["ICD9//25000"] == "Diabetes mellitus without mention of complication"
+    assert by_code["ICD10//E119"] == "Type 2 diabetes mellitus without complications"
+
+
 def test_extract_code_metadata_duplicate_codes_aggregation():
     """Description concatenation for duplicate codes from multiple metadata sources.
 


### PR DESCRIPTION
## Root cause

The `#145`-era refactor centralized format dispatch in `scan_source` and removed the old per-format read branch in `extract_code_metadata`, but left behind an unconditional

```python
def read_fn(fps):
    return scan_source(fps, infer_schema=False)
```

`infer_schema` is a csv-only kwarg. `io._scan_one`'s parquet branch (deliberately strict — it only tolerates `infer_schema_length`) forwards it to `pl.scan_parquet`, so any `_metadata` prefix that resolves to a **parquet** file crashes with

```
TypeError: scan_parquet() got an unexpected keyword argument 'infer_schema'
```

This is a MIMIC-IV 0.7-migration blocker: MIMIC's pre-MEDS step emits `hosp/d_icd_diagnoses.parquet` / `hosp/d_icd_procedures.parquet`, both `_metadata` sources.

## Fix

Choose reader kwargs **per resolved prefix** from its format family (determined from the first resolved file — sound because `scan_source` enforces format homogeneity across multi-file sources): csv-family prefixes read all-String via `infer_schema=False`; parquet prefixes read with no kwargs and keep their intrinsic types. The stale "csv-only kwargs are dropped for parquet chunks" comment is replaced with the real contract. `io._scan_one` stays strict by design — no kwarg tolerance added there.

Note: PR #147 carries the same pattern on its branch and will pick this fix up via merge-forward.

Closes #148

## Test plan

- New stage-level regression test `test_extract_code_metadata_parquet_source` via `_run_ecm_scenario`: a `_metadata` source provided as a parquet file mirroring MIMIC-IV's `d_icd_diagnoses.parquet` shape (typed `icd_version` ints included), asserting descriptions land. Verified it reproduces the exact `TypeError` on unpatched `dev`.
- Existing `test_partial_match_typed_int_components_join_csv_metadata` continues to guard the all-String csv read contract.
- Full suite: 102 passed, 1 deselected. `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)