### PR TITLE
meds-extract-download: resolve interpolations per selected bucket, not across all sources (#151)

### DIFF
--- a/src/MEDS_extract/download/cli.py
+++ b/src/MEDS_extract/download/cli.py
@@ -96,25 +96,39 @@ def main(cfg: DictConfig) -> None:
     spec_fp = Path(hydra.utils.to_absolute_path(str(cfg.spec))).expanduser().resolve()
     raw_input_dir = Path(hydra.utils.to_absolute_path(str(cfg.raw_input_dir))).expanduser().resolve()
 
-    # Resolve interpolations on ONLY the ``sources:`` subtree. Under the combined-MESSY
-    # pattern (one file carrying both ``sources:`` and event-conversion entries),
-    # resolving the whole document would require every ``${oc.env:...}`` in unrelated
-    # event-conversion sections to be set just to run ``meds-extract-download``. This is
-    # the symmetric sibling of ``MessyConfig.parse``'s "strip reserved keys before
-    # resolve=True" fix — the two layers coexist without cross-polluting env requirements.
+    # Resolve interpolations on ONLY the selected ``sources:`` buckets (``key`` plus the
+    # always-appended ``common``). Under the combined-MESSY pattern (one file carrying
+    # both ``sources:`` and event-conversion entries), resolving the whole document
+    # would require every ``${oc.env:...}`` in unrelated event-conversion sections to be
+    # set just to run ``meds-extract-download`` — and resolving all of ``sources:``
+    # would likewise require unselected buckets' credentials (e.g. a credentialed
+    # ``dataset`` bucket's env vars just to pull ``key=demo``). This is the symmetric
+    # sibling of ``MessyConfig.parse``'s "strip reserved keys before resolve=True" fix —
+    # the layers coexist without cross-polluting env requirements. Each selected bucket
+    # is resolved while still ATTACHED to the loaded document, so document-relative
+    # interpolations (e.g. ``${sources.demo.0.root}``) keep resolving; detaching the
+    # bucket first would break them.
     spec_raw = OmegaConf.load(spec_fp)
     sources_node = spec_raw.get("sources")
-    sources_dict = OmegaConf.to_container(sources_node, resolve=True) if sources_node is not None else {}
 
     # A key that names no bucket is a config error (likely a typo), not an empty
     # download: because ``common`` is always appended, a typo'd key would otherwise
-    # quietly fetch only the common bucket — or nothing — and "succeed".
-    if sources_dict and cfg.key not in sources_dict:
+    # quietly fetch only the common bucket — or nothing — and "succeed". Bucket names
+    # come from the UNRESOLVED node — listing them must not require any interpolation
+    # (in any bucket) to be resolvable.
+    if sources_node and cfg.key not in sources_node:
         logger.error(
             f"key={cfg.key!r} does not name a sources bucket in {spec_fp}. "
-            f"Available buckets: {sorted(sources_dict)}."
+            f"Available buckets: {sorted(sources_node)}."
         )
         sys.exit(1)
+
+    sources_dict = {}
+    if sources_node is not None:
+        for bucket in dict.fromkeys((cfg.key, "common")):  # de-dupe when key="common"
+            bucket_node = sources_node.get(bucket)
+            if bucket_node is not None:
+                sources_dict[bucket] = OmegaConf.to_container(bucket_node, resolve=True)
 
     sources = sources_from_spec({"sources": sources_dict}, key=cfg.key)
 

--- a/tests/test_download_fsspec.py
+++ b/tests/test_download_fsspec.py
@@ -167,8 +167,18 @@ patients:
     assert (raw_input_dir / "hello.csv").read_text().startswith("a,b")
 
 
-def _run_cli(tmp_path: Path, spec_body: str, *args: str, hydra_dir: str = ".hydra"):
-    """Run the ``meds-extract-download`` console script against an inline spec."""
+def _run_cli(
+    tmp_path: Path,
+    spec_body: str,
+    *args: str,
+    hydra_dir: str = ".hydra",
+    env: dict[str, str] | None = None,
+):
+    """Run the ``meds-extract-download`` console script against an inline spec.
+
+    ``env``, when given, fully replaces the subprocess environment (pass a copy of
+    ``os.environ`` plus/minus the vars under test).
+    """
     import subprocess
 
     spec_fp = tmp_path / "spec.yaml"
@@ -186,6 +196,7 @@ def _run_cli(tmp_path: Path, spec_body: str, *args: str, hydra_dir: str = ".hydr
             capture_output=True,
             text=True,
             check=False,
+            env=env,
         ),
         raw_input_dir,
     )
@@ -266,6 +277,73 @@ def test_cli_key_selects_bucket_and_appends_common(tmp_path: Path):
     assert (raw / "demo.csv").exists(), "selected bucket must be fetched"
     assert (raw / "shared.csv").exists(), "common bucket must always be appended"
     assert not (raw / "ds.csv").exists(), "unselected default bucket must not be fetched"
