### PR TITLE
EventConfig.extract: derive the time null pre-filter from the time expression's structure (#149)

### DIFF
--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import polars as pl
 from dftly import Parser
-from dftly.nodes.arithmetic import Hash
+from dftly.nodes.arithmetic import Coalesce, Hash
 from dftly.nodes.base import NodeBase
 from omegaconf import DictConfig, OmegaConf
 
@@ -44,6 +44,76 @@ logger = logging.getLogger(__name__)
 # partial-match metadata joins to their declaring event (without it, one event's
 # metadata would attach to other events' codes sharing a component value).
 SOURCE_BLOCK_COL = "source_block"
+
+
+def _non_null_source_filter(col: str, schema: pl.Schema) -> pl.Expr:
+    """A non-null filter on raw source column ``col``, also excluding ``""`` for String columns.
+
+    Columns whose dtype is unknown (absent from ``schema``) get the String treatment,
+    matching how csv sources read with ``infer_schema=False`` surface every column.
+    """
+    col_filter = pl.col(col).is_not_null()
+    if schema.get(col) == pl.String or schema.get(col) is None:
+        col_filter = col_filter & (pl.col(col) != pl.lit(""))
+    return col_filter
+
+
+def _time_null_prefilter(node: NodeBase, schema: pl.Schema) -> pl.Expr | None:
+    """Build the raw-column null pre-filter implied by a time expression's structure.
+
+    ``EventConfig.extract`` must drop rows whose time expression evaluates to null, but it
+    cannot filter on the parsed expression itself: that would re-trigger a polars
+    predicate-pushdown bug where ``strptime(strict=True)`` is evaluated during parquet
+    scanning before nulls are filtered. Instead this derives an equivalent filter over the
+    **raw source columns only**, mirroring the expression's structure:
+
+    - a ``coalesce`` node keeps a row when **any** branch could produce a value
+      (``pl.any_horizontal`` over the branches' filters, each derived recursively);
+    - any other node with child nodes needs **all** of them (``pl.all_horizontal``),
+      recursing so a ``coalesce`` nested inside e.g. a strptime is still honored;
+    - a leaf requires its referenced columns non-null (and non-empty for String columns);
+    - a branch referencing no columns (a literal) always yields a value, so it contributes
+      no constraint — ``None`` means "no filter needed".
+
+    Examples:
+        >>> import polars as pl
+        >>> from dftly import Parser
+        >>> schema = pl.Schema({"a": pl.String, "b": pl.Int64})
+
+        A single-column strptime requires that column:
+
+        >>> print(_time_null_prefilter(Parser()('$a::"%Y"'), schema))
+        [(col("a").is_not_null()) & ([(col("a")) != ("")])]
+
+        A coalesce across columns is an OR of its branches' filters — here
+        ``(a non-null AND non-empty) OR (b non-null)``:
+
+        >>> print(_time_null_prefilter(Parser()('coalesce($a::?"%Y", $b::?"%Y")'), schema))
+        [(col("a").is_not_null()) & ([(col("a")) != ("")])].any_horizontal([col("b").is_not_null()])
+
+        The ``??`` spelling and a coalesce nested inside a strptime produce the same shape:
+
+        >>> print(_time_null_prefilter(Parser()('coalesce($a, $b)::?"%Y"'), schema))
+        [(col("a").is_not_null()) & ([(col("a")) != ("")])].any_horizontal([col("b").is_not_null()])
+
+        A literal branch always yields a value, so no pre-filter is needed at all:
+
+        >>> _time_null_prefilter(Parser()('coalesce($a::?"%Y", "2020"::?"%Y")'), schema) is None
+        True
+    """
+    children = [v for v in (*node.args, *node.kwargs.values()) if isinstance(v, NodeBase)]
+    if isinstance(node, Coalesce):
+        branch_filters = [_time_null_prefilter(c, schema) for c in children]
+        if any(f is None for f in branch_filters):
+            return None
+        return branch_filters[0] if len(branch_filters) == 1 else pl.any_horizontal(*branch_filters)
+    if children:
+        filters = [f for c in children if (f := _time_null_prefilter(c, schema)) is not None]
+    else:
+        filters = [_non_null_source_filter(c, schema) for c in sorted(node.referenced_columns)]
+    if not filters:
+        return None
+    return filters[0] if len(filters) == 1 else pl.all_horizontal(*filters)
 
 
 # ── JoinConfig ───────────────────────────────────────────────────────
