### PR TITLE
RC-review cleanup bundle: dead code, cost gating, bounds, and API hygiene

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
   "numpy",
   "meds~=0.4.0",
   "MEDS-transforms>=0.6.7,<0.7",
-  "universal_pathlib",
-  "dftly>=0.5.0",
+  "universal_pathlib>=0.3.10",
+  "dftly>=0.5.0,<0.6",
 ]
 
 [dependency-groups]

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -1218,7 +1218,7 @@ class MessyConfig:
         ['MRN']
         >>> sorted(cfg.tables[1].subject_id_node.referenced_columns)
         ['patient_id']
-        >>> [e.name for e in cfg.iter_events()]
+        >>> [e.name for t in cfg.tables for e in t.events]
         ['dob', 'lab']
     """
 
@@ -1397,10 +1397,6 @@ class MessyConfig:
 
     def iter_tables(self) -> Iterator[TableConfig]:
         return iter(self.tables)
-
-    def iter_events(self) -> Iterator[EventConfig]:
-        for table in self.tables:
-            yield from table.events
 
     def shuffled_tables(self, seed: int | None = None) -> list[TableConfig]:
         """Return tables in randomized order.

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -581,13 +581,6 @@ class EventConfig:
         return frozenset(self.columns["code"].referenced_columns)
 
     @cached_property
-    def time_source_columns(self) -> frozenset[str]:
-        """Source columns referenced by the ``time`` expression (empty if static)."""
-        if self.is_static:
-            return frozenset()
-        return frozenset(self.columns["time"].referenced_columns)
-
-    @cached_property
     def referenced_columns(self) -> frozenset[str]:
         """All source columns referenced by any output column expression.
 

--- a/src/MEDS_extract/download/backends/http.py
+++ b/src/MEDS_extract/download/backends/http.py
@@ -185,7 +185,7 @@ class HTTPSource(Source):
         return Retrying(
             stop=stop_after_attempt(self._max_attempts),
             wait=self._retry_wait,
-            retry=retry_if_exception(self._should_retry_stream),
+            retry=retry_if_exception(self._should_retry),
             before_sleep=before_sleep_log(logger, logging.WARNING),
             reraise=True,
         )
@@ -249,7 +249,7 @@ class HTTPSource(Source):
         self._retrying()(self._resumable_stream, self._client, source_path, target)
 
     @classmethod
-    def _should_retry_stream(cls, exc: BaseException) -> bool:
+    def _should_retry(cls, exc: BaseException) -> bool:
         """Retry transient transport errors and 5xx responses; never 4xx.
 
         Shared by both request paths: ``_get`` raises only on 5xx inside its

--- a/src/MEDS_extract/download/cli.py
+++ b/src/MEDS_extract/download/cli.py
@@ -130,7 +130,14 @@ def main(cfg: DictConfig) -> None:
             if bucket_node is not None:
                 sources_dict[bucket] = OmegaConf.to_container(bucket_node, resolve=True)
 
-    sources = sources_from_spec({"sources": sources_dict}, key=cfg.key)
+    # Spec-shape errors (missing/unknown ``type:``, bad backend kwargs) are user config
+    # mistakes: log them and exit 1, mirroring the manifest-validation handling below,
+    # rather than dumping a raw traceback through Hydra.
+    try:
+        sources = sources_from_spec({"sources": sources_dict}, key=cfg.key)
+    except (TypeError, ValueError):
+        logger.exception(f"Could not construct sources from the spec at {spec_fp}")
+        sys.exit(1)
 
     if not sources:
         logger.warning(f"No sources resolved for key={cfg.key!r} in {spec_fp}. Nothing to do.")

--- a/src/MEDS_extract/download/cli.py
+++ b/src/MEDS_extract/download/cli.py
@@ -135,8 +135,8 @@ def main(cfg: DictConfig) -> None:
     # rather than dumping a raw traceback through Hydra.
     try:
         sources = sources_from_spec({"sources": sources_dict}, key=cfg.key)
-    except (TypeError, ValueError):
-        logger.exception(f"Could not construct sources from the spec at {spec_fp}")
+    except (TypeError, ValueError) as e:
+        logger.error(f"Could not construct sources from the spec at {spec_fp}: {e}")
         sys.exit(1)
 
     if not sources:
@@ -168,8 +168,8 @@ def main(cfg: DictConfig) -> None:
         # source-side hashing.)
         try:
             validate_unique_destinations(sources)
