### PR TITLE
EventConfig.extract: filter computed time/code post-select — naive null handling, drop accounting

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,8 @@
 # Migrating from MEDS_extract 0.6.x to 0.7.0
 
 The 0.7.0 release is a deliberate breaking cut. Four areas change: the MESSY config key layout, null
-handling in composite codes, metadata extraction / `codes.parquet`, and raw-data fetching (a first-class
-download layer replaces per-ETL `download.py` scripts). This guide walks every breaking change with
+handling in composite codes and event times, metadata extraction / `codes.parquet`, and raw-data
+fetching (a first-class download layer replaces per-ETL `download.py` scripts). This guide walks every breaking change with
 before/after snippets you can copy.
 
 > **Scope**: 0.6.x (any of 0.6.0–0.6.2) → 0.7.0. If you're on 0.5.x or earlier, land the 0.6.0 migration
@@ -10,19 +10,20 @@ before/after snippets you can copy.
 
 ## At a glance
 
-| Area                                 | Before (0.6.x)                                           | After (0.7.0)                                                                    |
-| ------------------------------------ | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `subject_id_col` / `subject_id_expr` | top-level table keys                                     | `_defaults.subject_id` (a dftly expression)                                      |
-| `transforms`                         | top-level table key                                      | `_table.cols`                                                                    |
-| `join`                               | top-level table key with `columns_from_right`            | `_table.join: {prefix: {key, cols}}`                                             |
-| `schema`                             | top-level table key (parsed, never used)                 | **removed**                                                                      |
-| Null component in a composite `code` | auto-filled with `"UNK"`, row kept                       | code is null → **row dropped**; opt back in per component with `?? 'UNK'`        |
-| `_match_on` metadata joins           | joined against **all** events' codes; dtype-fragile      | scoped to the declaring event; join keys dtype-normalized; key-rename now errors |
-| `codes.parquet`                      | run-order-dependent schema/values; `*_right` merge forks | deterministic byte-identical output; deduplicated values; stable schema          |
-| Multi-file source prefixes           | csv + parquet chunks silently unified                    | mixed csv/parquet chunks are an error                                            |
-| Raw-data fetching                    | hand-rolled `download.py` per ETL                        | MESSY `sources:` block + `meds-extract-download`                                 |
-| Python floor                         | 3.12                                                     | **3.11** (relaxed, not raised)                                                   |
-| Dependency pins                      | `MEDS-transforms~=0.6.0`, `dftly>=0.1.2,<0.2`            | `MEDS-transforms>=0.6.7,<0.7`, `dftly>=0.5.0`                                    |
+| Area                                 | Before (0.6.x)                                                      | After (0.7.0)                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `subject_id_col` / `subject_id_expr` | top-level table keys                                                | `_defaults.subject_id` (a dftly expression)                                      |
+| `transforms`                         | top-level table key                                                 | `_table.cols`                                                                    |
+| `join`                               | top-level table key with `columns_from_right`                       | `_table.join: {prefix: {key, cols}}`                                             |
+| `schema`                             | top-level table key (parsed, never used)                            | **removed**                                                                      |
+| Null component in a composite `code` | auto-filled with `"UNK"`, row kept                                  | code is null → **row dropped**; opt back in per component with `?? 'UNK'`        |
+| Unparsable `time` values             | strict-cast `""` silently dropped; lenient junk kept with null time | strict cast **errors**; lenient junk **drops the row**, with a per-event WARNING |
+| `_match_on` metadata joins           | joined against **all** events' codes; dtype-fragile                 | scoped to the declaring event; join keys dtype-normalized; key-rename now errors |
+| `codes.parquet`                      | run-order-dependent schema/values; `*_right` merge forks            | deterministic byte-identical output; deduplicated values; stable schema          |
+| Multi-file source prefixes           | csv + parquet chunks silently unified                               | mixed csv/parquet chunks are an error                                            |
+| Raw-data fetching                    | hand-rolled `download.py` per ETL                                   | MESSY `sources:` block + `meds-extract-download`                                 |
+| Python floor                         | 3.12                                                                | **3.11** (relaxed, not raised)                                                   |
+| Dependency pins                      | `MEDS-transforms~=0.6.0`, `dftly>=0.1.2,<0.2`                       | `MEDS-transforms>=0.6.7,<0.7`, `dftly>=0.5.0`                                    |
 
 ## 1. MESSY config redesign
 
