### PR TITLE
CI: wheel-install smoke, integration-job reruns, and a 3.13 test matrix row

### DIFF
--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -33,6 +33,18 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+      - name: Wheel smoke test
+        # Install the built wheel (not the source tree) into a clean venv and check the
+        # package imports and the console script resolves. Catches packaging regressions
+        # (missing entry points, missing package data, importable-vs-executable
+        # mismatches) that dev-environment tests cannot see (#90).
+        run: |
+          uv venv smoke-venv
+          source smoke-venv/bin/activate
+          uv pip install dist/*.whl
+          python -c "import MEDS_extract"
+          meds-extract-download --help
+
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
     if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
       fail-fast: false
 
     timeout-minutes: 30
@@ -55,7 +55,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
       fail-fast: false
 
     timeout-minutes: 30
@@ -120,8 +120,14 @@ jobs:
         # the default ``-m not integration`` from pyproject addopts. This covers the
         # full example walkthrough (``tests/test_example.py``) plus the live-PhysioNet
         # manifest smoke (``tests/test_download.py::test_physionet_...``).
+        # ``--reruns 2 --reruns-delay 60`` (pytest-rerunfailures) retries failures after
+        # a 60s pause — long enough to ride out a transient PhysioNet outage that
+        # exhausts the client's own ~65s tenacity retry budget (#111). Applied only to
+        # this integration invocation; unit-test jobs stay rerun-free so real flakes in
+        # our own code cannot hide.
         run: |
           uv run --extra download pytest -v -m integration \
+            --reruns 2 --reruns-delay 60 \
             --cov=src --cov-report=xml
 
       - name: Upload coverage to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dev = [
     "ruff",
     "pytest",
     "pytest-cov",
+    # Used only by the CI ``integration`` job (``--reruns 2 --reruns-delay 60``) to ride
+    # out transient PhysioNet outages (#111); unit-test invocations pass no ``--reruns``.
+    "pytest-rerunfailures",
     "meds_testing_helpers>=0.2.1",
     "yaml_to_disk>=0.0.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -726,6 +726,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "ruff" },
     { name = "yaml-to-disk" },
 ]
@@ -763,6 +764,7 @@ dev = [
     { name = "pre-commit", specifier = "<4" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "ruff" },
     { name = "yaml-to-disk", specifier = ">=0.0.4" },
 ]
@@ -1320,6 +1322,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/60/a90ca1cc6cffcb97b4260ed0ad2b7934b999d7c48abe4ea0840344862a3b/pytest_rerunfailures-16.4.tar.gz", hash = "sha256:8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11", size = 36635, upload-time = "2026-07-01T06:30:56.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/93/3cdcc4033444e822e01b573414b03fd37fd5533070c750477b8f5fa5224b/pytest_rerunfailures-16.4-py3-none-any.whl", hash = "sha256:f69b5beb39622c90d1e44bd945d826eff6db545dcf0b68f52b7e4ad15eaf6d6c", size = 16955, upload-time = "2026-07-01T06:30:55.333Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
CI/test-infrastructure changes only — no library code is touched (per the maintainer's test-code merge rule, this lands like test-only changes). Diff: two workflow files, a dev-group dependency, and its lockfile entry.

- **`python-build.yaml` — wheel smoke** (closes the #90 gap): the build job now installs the freshly built wheel (not the source tree) into a clean venv and runs `python -c "import MEDS_extract"` plus `meds-extract-download --help`. This catches missing/broken console-script entry points, missing package data, and importable-vs-executable mismatches that `uv sync` dev-environment tests can never see. The CLI's backends are imported lazily, so `--help` on the base wheel (no `[download]` extra) genuinely exercises entry-point resolution. Rehearsed locally: base-wheel venv install, import, and `--help` all pass.
- **`tests.yaml` — integration reruns** (mitigates #111): `pytest-rerunfailures` is added to the dev dependency group, and `--reruns 2 --reruns-delay 60` is applied **only** to the integration invocation. The production HTTP client already retries (~65s tenacity budget); the gap was the test/CI layer treating a longer PhysioNet outage as a red build. A 60s delay between reruns gives an outage up to ~4 minutes of total tolerance. Unit-test jobs deliberately get no reruns so real flakes in our own code cannot hide.
- **`tests.yaml` — Python 3.13**: added to both unit-test matrices (wheel verified working on 3.13; local 3.13 env import-checked).

Local: full suite green (`119 passed, 1 deselected` on the no-extras path; `156 passed, 2 deselected` with extras on the same base).

Closes #90. Refs #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)