### PR TITLE
Docs: 0.7.0 RC accuracy sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ standardized [MEDS format](https://medical-event-data-standard.github.io/). If y
 containing patient observations with timestamps, codes, and values, MEDS Extract can automatically convert
 your raw data into a compliant MEDS dataset in an efficient, scalable, and communicable way.
 
-> **Migrating from 0.6.x?** The 0.7.0 release is a breaking cut: MESSY config key names changed (unifying under `_defaults:` and `_table:`), null components in composite codes now drop rows unless you coalesce them, `codes.parquet` gained a deterministic stable schema, and `meds-extract-download` now handles raw-data fetching declaratively. See [**MIGRATION.md**](MIGRATION.md) for copy-pastable before/after snippets per change.
+> **Migrating from 0.6.x?** The 0.7.0 release is a breaking cut: MESSY config key names changed (unifying under `_defaults:` and `_table:`), null components in composite codes now drop rows unless you coalesce them, `codes.parquet` gained a deterministic stable schema, and `meds-extract-download` now handles raw-data fetching declaratively. See [**MIGRATION.md**](https://github.com/mmcdermott/MEDS_extract/blob/main/MIGRATION.md) for copy-pastable before/after snippets per change.
 
 ## 🚀 Quick Start
 
@@ -38,8 +38,8 @@ pip install MEDS-extract
 ```
 
 > [!NOTE]
-> The development line (towards **0.7.0**) pins `meds ~=0.4.0`, `MEDS-transforms >=0.6.7,<0.7`, and
-> `dftly >=0.3.0`, and supports Python ≥ 3.11. The MESSY config schema changed for 0.7.0 — subject IDs are
+> **0.7.0** pins `meds ~=0.4.0`, `MEDS-transforms >=0.6.7,<0.7`, and
+> `dftly >=0.5.0`, and supports Python ≥ 3.11. The MESSY config schema changed for 0.7.0 — subject IDs are
 > set in a `_defaults` block and table joins under `_table.join` — and the examples below use that new
 > syntax. Each `code`/`time`/property value is a [dftly](https://github.com/mmcdermott/dftly) expression
 > (see [Event Configuration Deep Dive](#-event-configuration-deep-dive)).
@@ -56,8 +56,8 @@ pip install MEDS-extract
 
 Ensure your data meets these requirements:
 
-- **File-based**: Data stored in `.csv`, `.csv.gz`, or `.parquet` files. These may be stored locally or in the
-    cloud, though intermediate processing currently must be done locally.
+- **File-based**: Data stored in `.csv`, `.csv.gz`, `.parquet`, or `.par` files. These may be stored locally
+    or in the cloud, though intermediate processing currently must be done locally.
 - **Comprehensive Rows**: Each file contains a dataframe structure where each row contains all required
     information to produce one or more MEDS events at full temporal granularity, without additional joining or
     merging.
@@ -68,6 +68,15 @@ Ensure your data meets these requirements:
 If these requirements are not met, you may need to perform some pre-processing steps to convert your raw data
 into an accepted format, though typically these are very minor (e.g., joining across a join key, converting
 time deltas into timestamps, etc.).
+
+#### Stage your raw data
+
+If your raw files live behind an HTTP endpoint, a PhysioNet release, a cloud bucket, or a local mirror, you
+can declare them in a `sources:` block and let the bundled `meds-extract-download` CLI stage them onto local
+disk (with checksum verification and resumable, rate-limit-polite transfers) instead of writing download
+scripts by hand. See the
+[download layer documentation](https://github.com/mmcdermott/MEDS_extract/blob/main/src/MEDS_extract/download/README.md)
+for the source types and CLI usage.
 
 ### 3. Create a MESSY file for your messy data!
 
@@ -386,7 +395,7 @@ are:
 > Quoting these expressions in YAML is optional for the forms shown here (the Quick Start above leaves them
 > unquoted and they parse fine); YAML only *requires* quoting when a value would otherwise be misread — e.g.
 > one beginning with `{`, `[`, or `*`. As a safe default, the shipped
-> [`example/messy.yaml`](./example/messy.yaml) single-quotes the f-strings and the `::`/`as` casts
+> [`example/messy.yaml`](https://github.com/mmcdermott/MEDS_extract/blob/main/example/messy.yaml) single-quotes the f-strings and the `::`/`as` casts
 > (e.g. `code: 'f"EYE_COLOR//{$eye_color}"'`, `time: '$dob::"%Y-%m-%dT%H:%M:%S"'`) while leaving bare
 > literals (`MEDS_BIRTH`) and plain `$column` references unquoted.
 
@@ -447,7 +456,8 @@ A MEDS `code` may never be null, and string interpolation **null-propagates**: i
 component is null, the whole `code` becomes null and that row is **dropped**. To keep such rows, give
 the component a fallback with dftly's `??` (coalesce) operator — single-quote a literal fallback
 *inside* the double-quoted f-string. Whether a missing component drops the row or is filled in is
-your choice, made per component:
+your choice, made per component. Drops are never silent: each event logs a WARNING summarizing how
+many rows were dropped for a null `code` and how many for a null `time`:
 
 ```python
 >>> import polars as pl
@@ -1115,21 +1125,22 @@ The `metadata/codes.parquet` file also includes:
 ### Performance Optimization
 
 - **Manually pre-shard your input data** if you have very large files. You can then configure your pipeline to
-    skip the row-sharding stage and start directly with the `convert_to_subject_sharded` stage.
-- **Use parallel processing** for faster extraction via the typical MEDs-Transforms parallelization
+    skip the row-sharding stage (`shard_events`) and start directly with the `split_and_shard_subjects` stage,
+    which builds the `.shards.json` subject-shard map that all downstream stages require.
+- **Use parallel processing** for faster extraction via the typical MEDS-Transforms parallelization
     options.
 
 ## Future Roadmap
 
-1. Incorporating more of the pre-MEDS and joining logic that is common into this repository.
+1. Incorporating more of the common pre-MEDS logic into this repository (table joins — including
+    aggregated joins — landed in 0.7.0).
 2. Automatic support for running in "demo mode" for testing and validation.
 3. Better examples and documentation for common use cases, including incorporating data cleaning stages
     after the core extraction.
-4. Providing a default runner or multiple default pipeline files for user convenience.
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for more details.
+We welcome contributions! Please see our [Contributing Guide](https://github.com/mmcdermott/MEDS_extract/blob/main/CONTRIBUTING.md) for more details.
 
 ## 📄 License
 
@@ -1158,4 +1169,4 @@ If you use MEDS Extract in your research, please cite:
 
 ______________________________________________________________________
 
-**Ready to standardize your EHR data?** Start with our [Quick Start](#-quick-start) guide or explore our [example](./example/) directory for a real, runnable configuration.
+**Ready to standardize your EHR data?** Start with our [Quick Start](#-quick-start) guide or explore our [example](https://github.com/mmcdermott/MEDS_extract/tree/main/example) directory for a real, runnable configuration.

--- a/docs/ingestion_pathways.md
+++ b/docs/ingestion_pathways.md
@@ -14,15 +14,15 @@ safe if we're precise about the file-layout contracts.
 
 ## Stages at a glance
 
-| Stage                                           | Consumes                                                 | Produces                                                                                           | File reader                                                                                                                   |
-| ----------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `shard_events`                                  | raw user data (`parquet` / `par` / `csv` / `csv.gz`)     | row-subsharded parquet                                                                             | `MEDS_extract.io.resolve_source_files` + `scan_source` via `messy_cfg.needed_source_columns()`                                |
-| `split_and_shard_subjects`                      | row-subsharded parquet                                   | JSON shards map (no parquet output)                                                                | `TableConfig.scan(dir)` — uses `resolve_source_files`, applies joins                                                          |
-| `convert_to_subject_sharded`                    | row-subsharded parquet + shards map                      | per-`shard` subject-sharded copy of the same tables (same schema as input, just filtered by shard) | `TableConfig.source_files(dir)` + `scan_source`, applies joins via `JoinConfig.apply`                                         |
-| `convert_to_MEDS_events`                        | subject-sharded source tables (output of previous stage) | same layout, same paths — just the row *schema* changes to MEDS events                             | `TableConfig.source_files(dir / shard)` + `scan_source`; **no join** (already materialized upstream)                          |
-| `extract_code_metadata`                         | raw metadata files + MEDS events                         | `codes.parquet` per worker, then a merged `codes.parquet`                                          | `resolve_source_files` + `scan_source` for metadata files; direct `rglob("*.parquet")` for event files (internal layout only) |
-| `merge_to_MEDS_cohort`                          | per-`(shard, prefix)` MEDS events                        | one MEDS parquet **per shard** (e.g. `train/0.parquet`), across all table sources                  | its own `merge_subdirs_and_sort` helper — reads `{sp_dir}/{prefix}.parquet` by explicit prefix list                           |
-| `finalize_MEDS_data` / `finalize_MEDS_metadata` | per-shard MEDS parquet                                   | MEDS-schema-validated parquet                                                                      | delegates to `MEDS_transforms`, no in-repo file I/O                                                                           |
+| Stage                                           | Consumes                                                 | Produces                                                                                                            | File reader                                                                                                                   |
+| ----------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `shard_events`                                  | raw user data (`parquet` / `par` / `csv` / `csv.gz`)     | row-subsharded parquet                                                                                              | `MEDS_extract.io.resolve_source_files` + `scan_source` via `messy_cfg.needed_source_columns()`                                |
+| `split_and_shard_subjects`                      | row-subsharded parquet                                   | JSON shards map (no parquet output)                                                                                 | `TableConfig.scan(dir)` — uses `resolve_source_files`, applies joins                                                          |
+| `convert_to_subject_sharded`                    | row-subsharded parquet + shards map                      | per-`shard` subject-sharded copy of the same tables (same schema as input, just filtered by shard)                  | `TableConfig.source_files(dir)` + `scan_source`, applies joins via `JoinConfig.apply`                                         |
+| `convert_to_MEDS_events`                        | subject-sharded source tables (output of previous stage) | same layout, same paths — just the row *schema* changes to MEDS events                                              | `TableConfig.source_files(dir / shard)` + `scan_source`; **no join** (already materialized upstream)                          |
+| `extract_code_metadata`                         | raw metadata files + MEDS events                         | one partial `{prefix}_{entry}.parquet` per `(metadata prefix, config entry)` pair, then one reduced `codes.parquet` | `resolve_source_files` + `scan_source` for metadata files; direct `rglob("*.parquet")` for event files (internal layout only) |
+| `merge_to_MEDS_cohort`                          | per-`(shard, prefix)` MEDS events                        | one MEDS parquet **per shard** (e.g. `train/0.parquet`), across all table sources                                   | its own `merge_subdirs_and_sort` helper — reads `{sp_dir}/{prefix}.parquet` by explicit prefix list                           |
+| `finalize_MEDS_data` / `finalize_MEDS_metadata` | per-shard MEDS parquet                                   | MEDS-schema-validated parquet                                                                                       | delegates to `MEDS_transforms`, no in-repo file I/O                                                                           |
 
 Three things worth calling out, because they're easy to get wrong:
 
@@ -174,7 +174,7 @@ raw_data/
   medication_classes.csv
 ```
 
-Each top-level prefix in `event_cfg.yaml` (and each join target) resolves to
+Each top-level prefix in `example/messy.yaml` (and each join target) resolves to
 a single bare file — layout (a) above. `stays` is a join target (not a
 top-level table), but it still appears in `needed_source_columns()` because
 `labs_vitals` pulls columns from it.
@@ -264,7 +264,7 @@ data/
   train/1/...
   tuning/0/...
   held_out/0/...
-  event_conversion_config.yaml              ← verbatim copy of source config
+  event_conversion_config.yaml              ← copy of source config (reserved `sources:` blocks redacted)
 ```
 
 **Same paths as the previous stage.** This stage is a schema-only

--- a/example/README.md
+++ b/example/README.md
@@ -92,13 +92,13 @@ intentionally not committed — it carries a wall-clock timestamp.
 
 Contents of each file:
 
-| File                                     | What's in it                                                                                                                |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `data/{train,tuning,held_out}/0.parquet` | Final MEDS event parquets — one row per event, schema per the MEDS spec (`subject_id`, `time`, `code`, `numeric_value`, …). |
-| `metadata/codes.parquet`                 | One row per distinct code observed in the data: `code`, `description`, `code_template`.                                     |
-| `metadata/subject_splits.parquet`        | `subject_id` → `split` mapping.                                                                                             |
-| `metadata/.shards.json`                  | `shard_name` (e.g. `"train/0"`) → `[subject_ids]` mapping — the upstream shard assignment used across stages.               |
-| `metadata/dataset.json`                  | Dataset name + version + ETL info + `created_at` timestamp.                                                                 |
+| File                                     | What's in it                                                                                                                                     |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `data/{train,tuning,held_out}/0.parquet` | Final MEDS event parquets — one row per event, schema per the MEDS spec (`subject_id`, `time`, `code`, `numeric_value`, …).                      |
+| `metadata/codes.parquet`                 | One row per observed code that matched a `_metadata` entry (an inner join — unmatched codes are absent): `code`, `description`, `code_template`. |
+| `metadata/subject_splits.parquet`        | `subject_id` → `split` mapping.                                                                                                                  |
+| `metadata/.shards.json`                  | `shard_name` (e.g. `"train/0"`) → `[subject_ids]` mapping — the upstream shard assignment used across stages.                                    |
+| `metadata/dataset.json`                  | Dataset name + version + ETL info + `created_at` timestamp.                                                                                      |
 
 ## Automated check
 

--- a/src/MEDS_extract/convert_to_subject_sharded/examples/join/README.md
+++ b/src/MEDS_extract/convert_to_subject_sharded/examples/join/README.md
@@ -1,4 +1,4 @@
 Demonstrates `_table.join` — the `vitals` table has no `subject_id` column of its own, so
 `_table.join.stays.key: stay_id, cols: [subject_id]` brings in the `subject_id` from the
-`stays` table via an inner join on `stay_id`. The stage materializes the joined frame, filters
+`stays` table via a left join on `stay_id`. The stage materializes the joined frame, filters
 to the split's subjects, and writes per-subject shards.

--- a/src/MEDS_extract/finalize_MEDS_metadata/examples/default/README.md
+++ b/src/MEDS_extract/finalize_MEDS_metadata/examples/default/README.md
@@ -1,8 +1,8 @@
 Takes the cohort's aggregated `metadata/codes.parquet` plus the `metadata/.shards.json` split
 map and produces three schema-compliant MEDS metadata files:
 
-- `metadata/codes.parquet` — validated against the MEDS code metadata schema (mandatory `code`,
-    `description`, `parent_codes` columns).
+- `metadata/codes.parquet` — validated against the MEDS code metadata schema (required `code`
+    column; `description` / `parent_codes` typed to the schema when present, not added if absent).
 - `metadata/subject_splits.parquet` — derived from the shards map (`Int64 subject_id`, `str split`).
 - `metadata/dataset.json` — dataset-level info (name, version, ETL version, MEDS version,
     and a `created_at` timestamp; not diffed by the stage test since it changes each run).

--- a/src/MEDS_extract/finalize_MEDS_metadata/finalize_MEDS_metadata.py
+++ b/src/MEDS_extract/finalize_MEDS_metadata/finalize_MEDS_metadata.py
@@ -31,10 +31,11 @@ def main(cfg: DictConfig):
     """Writes out schema compliant MEDS metadata files for the extracted dataset.
 
     In particular, this script ensures that
-    (1) a compliant `metadata/codes.parquet` file exists that has the mandatory columns
-      - `code` (string)
-      - `description` (string)
-      - `parent_codes` (list of strings)
+    (1) a `metadata/codes.parquet` file exists, validated against the MEDS code metadata schema:
+      - `code` (string) is required
+      - `description` (string) and `parent_codes` (list of strings) are typed to the schema when
+        present in the input, but are not added when absent (only the empty-input case emits the
+        full three-column schema)
     (2) a `metadata/dataset.json` file exists that has the keys
       - `dataset_name` (string)
       - `dataset_version` (string)

--- a/src/MEDS_extract/io.py
+++ b/src/MEDS_extract/io.py
@@ -91,8 +91,6 @@ def scan_source(
         │ 2          ┆ 78  │
         └────────────┴─────┘
 
-        A prefix may mix formats across its chunk files (e.g. one ``.csv`` and
-        one ``.parquet`` chunk). Format dispatch — including which kwargs each
         A multi-file scan must be format-homogeneous — mixing csv-family and
         parquet-family chunks in one source is a config error rather than a silent
         dtype coercion (typed parquet + all-String csv would otherwise unify through
@@ -215,7 +213,8 @@ def resolve_source_files(dir: Path | UPath, prefix: str) -> list[Path | UPath]:
 
         **Sub-sharded directory layout** — many chunks per prefix, typical
         output of ``shard_events``. All files under ``{prefix}/`` are
-        returned sorted by name, and may mix formats:
+        returned sorted by name; the chunks must share one format family
+        (csv-family or parquet-family — ``scan_source`` rejects a mix):
 
         >>> with yaml_disk('''
         ... vitals/[0-2).parquet:

--- a/src/MEDS_extract/split_and_shard_subjects/split_and_shard_subjects.py
+++ b/src/MEDS_extract/split_and_shard_subjects/split_and_shard_subjects.py
@@ -219,7 +219,7 @@ def main(cfg: DictConfig):
             exceed this number. Instead, the number of shards necessary to include all subjects in a split
             such that no shard exceeds this number will be calculated, then the subjects will be evenly,
             randomly split amongst those shards so that all shards within a split have approximately the same
-            number of patietns.
+            number of patients.
         cfg.stage_cfg.external_splits_json_fp: The path to a json file containing any
             pre-defined splits for specialty held-out test sets beyond the IID held out set that will be
             produced (e.g., for prospective datasets, etc.).


### PR DESCRIPTION
Docs/comments/docstrings-only accuracy pass over the 0.7.0 RC. Fixes:

- **README**: dftly pin `>=0.3.0` → `>=0.5.0`; "development line (towards 0.7.0) pins" → "0.7.0 pins"; add `.par` to accepted formats; pre-sharded entry point corrected to `split_and_shard_subjects` (it builds the `.shards.json` map downstream stages require), not `convert_to_subject_sharded`; document the per-event WARNING with null-code/null-time drop counts; new "Stage your raw data" Quick Start step linking the `meds-extract-download` layer docs; MIGRATION.md/CONTRIBUTING.md/example links made absolute GitHub URLs (they 404 on the docs site); roadmap pruned/reworded for items delivered this release (aggregated joins, packaged default pipeline); "MEDs-Transforms" typo.
- **example/README**: `codes.parquet` is one row per observed code that matched a `_metadata` entry (inner join — unmatched codes absent).
- **io.py**: `resolve_source_files` docstring — chunks must share one format family, not "may mix formats"; deleted two garbled leftover sentences from the pre-mixed-format-error docstring.
- **convert_to_subject_sharded join example README**: `_table.join` is a left join, not inner.
- **docs/ingestion_pathways**: config copy has reserved `sources:` blocks redacted (not verbatim); `event_cfg.yaml` → `example/messy.yaml`; `extract_code_metadata` produces per-`(prefix, entry)` partials then one reduced `codes.parquet`.
- **split_and_shard_subjects**: "patietns" typo.
- **finalize_MEDS_metadata docstring + example README**: describe actual column behavior (`description`/`parent_codes` typed when present, not added when absent). If #160 merges, this claim should be restored to the "ensures" language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)