-        except ValueError:
-            logger.exception("Source manifests failed validation")
+        except ValueError as e:
+            logger.error(f"Source manifests failed validation: {e}")
             sys.exit(1)
 
         all_ok = True

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -7,6 +7,7 @@ import time
 from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 from dftly import Parser
@@ -284,7 +285,9 @@ def resolve_match_columns(event_cfg: dict) -> list[str]:
     return match_on
 
 
-def extract_metadata(metadata_df: pl.LazyFrame, event_cfg: dict[str, str | None]) -> pl.LazyFrame:
+def extract_metadata(
+    metadata_df: pl.LazyFrame | pl.DataFrame, event_cfg: dict[str, Any]
+) -> pl.LazyFrame | pl.DataFrame:
     """Extracts a single metadata dataframe block for an event configuration from the raw metadata.
 
     Every metadata join is a component join, so this function never assembles a ``code``
@@ -296,9 +299,10 @@ def extract_metadata(metadata_df: pl.LazyFrame, event_cfg: dict[str, str | None]
     full codes.
 
     Args:
-        metadata_df: The raw metadata DataFrame. Mandatory columns are determined by the `event_cfg`
-            configuration dictionary.
-        event_cfg: A dictionary containing the configuration for the event. This must contain the critical
+        metadata_df: The raw metadata frame (lazy or eager; the output matches the input's
+            laziness). Mandatory columns are determined by the `event_cfg` configuration dictionary.
+        event_cfg: A dictionary containing the configuration for the event. Not mutated (values may
+            be nested `_metadata` mappings, not just strings). This must contain the critical
             `"code"` key alongside a mandatory `_metadata` block, which must contain some columns that should
             be extracted from the metadata to link to the code.
             The `"code"`` value is a dftly expression: string literals must be quoted
@@ -493,8 +497,6 @@ def extract_metadata(metadata_df: pl.LazyFrame, event_cfg: dict[str, str | None]
         │ D    ┆ 3             ┆ f"FOO//{$code}//{$code_modifie… ┆ null        ┆ ["expanded form"]   │
         └──────┴───────────────┴─────────────────────────────────┴─────────────┴─────────────────────┘
     """
-    event_cfg = copy.deepcopy(event_cfg)
-
     if not isinstance(event_cfg, dict | DictConfig):
         raise TypeError(f"Event configuration must be a dictionary. Got: {type(event_cfg)} {event_cfg}.")
 

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -132,6 +132,43 @@ def validate_event_data_schema(data_schema: pl.Schema) -> bool:
     return True
 
 