@@ -185,7 +186,9 @@ sed -i '
 
 The `join:` block must be edited by hand.
 
-## 2. Null components in composite codes
+## 2. Null handling: composite codes and event times
+
+### Null components in composite codes
 
 0.6.x silently rendered any null component of an interpolated `code` as the literal `"UNK"` and kept the
 row. 0.7.0 makes that an explicit author choice: the composite `code` expression null-propagates — if
@@ -205,6 +208,41 @@ clashes with the f-string delimiter.
 **What you must change:** audit every interpolated `code` in your MESSY file. For each component,
 decide: should a null value drop the row (leave it bare) or be filled (add `?? 'UNK'` or another
 literal)? To reproduce 0.6.x output exactly, coalesce every component with `?? 'UNK'`.
+
+### Null and unparsable `time` values
+
+0.7.0 drops null-time rows by filtering the **computed** `time` column, not by pre-filtering the raw
+source columns it references. Three visible consequences:
+
+- **Strict casts (`::"fmt"`) now error on unparsable non-null values.** Previously an empty-string
+    `""` in a String time column was silently pre-filtered before the cast ever saw it; now a strict
+    cast raises a polars `InvalidOperationError` naming the offending value(s). Strict means strict:
+    if your data contains `""` (or other junk) time values you consider droppable, switch to a
+    lenient cast (`::?"fmt"`) — or clean the data in pre-MEDS.
+
+- **Lenient casts (`::?"fmt"`) now drop rows whose value parses under no format.** Previously such
+    rows slipped past the raw-column pre-filter and leaked downstream with `time=null` — invalid
+    MEDS output. Dropped rows are no longer silent: each event logs one WARNING with counts, so a
+    mis-specified format that wipes out a whole table is immediately visible (null-code drops are
+    counted in the same message):
+
+    ```text
+    `admissions/visit`: dropped 12/5000 rows with null time (unparsable or missing under the configured formats)
+    ```
+
+- **Coalesced multi-format times work as written**, including across columns. The idiom for a single
+    column mixing several formats is a coalesce of lenient parses — each row takes the first format
+    that matches, and rows matching none are dropped (and counted):
+
+```yaml
+visit:
+  code: VISIT
+  time: coalesce($ts::?"%m/%d/%y %H:%M:%S", $ts::?"%m/%d/%y")
+```
+
+**What you must change:** audit every strict (`::"fmt"`) time cast — if the column can contain `""`
+or unparsable junk you want dropped rather than erroring, make it lenient (`::?"fmt"`). Then watch
+the extraction logs: new WARNING lines are the rows 0.6.x was dropping (or leaking) silently.
 
 ## 3. Metadata extraction and `codes.parquet`
 
@@ -408,8 +446,9 @@ for the stage DAG.
 
 ## Recommended migration order
 
-1. **Rewrite your MESSY file** per section 1 (key renames), then audit composite codes per section 2
-    (`??` coalescing where you want rows kept).
+1. **Rewrite your MESSY file** per section 1 (key renames), then audit composite codes and time
+    casts per section 2 (`??` coalescing where you want rows kept; `::?` where unparsable times
+    should drop instead of error).
 2. **Add a `sources:` block** to the same file (renaming it to `messy.yaml` is conventional, not
     required) and delete your `download.py`. Move credentials to `${oc.env:...}`.
 3. **Bump the dependency pins** per section 5.

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -353,8 +353,9 @@ class EventConfig:
             │ 3          ┆ EYE_COLOR ┆ null         ┆ brown     ┆ patients/eye_color │
             └────────────┴───────────┴──────────────┴───────────┴────────────────────┘
 