@@ -496,18 +566,16 @@ class EventConfig:
             df = df.filter(exprs["code"].is_not_null())
 
         if not self.is_static:
-            # Filter on source columns being non-null/non-empty rather than on the parsed time
-            # expression, to avoid a polars predicate-pushdown bug where strptime(strict=True)
-            # is evaluated during parquet scanning before nulls are filtered.
+            # Filter on raw source columns being non-null/non-empty rather than on the parsed
+            # time expression, to avoid a polars predicate-pushdown bug where
+            # strptime(strict=True) is evaluated during parquet scanning before nulls are
+            # filtered. The filter mirrors the time expression's structure (see
+            # ``_time_null_prefilter``): a coalesce across columns keeps a row when ANY branch
+            # can produce a time; anything else needs ALL its referenced columns.
             if self.time_source_columns:
-                schema = df.collect_schema()
-                ts_filters = []
-                for c in sorted(self.time_source_columns):
-                    col_filter = pl.col(c).is_not_null()
-                    if schema.get(c) == pl.String or schema.get(c) is None:
-                        col_filter = col_filter & (pl.col(c) != pl.lit(""))
-                    ts_filters.append(col_filter)
-                df = df.filter(pl.all_horizontal(*ts_filters))
+                time_filter = _time_null_prefilter(self.columns["time"], df.collect_schema())
+                if time_filter is not None:
+                    df = df.filter(time_filter)
             else:
                 df = df.filter(exprs["time"].is_not_null())
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,6 +46,62 @@ def test_non_string_time_column_regression():
     assert set(result["subject_id"].to_list()) == {1, 3}
 
 
+def test_coalesce_across_columns_time_keeps_partial_rows(tmp_path):
+    """Regression: a time coalescing across columns must keep rows where only one column is set (#149).
+
+    The null pre-filter used to AND ``is_not_null`` over ALL time source columns, silently
+    dropping every row where either column was null — on the MIMIC-IV demo this lost 16 of
+    31 deaths (all out-of-hospital deaths, with ``dod`` but no admissions ``deathtime``).
+    The filter is now derived from the time expression's structure: an OR across coalesce
+    branches. Verified both on an in-memory frame and through ``scan_parquet`` (the
+    pre-filter exists to keep strict strptime off unfiltered scan batches, so the parquet
+    path is the one that must stay safe).
+    """
+    raw = pl.DataFrame(
+        {
+            "subject_id": [1, 2, 3],
+            "deathtime": ["2021-01-01 12:00:00", None, None],
+            "dod": ["2021-01-01", "2021-01-02", None],
+        }
+    )
+    ev = _event("MEDS_DEATH", 'coalesce($deathtime::?"%Y-%m-%d %H:%M:%S", $dod::?"%Y-%m-%d")')
+
+    result = ev.extract(raw.lazy(), "patients/death").collect()
+    assert set(result["subject_id"].to_list()) == {1, 2}
+
+    fp = tmp_path / "patients.parquet"
+    raw.write_parquet(fp)
+    result = ev.extract(pl.scan_parquet(fp, glob=False), "patients/death").collect()
+    assert set(result["subject_id"].to_list()) == {1, 2}
+
+
+def test_coalesce_same_column_multi_format_time_unchanged():
+    """A same-column multi-format coalesce keeps rows parseable by either format, drops null/unparsable."""
+    raw = pl.DataFrame(
+        {
+            "subject_id": [1, 2, 3],
+            "t": ["2021-01-01 12:00:00", "2021-01-02", None],
+        }
+    )
+    ev = _event("MEDS_DEATH", 'coalesce($t::?"%Y-%m-%d %H:%M:%S", $t::?"%Y-%m-%d")')
+    result = ev.extract(raw.lazy(), "patients/death").collect()
+    assert set(result["subject_id"].to_list()) == {1, 2}
+
+
+def test_coalesce_nested_inside_strptime_time_keeps_partial_rows():
+    """A coalesce nested inside another node (``coalesce($a, $b)::?fmt``) also ORs its branches (#149)."""
+    raw = pl.DataFrame(
+        {
+            "subject_id": [1, 2, 3],
+            "a": ["2021-01-01", None, None],
+            "b": ["2021-06-01", "2021-01-02", None],
+        }
+    )
+    ev = _event("MEDS_DEATH", 'coalesce($a, $b)::?"%Y-%m-%d"')
+    result = ev.extract(raw.lazy(), "patients/death").collect()
+    assert set(result["subject_id"].to_list()) == {1, 2}
+
+
 # ── Combined-MESSY ``sources:`` hygiene: credential redaction in logs ─────────────────────────────
 
 