+def build_code_component_map(all_data: pl.LazyFrame) -> pl.DataFrame:
+    """Materialize the code-components map every reducer-side metadata join runs against.
+
+    One row per distinct (full code, components, declaring source block): the full code
+    under the reserved collision-proof :data:`FULL_CODE_COL` alias, the unnested
+    component columns, and the declaring ``source_block`` so each join attaches only to
+    its own event's codes.
+
+    This is a full-dataset scan + unique + collect — the single most expensive step of
+    the stage outside the map compute itself — and its output is consumed only by the
+    reduction, so :func:`main` calls it exclusively in worker 0 after the map phase.
+
+    Examples:
+        >>> all_data = pl.LazyFrame({
+        ...     "code": ["CHART//1", "CHART//1", "LAB//1"],
+        ...     "code_components": [{"itemid": "1"}, {"itemid": "1"}, {"itemid": "1"}],
+        ...     "source_block": ["chartevents/chart", "chartevents/chart", "labevents/lab"],
+        ... })
+        >>> build_code_component_map(all_data).sort("__meds_full_code")
+        shape: (2, 3)
+        ┌──────────────────┬────────┬───────────────────┐
+        │ __meds_full_code ┆ itemid ┆ source_block      │
+        │ ---              ┆ ---    ┆ ---               │
+        │ str              ┆ str    ┆ str               │
+        ╞══════════════════╪════════╪═══════════════════╡
+        │ CHART//1         ┆ 1      ┆ chartevents/chart │
+        │ LAB//1           ┆ 1      ┆ labevents/lab     │
+        └──────────────────┴────────┴───────────────────┘
+    """
+    return (
+        all_data.select(pl.col("code").alias(FULL_CODE_COL), "code_components", SOURCE_BLOCK_COL)
+        .unique()
+        .collect()
+        .unnest("code_components")
+    )
+
+
 def _parse_code(code_value: str | NodeBase) -> tuple[NodeBase, str]:
     """Return the parsed dftly node and template string for a ``code`` config value.
 
@@ -651,18 +688,11 @@ def main(cfg: DictConfig):
     all_event_dfs = [pl.scan_parquet(fp, glob=False) for fp in event_parquet_files]
     all_data = pl.concat(all_event_dfs, how="diagonal_relaxed")
 
-    # Build the code_components map every metadata join runs against: full code (under the
-    # reserved collision-proof alias), unnested component columns, and the declaring
-    # source_block so each join attaches only to its own event's codes.
-    if validate_event_data_schema(all_data.collect_schema()):
-        code_component_map = (
-            all_data.select(pl.col("code").alias(FULL_CODE_COL), "code_components", SOURCE_BLOCK_COL)
-            .unique()
-            .collect()
-            .unnest("code_components")
-        )
-    else:
-        code_component_map = None
+    # Schema validation runs in EVERY worker (it's a cheap metadata-only check) so a
+    # pre-0.7 events layout fails loudly everywhere — but the component map itself is
+    # only materialized by the reducer (worker 0) below: it is a full-dataset
+    # scan/unique/collect that the N-1 map-only workers never use.
+    has_code_components = validate_event_data_schema(all_data.collect_schema())
 
     all_out_fps = []
     # Deterministic reduction order: partial files are produced in each worker's
@@ -720,11 +750,17 @@ def main(cfg: DictConfig):
 
     logger.info("Extracted metadata for all events. Merging.")
 
-    if cfg.worker != 0:  # pragma: no cover
+    if cfg.worker != 0:
         logger.info("Code metadata extraction completed. Exiting")
         return
 
     logger.info("Starting reduction process")
+
+    # Build the code_components map every metadata join runs against: full code (under
+    # the reserved collision-proof alias), unnested component columns, and the declaring
+    # source_block so each join attaches only to its own event's codes. Reducer-only:
+    # this is the one full-dataset collect in the stage.
+    code_component_map = build_code_component_map(all_data) if has_code_components else None
 
     wait_for_complete_parquets(all_out_fps, polling_time=cfg.polling_time)
 

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -800,7 +800,10 @@ def main(cfg: DictConfig):
     else:
         reduced = pl.concat(expanded_dfs, how="diagonal_relaxed").unique(maintain_order=True)
 
-    join_cols = ["code", *cfg.get("code_modifier_cols", [])]
+    # The reduction is keyed on the assembled MEDS code alone: component-level
+    # narrowing already happened in the expansion join above, so by this point
+    # every metadata row is fully resolved to a full code.
+    join_cols = ["code"]
     reduced_cols = reduced.collect_schema().names()
     metadata_cols = [c for c in reduced_cols if c not in join_cols]
 

--- a/tests/test_download_fsspec.py
+++ b/tests/test_download_fsspec.py
@@ -364,8 +364,8 @@ def test_cli_common_bucket_interpolation_still_resolved(tmp_path: Path):
 
 
 def test_cli_cross_source_collision_exits_before_any_fetch(tmp_path: Path):
-    """Two sources listing the same rel_path into one shared raw_input_dir is a config error caught up-front —
-    not a mid-download race/FileExistsError."""
+    """Two sources listing the same rel_path into one shared raw_input_dir is a config error caught up-front
+    — not a mid-download race/FileExistsError."""
     m1 = tmp_path / "m1"
     m2 = tmp_path / "m2"
     for m in (m1, m2):
@@ -388,8 +388,8 @@ def test_cli_cross_source_collision_exits_before_any_fetch(tmp_path: Path):
 
 
 def test_cli_fail_fast_skips_remaining_sources(tmp_path: Path):
-    """With the default ``continue_on_error=false``, a failing source stops the whole run — later sources are
-    not attempted.
+    """With the default ``continue_on_error=false``, a failing source stops the whole run — later sources
+    are not attempted.
 
     With ``continue_on_error=true``, they are.
     """

--- a/tests/test_download_fsspec.py
+++ b/tests/test_download_fsspec.py
@@ -239,6 +239,23 @@ def test_cli_unknown_key_exits_nonzero(tmp_path: Path):
     assert not raw.exists()  # nothing was staged
 
 