-            A null in a referenced ``time`` column, or in a **bare-column** ``code``
-            (``code: $col``), filters the row out before selection:
+            A row whose computed ``time`` is null, or whose **bare-column** ``code``
+            (``code: $col``) is null, is dropped after selection (with a per-event
+            WARNING summarizing the drop counts):
 
             >>> raw = pl.DataFrame({
             ...     "subject_id": [1, 2, 3],
@@ -371,6 +372,31 @@ class EventConfig:
             ╞════════════╪══════╪════════════╡
             │ 1          ┆ A    ┆ 2021-01-01 │
             └────────────┴──────┴────────────┘
+
+            A single time column mixing several formats is handled by coalescing lenient
+            (``::?``) parses — each row takes the first format that matches, and rows
+            matching none (garbage, ``""``, null) get a null time and are dropped (and
+            counted in the WARNING). This is the documented multi-format idiom; a strict
+            (``::"fmt"``) cast would instead *error* on the first unparsable value:
+
+            >>> raw = pl.DataFrame({
+            ...     "subject_id": [1, 2, 3, 4],
+            ...     "ts": ["01/02/21 12:30:00", "01/03/21", "not a date", None],
+            ... })
+            >>> ev = EventConfig.parse("visit", {
+            ...     "code": "VISIT",
+            ...     "time": 'coalesce($ts::?"%m/%d/%y %H:%M:%S", $ts::?"%m/%d/%y")',
+            ... })
+            >>> ev.extract(raw.lazy(), "visits/visit").collect().select("subject_id", "time")
+            shape: (2, 2)
+            ┌────────────┬─────────────────────┐
+            │ subject_id ┆ time                │
+            │ ---        ┆ ---                 │
+            │ i64        ┆ datetime[μs]        │
+            ╞════════════╪═════════════════════╡
+            │ 1          ┆ 2021-01-02 12:30:00 │
+            │ 2          ┆ 2021-01-03 00:00:00 │
+            └────────────┴─────────────────────┘
 
             A *composite / interpolated* code null-propagates the same way: if **any** referenced
             component is null, the whole code is null, so the row is dropped. Below, only the row
@@ -488,30 +514,57 @@ class EventConfig:
 
         exprs[SOURCE_BLOCK_COL] = pl.lit(source_block)
 
-        if self.code_source_columns:
+        out = df.select(**exprs)
+
+        # Null-`code` / null-`time` rows are dropped by filtering the COMPUTED columns, after the
+        # select — never via a fallible predicate over the raw source expressions. Polars pushes
+        # eligible predicates into the parquet scan itself, where they are evaluated on
+        # validity-unmasked data (null slots of a String column surface as ""), so a predicate
+        # containing a strict cast/strptime panics on polars >= 1.28 (and mis-evaluates silently
+        # before that): https://github.com/pola-rs/polars/issues/28521. A predicate on a computed
+        # column instead stays above the SELECT boundary (verified on polars 1.26-1.43 and
+        # regression-guarded in tests), and the scan's projection pushdown is preserved. Note the
+        # deliberate consequence for strict (`::"fmt"`) time casts: an unparsable non-null value
+        # (e.g. "") now raises an InvalidOperationError naming the value, instead of being
+        # silently pre-filtered; authors who want unparsable values dropped opt in with a
+        # lenient (`::?"fmt"`) cast, which nulls them so they are dropped (and counted) here.
+        drop_null_code = bool(self.code_source_columns)
+        drop_null_time = not self.is_static
+
+        if drop_null_code or drop_null_time:
+            # Drop accounting: one aggregation pass over the pre-filter frame so silently
+            # vanishing rows (unparsable times, null code components) are surfaced per event.
+            stats_exprs = [pl.len().alias("n_total")]
+            if drop_null_code:
+                stats_exprs.append(pl.col("code").is_null().sum().alias("n_null_code"))
+            if drop_null_time:
+                stats_exprs.append(pl.col("time").is_null().sum().alias("n_null_time"))
+            stats = out.select(stats_exprs).collect()
+            n_total = stats["n_total"][0]
+            n_null_code = stats["n_null_code"][0] if drop_null_code else 0
+            n_null_time = stats["n_null_time"][0] if drop_null_time else 0
+            if n_null_time or n_null_code:
+                parts = []
+                if n_null_time:
+                    parts.append(
+                        f"{n_null_time}/{n_total} rows with null time "
+                        f"(unparsable or missing under the configured formats)"
+                    )
+                if n_null_code:
+                    count = f"{n_null_code}" if n_null_time else f"{n_null_code}/{n_total} rows"
+                    parts.append(f"{count} with null code")
+                logger.warning(f"`{source_block}`: dropped " + " and ".join(parts))
+
+        if drop_null_code:
             # A MEDS `code` may never be null. A bare-column code that is null, or an interpolated
-            # code with a null (un-coalesced) component, evaluates to a null code — drop those rows.
-            # Filter on the code expression itself (not the raw source columns) so rows the author
-            # rescued with a `??` coalesce are kept, since those never evaluate to null.
-            df = df.filter(exprs["code"].is_not_null())
+            # code with a null (un-coalesced) component, evaluates to a null code — drop those
+            # rows. Rows the author rescued with a `??` coalesce never evaluate to null, so they
+            # are kept.
+            out = out.filter(pl.col("code").is_not_null())
+        if drop_null_time:
+            out = out.filter(pl.col("time").is_not_null())
 
-        if not self.is_static:
-            # Filter on source columns being non-null/non-empty rather than on the parsed time
-            # expression, to avoid a polars predicate-pushdown bug where strptime(strict=True)
-            # is evaluated during parquet scanning before nulls are filtered.
-            if self.time_source_columns:
-                schema = df.collect_schema()
-                ts_filters = []
-                for c in sorted(self.time_source_columns):
-                    col_filter = pl.col(c).is_not_null()
-                    if schema.get(c) == pl.String or schema.get(c) is None:
-                        col_filter = col_filter & (pl.col(c) != pl.lit(""))
-                    ts_filters.append(col_filter)
-                df = df.filter(pl.all_horizontal(*ts_filters))
-            else:
-                df = df.filter(exprs["time"].is_not_null())
-
-        return df.select(**exprs).unique(maintain_order=True)
+        return out.unique(maintain_order=True)
 
 
 # ── TableConfig ──────────────────────────────────────────────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,11 +3,15 @@
 Happy-path extraction, parsing, validation, and source-column planning are demonstrated as
 doctests on :class:`EventConfig`, :class:`TableConfig`, and :class:`MessyConfig` in
 ``src/MEDS_extract/config.py`` — this file keeps only regression tests that are awkward to
-express as doctests: polars scan/dtype edge cases (null-heavy time columns, typed
-non-string time columns) and log-capture assertions (``sources:`` credential redaction).
+express as doctests: polars scan/dtype/plan-shape edge cases (null-heavy time columns,
+typed non-string time columns, cross-column time coalesces, predicate-pushdown safety) and
+log-capture assertions (drop-count warnings, ``sources:`` credential redaction).
 """
 
+import logging
+
 import polars as pl
+import pytest
 
 from MEDS_extract.config import EventConfig, MessyConfig
 
@@ -24,9 +28,10 @@ def _event(code: str, time: str | None = None, **extras) -> EventConfig:
 def test_scan_parquet_null_time_regression(tmp_path):
     """Regression: strptime on null-heavy time columns must not crash with scan_parquet.
 
-    Polars predicate pushdown can cause strptime(strict=True) to evaluate on empty
-    strings during parquet scanning. The null filter uses source columns, not the
-    parsed time expression, to sidestep that bug.
+    A strptime(strict=True) predicate pushed into the parquet scan evaluates on
+    validity-unmasked data, where null slots surface as "" and panic the process
+    (pola-rs/polars#28521). The null filter runs on the computed ``time`` column after
+    the select, which polars keeps above the scan, sidestepping that bug.
     """
     raw = pl.DataFrame({"subject_id": [1, 2, 3], "dod": ["2018-11-01T00:00:00", None, None]})
     fp = tmp_path / "test.parquet"
@@ -44,6 +49,129 @@ def test_non_string_time_column_regression():
     result = _event("MEDS_BIRTH", "$year_of_birth::year").extract(raw.lazy(), "patients/dob").collect()
     assert len(result) == 2
     assert set(result["subject_id"].to_list()) == {1, 3}
+
+
+def test_coalesce_across_columns_time_keeps_partial_rows(tmp_path):
+    """Regression: a time coalescing across columns must keep rows where only one column is set (#149).
+
+    The old raw-column null pre-filter ANDed ``is_not_null`` over ALL time source columns,
+    silently dropping every row where either column was null — on the MIMIC-IV demo this
+    lost 16 of 31 deaths (all out-of-hospital deaths, with ``dod`` but no admissions
+    ``deathtime``). The filter now runs on the computed ``time`` column, so coalesce
+    semantics apply. Verified both on an in-memory frame and through ``scan_parquet`` (the
+    path where a fallible predicate pushed into the scan would panic).
+    """
+    raw = pl.DataFrame(
+        {
+            "subject_id": [1, 2, 3],
+            "deathtime": ["2021-01-01 12:00:00", None, None],
+            "dod": ["2021-01-01", "2021-01-02", None],
+        }
+    )
+    ev = _event("MEDS_DEATH", 'coalesce($deathtime::?"%Y-%m-%d %H:%M:%S", $dod::?"%Y-%m-%d")')
+
+    result = ev.extract(raw.lazy(), "patients/death").collect()
+    assert set(result["subject_id"].to_list()) == {1, 2}
+
+    fp = tmp_path / "patients.parquet"
+    raw.write_parquet(fp)
+    result = ev.extract(pl.scan_parquet(fp, glob=False), "patients/death").collect()
+    assert set(result["subject_id"].to_list()) == {1, 2}
+
+
+def test_coalesce_nested_inside_strptime_time_keeps_partial_rows():
+    """A coalesce nested inside another node (``coalesce($a, $b)::?fmt``) also keeps partial rows (#149)."""
+    raw = pl.DataFrame(
+        {
+            "subject_id": [1, 2, 3],
+            "a": ["2021-01-01", None, None],
+            "b": ["2021-06-01", "2021-01-02", None],
+        }
+    )
+    ev = _event("MEDS_DEATH", 'coalesce($a, $b)::?"%Y-%m-%d"')
+    result = ev.extract(raw.lazy(), "patients/death").collect()
+    assert set(result["subject_id"].to_list()) == {1, 2}
+
+
+def test_strict_cast_empty_string_time_errors(tmp_path):
+    """A strict (``::"fmt"``) time cast over an unparsable ``""`` raises a clean error naming the value.
+
+    Previously such rows were silently pre-filtered away by the raw-column ``!= ""`` guard.
+    That guard is gone: strict means strict, and the failure is a normal
+    ``InvalidOperationError`` (not a pushdown panic), including through ``scan_parquet``.
+    Authors who want unparsable values dropped opt in with a lenient ``::?`` cast.
+    """
+    raw = pl.DataFrame({"subject_id": [1, 2], "dod": ["2018-11-01T00:00:00", ""]})
+    fp = tmp_path / "patients.parquet"
+    raw.write_parquet(fp)
+
+    ev = _event("MEDS_DEATH", '$dod::"%Y-%m-%dT%H:%M:%S"')
+    with pytest.raises(pl.exceptions.InvalidOperationError, match=r'\[""\]'):
+        ev.extract(pl.scan_parquet(fp, glob=False), "patients/death").collect()
+
+
+def test_lenient_unparsable_time_row_dropped():
+    """Regression: a lenient (``::?``) cast of an unparsable value must DROP the row.
+
+    On dev before this fix, junk rows slipped past the raw-column pre-filter (non-null,
+    non-empty) and leaked downstream with ``time=null`` — invalid MEDS output. The computed
+    ``time`` filter now drops them.
+    """
+    raw = pl.DataFrame({"subject_id": [1, 2, 3], "dod": ["2018-11-01T00:00:00", "not a date", None]})
+    ev = _event("MEDS_DEATH", '$dod::?"%Y-%m-%dT%H:%M:%S"')
+    result = ev.extract(raw.lazy(), "patients/death").collect()
+    assert set(result["subject_id"].to_list()) == {1}
+    assert result["time"].null_count() == 0
+
+
+def test_time_filter_not_pushed_into_scan(tmp_path):
+    """Plan shape: the computed time/code null filters must stay above the SELECT, not enter the scan.
+
+    Polars evaluates predicates pushed into ``scan_parquet`` on validity-unmasked data
+    (null slots of a String column surface as ``""``), so a fallible predicate there
+    panics on polars >= 1.28 (pola-rs/polars#28521). A pushed predicate shows up as a
+    ``SELECTION`` line inside the scan node of ``explain()``; assert it never appears and
+    that the filter sits above the select while column projection is still pushed down.
+    """
+    raw = pl.DataFrame({"subject_id": [1, 2], "dod": ["2018-11-01T00:00:00", None], "junk": ["x", "y"]})
+    fp = tmp_path / "patients.parquet"
+    raw.write_parquet(fp)
+
+    ev = _event("MEDS_DEATH", '$dod::"%Y-%m-%dT%H:%M:%S"')
+    plan = ev.extract(pl.scan_parquet(fp, glob=False), "patients/death").explain()
+
+    assert "SELECTION" not in plan  # no predicate inside the scan node
+    assert 'FILTER col("time").is_not_null()' in plan
+    assert plan.index('FILTER col("time")') < plan.index("Parquet SCAN")
+    assert "PROJECT 2/3 COLUMNS" in plan  # projection pushdown intact (junk not read)
+
+
+def test_extract_drop_accounting_warning(caplog):
+    """Dropped-row counts surface as one WARNING per event; zero-drop events stay silent (#26)."""
+    ev = _event("$name", '$ts::?"%Y-%m-%d"')
+
+    lossy = pl.DataFrame(
+        {
+            "subject_id": [1, 2, 3, 4],
+            "name": ["A", "B", None, "D"],
+            "ts": ["2021-01-01", "junk", "2021-01-03", None],
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="MEDS_extract.config"):
+        result = ev.extract(lossy.lazy(), "patients/e").collect()
+    assert set(result["subject_id"].to_list()) == {1}
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == [
+        "`patients/e`: dropped 2/4 rows with null time "
+        "(unparsable or missing under the configured formats) and 1 with null code"
+    ]
+
+    caplog.clear()
+    clean = pl.DataFrame({"subject_id": [1], "name": ["A"], "ts": ["2021-01-01"]})
+    with caplog.at_level(logging.WARNING, logger="MEDS_extract.config"):
+        result = ev.extract(clean.lazy(), "patients/e").collect()
+    assert len(result) == 1
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
 
 
 # ── Combined-MESSY ``sources:`` hygiene: credential redaction in logs ─────────────────────────────


### PR DESCRIPTION
## Silent data loss, and why the "clever" fix is the wrong one

`EventConfig.extract`'s non-static branch pre-filtered null times on the **raw source columns**, ANDing `is_not_null()` (plus `!= ""` for Strings) over ALL of `time_source_columns`. For a cross-column time coalesce —

```yaml
death:
  code: MEDS_DEATH
  time: coalesce($deathtime::?"%Y-%m-%d %H:%M:%S", $dod::?"%Y-%m-%d")
```

— that predicate is stricter than the expression it stands in for, and every row with either column null was silently dropped: **16 of 31 deaths** on the MIMIC-IV demo (all out-of-hospital deaths). #152 fixed this by deriving a structure-mirroring OR-of-ANDs pre-filter from the parsed expression tree — a shadow re-implementation of coalesce/strptime null semantics that must be kept in lock-step with every dftly node type, forever.

This PR supersedes #152 with the naive approach: **select first, then filter the computed `time`/`code` columns.**

### Why the pre-filter existed, and why naive is safe

The raw-column pre-filter was a workaround for a real polars hazard: a fallible predicate (strict cast/strptime) pushed into `scan_parquet` is evaluated on **validity-unmasked data** — null slots of a String column surface as `""` — so it **panics** (process abort, not a catchable error) on polars >= 1.28, and mis-evaluates silently before that. Filed upstream as pola-rs/polars#28521. That shape stays forbidden and regression-guarded (`test_scan_parquet_null_time_regression`).

But the workaround overshot: a predicate on the **computed** `time` column after a `select` provably stays above the SELECT boundary — verified on polars 1.26 → 1.43, and asserted in-suite via `explain()` (`test_time_filter_not_pushed_into_scan`: no `SELECTION` inside the scan node, `FILTER` above the select, projection pushdown intact). So the naive shape gets the expression's exact null semantics with no shadow interpreter. The pre-select `code` null filter is moved post-select too — it filtered on the raw code *expression*, the same latent scan-pushdown hazard if a code expression ever contains a strict cast.

### Semantic deltas vs. current `dev`

| Case | dev | this PR |
| --- | --- | --- |
| Cross-column time coalesce, one column null | row **silently dropped** (#149) | row kept, coalesce semantics |
| Lenient (`::?`) cast, unparsable junk value | row **leaked** downstream with `time=null` (invalid MEDS) | row dropped, counted in WARNING |
| Strict (`::"fmt"`) cast, `""` value | row silently pre-filtered | clean `InvalidOperationError` naming the value (deliberate: strict means strict; use `::?` to drop) |
| Strict cast, non-null junk (`"garbage"`) | error | error (unchanged, inherent) |
| Null time / null bare-column code | dropped silently | dropped, **counted** |

### Drop accounting (the long-open row-drop-visibility request, #26)

Per event, one extra lazy aggregation pass over the pre-filter frame computes `(n_total, n_null_code, n_null_time)` in a single `select(...).collect()`; when any drops occur the event logs one WARNING, e.g.

```
`patients/death`: dropped 2/4 rows with null time (unparsable or missing under the configured formats) and 1 with null code
```

Zero-drop events stay silent. Design choice: the eager stats pass inside `extract` was chosen over the lazier alternative (returning counts for a stage-side wrapper to log) because it keeps the accounting self-contained for every caller of the public `extract`/`extract_events` API, needs no API change, and the pass is projection-pruned to just the code/time source columns. Measured cost: full example test suite 18.94s vs 18.80s baseline — noise.

`MIGRATION.md` documents the strict-error / lenient-drop deltas and the multi-format same-column idiom (`coalesce($t::?"%m/%d/%y %H:%M:%S", $t::?"%m/%d/%y")`), which is now also an `extract` doctest.

Closes #149
Closes #26
Supersedes #152 (its cross-column and nested-coalesce regression tests are carried over; its `_time_null_prefilter`/`_non_null_source_filter` machinery is not needed and not ported).

## Test plan

- `test_coalesce_across_columns_time_keeps_partial_rows` — #149 repro (subjects 1, 2 kept; 3 dropped), in-memory and through `scan_parquet`; ported from #152.
- `test_coalesce_nested_inside_strptime_time_keeps_partial_rows` — `coalesce($a, $b)::?fmt` spelling; ported from #152.
- `test_scan_parquet_null_time_regression` — null-heavy strict scan must not panic; kept green throughout.
- `test_strict_cast_empty_string_time_errors` — strict + `""` → clean `InvalidOperationError` matching `[""]`, not a panic.
- `test_lenient_unparseable_time_row_dropped` — regression for the null-time leak.
- `test_time_filter_not_pushed_into_scan` — plan-shape guard via `explain()`.
- `test_extract_drop_accounting_warning` — exact WARNING text with counts; silent when zero drops.
- `EventConfig.extract` doctests updated; new multi-format coalesce doctest.
- Full suite: **107 passed, 1 deselected** (baseline 101). `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