+
+
+def _issue_151_spec(tmp_path: Path) -> str:
+    """The credentialed-``dataset`` + public-``demo`` (+ interpolated ``common``) spec shape.
+
+    ``dataset`` needs an env var (``FIX151_UNSET_CRED``) the tests deliberately never
+    set; ``demo`` is a plain local mirror; ``common`` resolves its root from an env var
+    (``FIX151_COMMON_ROOT``) the tests DO set.
+    """
+    m_demo = tmp_path / "m_demo"
+    m_common = tmp_path / "m_common"
+    for m, fname in [(m_demo, "demo.csv"), (m_common, "shared.csv")]:
+        m.mkdir(exist_ok=True)
+        (m / fname).write_text(f"from {m.name}\n")
+    return f"""sources:
+  dataset:
+    - type: fsspec
+      root: ${{oc.env:FIX151_UNSET_CRED}}
+  demo:
+    - type: fsspec
+      root: {m_demo}
+  common:
+    - type: fsspec
+      root: ${{oc.env:FIX151_COMMON_ROOT}}
+"""
+
+
+def _issue_151_env(tmp_path: Path) -> dict[str, str]:
+    """Subprocess env for the issue-#151-shaped tests: common root set, credential unset."""
+    import os
+
+    env = {k: v for k, v in os.environ.items() if k != "FIX151_UNSET_CRED"}
+    env["FIX151_COMMON_ROOT"] = str(tmp_path / "m_common")
+    return env
+
+
+def test_cli_unselected_bucket_interpolations_not_resolved(tmp_path: Path):
+    """``key=demo`` must succeed without the credentialed ``dataset`` bucket's env vars set.
+
+    Demo users (and credential-free CI) must not need unrelated credentials in the
+    environment to pull a bucket that doesn't use them: interpolations are resolved
+    per selected bucket, not across all of ``sources:``.
+    """
+    result, raw = _run_cli(tmp_path, _issue_151_spec(tmp_path), "key=demo", env=_issue_151_env(tmp_path))
+    assert result.returncode == 0, (
+        "CLI failed; likely resolved unselected buckets' interpolations too.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert (raw / "demo.csv").read_text() == "from m_demo\n", "selected bucket must be staged"
+
+
+def test_cli_selected_bucket_interpolation_failure_is_clear(tmp_path: Path):
+    """Selecting the credentialed bucket WITHOUT its env var set must still fail, and the error must name the
+    missing variable — narrowing resolution to the selected bucket may not swallow its own interpolation
+    errors."""
+    result, raw = _run_cli(tmp_path, _issue_151_spec(tmp_path), "key=dataset", env=_issue_151_env(tmp_path))
+    assert result.returncode != 0
+    assert "FIX151_UNSET_CRED" in result.stdout + result.stderr, "error must name the missing env var"
+    assert not raw.exists(), "nothing may be staged on a failed resolve"
+
+
+def test_cli_common_bucket_interpolation_still_resolved(tmp_path: Path):
+    """The always-appended ``common`` bucket's interpolations ARE resolved whichever key is selected — per-
+    bucket narrowing covers ``key`` plus ``common``, not ``key`` alone."""
+    result, raw = _run_cli(tmp_path, _issue_151_spec(tmp_path), "key=demo", env=_issue_151_env(tmp_path))
+    assert result.returncode == 0, f"CLI failed:\n{result.stdout}\n{result.stderr}"
+    assert (raw / "shared.csv").read_text() == "from m_common\n", "common bucket must be staged"
 
 
 def test_cli_cross_source_collision_exits_before_any_fetch(tmp_path: Path):


### PR DESCRIPTION
## Root cause

`download/cli.py` materialized the entire `sources:` subtree eagerly —
`OmegaConf.to_container(sources_node, resolve=True)` — *before* `key=` selected a bucket. Every `${oc.env:...}` interpolation in every bucket therefore had to resolve, so `key=demo` failed with an `InterpolationResolutionError` unless the unrelated credentialed `dataset` bucket's env vars (e.g. `DATASET_DOWNLOAD_USERNAME`) were set. This is the per-bucket variant of the resolution-scoping principle the CLI already applied one level up (resolving only `sources:` rather than the whole combined-MESSY document).

## Fix

Select first, resolve second: only the `cfg.key` bucket and the always-appended `common` bucket are resolved, each via `OmegaConf.to_container(bucket_node, resolve=True)` on the sub-node **while still attached** to the loaded document — verified that document-relative interpolations (e.g. `${sources.demo.0.root}`) resolve correctly on attached nodes but break if the bucket is detached first. Unknown-`key` validation now reads bucket names from the unresolved node, so listing available buckets never requires any interpolation to be resolvable.

Preserved unchanged: the no-`sources:`-block warn-and-exit-0 path, `key=common` no-double-count, unknown-`key` hard error with bucket listing, and cross-source collision validation.

## Test plan

Three new extras-free CLI subprocess tests in `tests/test_download_fsspec.py` (so the no-extras CI job runs them), using the issue's exact spec shape — credentialed `dataset` bucket (`${oc.env:FIX151_UNSET_CRED}`), plain fsspec `demo` bucket, and a `common` bucket whose root is itself an env interpolation:

- `test_cli_unselected_bucket_interpolations_not_resolved` — `key=demo` succeeds (rc=0, files staged) with the credential env var unset
- `test_cli_selected_bucket_interpolation_failure_is_clear` — `key=dataset` without the env var fails (rc!=0) with an error naming the missing variable, nothing staged
- `test_cli_common_bucket_interpolation_still_resolved` — the `common` bucket's interpolation resolves and its files stage when `key=demo` is selected

Full suite: 104 passed, 1 deselected. `pre-commit run --all-files` clean.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)