+def test_cli_malformed_source_entry_logs_and_exits_nonzero(tmp_path: Path):
+    """A malformed ``sources:`` entry (here an unknown ``type:``) is a user config error:
+
+    the CLI must log it and exit non-zero via the same log-and-``sys.exit(1)`` path as
+    manifest-validation failures — naming the spec file and surfacing the underlying
+    spec error — rather than letting the raw exception propagate through Hydra.
+    """
+    result, raw = _run_cli(tmp_path, "sources:\n  dataset:\n    - type: s3\n      root: /x\n")
+    assert result.returncode != 0, f"expected failure exit:\n{result.stdout}\n{result.stderr}"
+    combined = result.stdout + result.stderr
+    # Pin the failure to the intended cause: the CLI's own log line plus the
+    # underlying spec error, so an unrelated crash can't satisfy this vacuously.
+    assert "Could not construct sources" in combined
+    assert "Unknown source type" in combined
+    assert not raw.exists()  # nothing was staged
+
+
 def test_cli_no_sources_block_warns_and_exits_zero(tmp_path: Path):
     """A spec with no ``sources:`` block at all is a legitimately download-free ETL:
 

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -58,6 +58,7 @@ def _run_ecm_scenario(
     raw_files: dict[str, str | pl.DataFrame],
     existing_codes: pl.DataFrame | None = None,
     description_separator: str = "\n",
+    worker: int = 0,
 ) -> pl.DataFrame | None:
     """Run the extract_code_metadata stage over synthetic event shards and raw metadata files.
 