### PR DESCRIPTION
## Silent data loss

An event whose `time` coalesces across two source columns — MIMIC's death event,

```yaml
death:
  code: MEDS_DEATH
  time: coalesce($deathtime::?"%Y-%m-%d %H:%M:%S", $dod::?"%Y-%m-%d")
```

— silently dropped every row where *either* column was null: the non-static pre-filter in `EventConfig.extract` ANDed `is_not_null()` over **all** `time_source_columns` (`pl.all_horizontal`), which is stricter than the coalesce semantics it stands in for. On the MIMIC-IV demo this loses **16 of 31 deaths** (every out-of-hospital death has `dod` but no admissions `deathtime`). No crash, no warning. This is a MIMIC-IV 0.7-migration blocker.

## Fix

New `_time_null_prefilter` helper (doctested) derives the pre-filter from the parsed time expression's structure:

- a dftly `Coalesce` node (both the `coalesce(...)` and `??` spellings parse to the same node) ORs its branches' filters via `pl.any_horizontal`, each branch derived recursively;
- any other node ANDs its child nodes' filters via `pl.all_horizontal` — recursing through children, so a coalesce nested inside another node (`coalesce($a, $b)::?fmt` parses as `Strptime(source=Coalesce(...))`) is also honored;
- a `Column` leaf requires non-null (plus non-empty for String/unknown-dtype columns, matching the existing csv all-String contract);
- a branch referencing no columns (a literal) always yields a value and contributes no constraint — if any coalesce branch is a literal, no pre-filter is applied at all.

The critical constraint is preserved by construction: the filter references only **raw source columns**, never the parsed/strptime'd expression — that is the standing workaround for a polars predicate-pushdown bug where `strptime(strict=True)` evaluates during parquet scanning before nulls are filtered. Single-column and same-column multi-format coalesce behavior is unchanged.

Closes #149

## Test plan

- `test_coalesce_across_columns_time_keeps_partial_rows`: the issue's minimal repro (subjects 1, 2 kept; 3 dropped), verified both in-memory and through `scan_parquet`. Fails on unpatched `dev` with exactly the reported signature (`{1} == {1, 2}`).
- `test_coalesce_nested_inside_strptime_time_keeps_partial_rows`: the `coalesce($a, $b)::?fmt` spelling — also failed unpatched.
- `test_coalesce_same_column_multi_format_time_unchanged`: `coalesce($t::?f1, $t::?f2)` behavior unchanged (passes both before and after).
- Existing `test_scan_parquet_null_time_regression` / `test_non_string_time_column_regression` continue to guard single-column and non-String-dtype behavior.
- Helper doctests show the OR-of-ANDs filter shape and the literal-branch no-filter case.
- Full suite: 105 passed, 1 deselected. `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)