@@ -66,8 +67,10 @@ def _run_ecm_scenario(
     ``raw_files`` maps raw metadata file paths (which may include subdirectories) to either
     text content (written verbatim) or a DataFrame (written as parquet). ``existing_codes``,
     when given, is written as a pre-existing ``metadata/codes.parquet`` for the reducer to
-    merge with. Returns the reduced ``codes.parquet`` as a DataFrame, or ``None`` if the
-    stage exited without writing one (the no-metadata-blocks early return).
+    merge with. ``worker`` selects the MR worker id (worker 0 is the reducer; any other id
+    runs the map phase only). Returns the reduced ``codes.parquet`` as a DataFrame, or
+    ``None`` if the stage exited without writing one (the no-metadata-blocks early return
+    or a non-reducer worker).
     """
     from MEDS_extract.extract_code_metadata.extract_code_metadata import main as ecm_stage
 
@@ -108,6 +111,7 @@ def _run_ecm_scenario(
 
     cfg = _make_cfg(
         {
+            "worker": worker,
             "input_dir": str(raw_dir),
             "stage_cfg": {
                 "data_input_dir": str(root / "events"),
@@ -1366,3 +1370,50 @@ def test_atomic_write_parquet_never_exposes_partial_state(tmp_path):
     # And the .tmp staging file must not leak into the final tree.
     leftover = list(tmp_path.glob("*.tmp"))
     assert not leftover, f"unexpected .tmp leftovers: {leftover}"
+
+
+def test_component_map_built_only_by_the_reducer_worker(monkeypatch):
+    """Non-zero workers never materialize the code-component map (map-phase cost gate).
+
+    The component map is a full-dataset scan/unique/collect consumed exclusively by
+    worker 0's reduction, so the N-1 map-only workers must not pay for building it.
+    ``build_code_component_map`` is spied via monkeypatch: a worker-1 run must not call
+    it (and must not write ``codes.parquet``), while the subsequent worker-0 run over
+    the same layout calls it exactly once and reduces normally.
+    """
+    from MEDS_extract.extract_code_metadata import extract_code_metadata as ecm
+
+    calls = []
+    real_build = ecm.build_code_component_map
+
+    def spying_build(all_data):
+        calls.append(1)
+        return real_build(all_data)
+
+    monkeypatch.setattr(ecm, "build_code_component_map", spying_build)
+
+    messy = """\
+data:
+  measurement:
+    code: $lab_code
+    _metadata:
+      lab_meta:
+        description: title
+"""
+    scenario_kwargs = {
+        "event_frames": {"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
+        "raw_files": {"lab_meta.csv": "lab_code,title\nHR,Heart Rate\n"},
+    }
+
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(Path(d), messy, worker=1, **scenario_kwargs)
+    assert codes_df is None, "A non-reducer worker must not write codes.parquet."
+    assert calls == [], (
+        "Worker 1 built the code-component map: the full-dataset collect must be "
+        "gated behind the worker-0 reduction."
+    )
+
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(Path(d), messy, worker=0, **scenario_kwargs)
+    assert calls == [1], f"Worker 0 should build the map exactly once; got {len(calls)} calls."
+    assert codes_df.filter(pl.col("code") == "HR")["description"].to_list() == ["Heart Rate"]

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dftly", specifier = ">=0.5.0" },
+    { name = "dftly", specifier = ">=0.5.0,<0.6" },
     { name = "httpx", marker = "extra == 'download'", specifier = ">=0.27" },
     { name = "hydra-core" },
     { name = "hydra-joblib-launcher", marker = "extra == 'local-parallelism'" },
@@ -753,7 +753,7 @@ requires-dist = [
     { name = "polars", specifier = ">=1.26" },
     { name = "pyarrow" },
     { name = "tenacity", marker = "extra == 'download'", specifier = ">=8" },
-    { name = "universal-pathlib" },
+    { name = "universal-pathlib", specifier = ">=0.3.10" },
 ]
 provides-extras = ["local-parallelism", "slurm-parallelism", "download"]
 


### PR DESCRIPTION
Bundle of small code cleanups queued from the 0.7.0 RC design review, **one commit per finding** for easy per-item review (and easy dropping of any item you disagree with). Opened for maintainer review — not intended for auto-merge.

| Commit | Finding | Rationale |
|---|---|---|
| `9908e20` | Delete dead `EventConfig.time_source_columns` | Zero callers after #154 moved the computed-time null filter post-select; it only ever fed the deleted pre-filter derivation. |
| `0d32dbb` | Delete the dead `code_modifier_cols` reducer knob | Post-#147 the expansion join fully resolves metadata rows to assembled codes before reduction, so the reduced frame only ever carries a `code` key — any configured `code_modifier_cols` would *crash* the `n_unique`/`group_by` on a missing column. Never set by any config/doc/test. `join_cols` is now hardcoded to `["code"]`. |
| `61dc732` | Delete `MessyConfig.iter_events` | Its only reference was its own class doctest (now expressed directly over `cfg.tables`). `iter_tables` stays — it has a real caller in `split_and_shard_subjects`. |
| `092bd0b` | Gate the component-map `.collect()` behind the worker-0 reduction | Every worker materialized the code-component map — a full-dataset scan/unique/collect — but only worker 0's reduction consumes it; N−1 map-only workers paid the stage's most expensive non-map step for nothing. The cheap metadata-only schema validation stays pre-map in every worker so a pre-0.7 events layout still fails loudly everywhere. **Test**: `build_code_component_map` is monkeypatch-spied — a worker-1 run must not call it (nor write `codes.parquet`); a worker-0 run calls it exactly once and reduces normally. |
| `1499ddb` | pyproject: `dftly>=0.5.0,<0.6` + `universal_pathlib>=0.3.10` | dftly is pre-1.0 and the event layer leans on 0.5 contracts (`??` coalescing, `referenced_columns`/`NodeBase` internals); pin the verified minor. The unbounded `universal_pathlib` floor was a lie — floor at the lock-resolved 0.3.10 the suite actually verifies. |
| `16ff7f4` | Rename `_should_retry_stream` → `_should_retry` | The predicate is shared by both request paths (`_get` manifest GETs and `_pull` streaming); the `_stream` suffix misdescribes half its callers. Private; no external references. |
| `04d228f` | cli: log-and-exit on spec construction errors | `sources_from_spec` errors (unknown `type:`, bad backend kwargs) propagated raw through Hydra while manifest validation just below already had the friendly try/log/`sys.exit(1)` treatment. Same pattern applied; `TypeError` caught alongside `ValueError` because kwarg typos surface as constructor `TypeError`s. **Test**: `type: s3` spec exits non-zero with the CLI log line + the underlying "Unknown source type" message. |
| `9ce459f` | `extract_metadata` hygiene | (1) annotation drift: the function is laziness-preserving (its own doctests use eager frames), so annotate `pl.LazyFrame \| pl.DataFrame` both sides; `event_cfg` values are nested mappings, not `str \| None`. (2) the `isinstance` TypeError guard ran only *after* `deepcopy` had already accepted arbitrary junk — check first. (3) drop `extract_metadata`'s own `deepcopy` outright: it never mutates `event_cfg`, and `main()` already deepcopies each entry before popping `source_block` — the per-call deepcopy was duplicate work. |
| `06381cc` | docformatter reflow | Mechanical pre-commit reflow of two pre-existing docstrings in a touched file. |

Local: full suite green with extras (`159 passed, 2 deselected`); pre-commit clean over the whole branch diff.

Refs the 0.7.0 RC review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)