### PR TITLE
Tests: 0.7.0 RC coverage wave

### DIFF
--- a/src/MEDS_extract/convert_to_subject_sharded/examples/aggregated_join/README.md
+++ b/src/MEDS_extract/convert_to_subject_sharded/examples/aggregated_join/README.md
@@ -1,0 +1,9 @@
+Demonstrates the *aggregated* form of `_table.join` (issue #65) — `cols: {deathtime: min}`
+groups the right-hand `admissions` table by the join key and reduces each listed column
+before the left join, so every `patients` row gains a single `min(deathtime)` value.
+
+The right side is deliberately split across **two** chunk files: subject 111 has admissions
+in both chunks, and its earliest death-time (`2020-03-01`) lives in the *second* chunk —
+proving the aggregation runs over the concatenated multi-file scan, not per chunk. This is
+the MIMIC-IV `fix_static_data` replacement shape: earliest death-time per subject pulled
+from the admissions table straight in the MESSY spec.

--- a/src/MEDS_extract/convert_to_subject_sharded/examples/aggregated_join/in.yaml
+++ b/src/MEDS_extract/convert_to_subject_sharded/examples/aggregated_join/in.yaml
@@ -1,0 +1,26 @@
+data/patients/[0-2).parquet:
+  subject_id: [111, 222]
+
+data/admissions/[0-2).parquet:
+  subject_id: [111, 111]
+  deathtime: ["2020-03-05 00:00:00", "2020-03-03 00:00:00"]
+
+data/admissions/[2-4).parquet:
+  subject_id: [111, 222]
+  deathtime: ["2020-03-01 00:00:00", "2021-06-01 00:00:00"]
+
+metadata/.shards.json:
+  train/0: [111]
+  tuning/0: [222]
+
+event_cfg.yaml: |
+  patients:
+    _table:
+      join:
+        admissions:
+          key: subject_id
+          cols:
+            deathtime: min
+    death:
+      code: MEDS_DEATH
+      time: '$deathtime::"%Y-%m-%d %H:%M:%S"'

--- a/src/MEDS_extract/convert_to_subject_sharded/examples/aggregated_join/out_data.yaml
+++ b/src/MEDS_extract/convert_to_subject_sharded/examples/aggregated_join/out_data.yaml
@@ -1,0 +1,7 @@
+data/train/0/patients.parquet:
+  subject_id: [111]
+  deathtime: ["2020-03-01 00:00:00"]
+
+data/tuning/0/patients.parquet:
+  subject_id: [222]
+  deathtime: ["2021-06-01 00:00:00"]

--- a/src/MEDS_extract/convert_to_subject_sharded/examples/aggregated_join/pipeline_cfg.yaml
+++ b/src/MEDS_extract/convert_to_subject_sharded/examples/aggregated_join/pipeline_cfg.yaml
@@ -1,0 +1,2 @@
+event_conversion_config_fp: ${input_dir}/event_cfg.yaml
+shards_map_fp: ${input_dir}/metadata/.shards.json

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ import logging
 import polars as pl
 import pytest
 
-from MEDS_extract.config import EventConfig, JoinConfig, MessyConfig
+from MEDS_extract.config import EventConfig, JoinConfig, MessyConfig, TableConfig
 
 _ = pl.Config.set_tbl_width_chars(600)
 
@@ -144,6 +144,76 @@ def test_time_filter_not_pushed_into_scan(tmp_path):
     assert 'FILTER col("time").is_not_null()' in plan
     assert plan.index('FILTER col("time")') < plan.index("Parquet SCAN")
     assert "PROJECT 2/3 COLUMNS" in plan  # projection pushdown intact (junk not read)
+
+
+def test_extract_dedups_identical_raw_rows():
+    """Two identical raw rows collapse to ONE event; distinct rows survive.
+
+    Pins the ``.unique(maintain_order=True)`` at the end of :meth:`EventConfig.extract` —
+    without it, duplicated source rows (a common raw-data wart) would emit duplicated
+    MEDS events.
+    """
+    raw = pl.DataFrame(
+        {
+            "subject_id": [1, 1, 2],
+            "name": ["A", "A", "A"],
+            "ts": ["2021-01-01", "2021-01-01", "2021-01-01"],
+        }
+    )
+    ev = _event("$name", '$ts::"%Y-%m-%d"')
+    out = ev.extract(raw.lazy(), "t/e").collect()
+    assert out.height == 2, f"identical rows must dedup to one event each:\n{out}"
+    assert sorted(out["subject_id"].to_list()) == [1, 2]
+
+
+_DROP_VARIANT_CASES = {
+    # Literal code (no code-null filter) + lenient time with one unparsable and one
+    # missing value: the message carries ONLY the time clause.
+    "time_only": (
+        {"code": "VISIT", "time": '$ts::?"%Y-%m-%d"'},
+        pl.DataFrame({"subject_id": [1, 2, 3], "name": ["A", "B", "C"], "ts": ["2021-01-01", "junk", None]}),
+        "`patients/e`: dropped 2/3 rows with null time (unparsable or missing under the configured formats)",
+        {1},
+    ),
+    # Bare-column code with one null + fully-parsable time: ONLY the code clause, in its
+    # standalone `n/total rows` form (no time count to piggyback on).
+    "code_only": (
+        {"code": "$name", "time": '$ts::"%Y-%m-%d"'},
+        pl.DataFrame(
+            {"subject_id": [1, 2, 3], "name": ["A", None, "C"], "ts": ["2021-01-01"] * 3},
+        ),
+        "`patients/e`: dropped 1/3 rows with null code",
+        {1, 3},
+    ),
+    # Static event (no time filter at all) with a null code component: same standalone
+    # code clause — the static path must not emit a time clause.
+    "static_code_only": (
+        {"code": "$name", "time": None},
+        pl.DataFrame({"subject_id": [1, 2, 3], "name": ["A", None, "C"]}),
+        "`patients/e`: dropped 1/3 rows with null code",
+        {1, 3},
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("event_raw", "df", "expected_msg", "expected_subjects"),
+    _DROP_VARIANT_CASES.values(),
+    ids=_DROP_VARIANT_CASES.keys(),
+)
+def test_extract_drop_accounting_message_variants(caplog, event_raw, df, expected_msg, expected_subjects):
+    """Each drop-accounting message variant surfaces exactly (#26).
+
+    The combined time+code form is pinned in ``test_extract_drop_accounting_warning``;
+    this parametrization pins the exact wording of the time-only, code-only, and
+    static-event code-only variants.
+    """
+    ev = EventConfig.parse("e", event_raw)
+    with caplog.at_level(logging.WARNING, logger="MEDS_extract.config"):
+        result = ev.extract(df.lazy(), "patients/e").collect()
+    assert set(result["subject_id"].to_list()) == expected_subjects
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == [expected_msg]
 
 
 def test_extract_drop_accounting_warning(caplog):
@@ -291,3 +361,85 @@ def test_join_config_validation_error_paths():
         JoinConfig(
             input_prefix="stays", left_on="k", right_on="k", cols=("a", "b"), aggregations=(("a", "min"),)
         )
+    # The per-prefix block must itself be a mapping — a bare scalar (a YAML slip like
+    # ``join: {stays: stay_id}``) is named alongside the expected shape.
+    with pytest.raises(ValueError, match=r"must be a mapping with 'key'/'left_on'\+'right_on'"):
+        JoinConfig.parse({"stays": "not_a_dict"})
+
+
+@pytest.mark.parametrize(
+    ("agg", "expected"),
+    [
+        ("count", [3, 1, None]),
+        ("sum", [7.0, 10.0, None]),
+        ("mean", [pytest.approx(7.0 / 3.0), 10.0, None]),
+    ],
+)
+def test_aggregated_join_apply_numeric_aggregations(tmp_path, agg, expected):
+    """``JoinConfig.apply`` success paths for the numeric aggregations (``min`` is pinned by the ``apply``
+    doctest; ``max`` by the String-dtype checks test).
+
+    Three right-side rows for subject 1 (one per admission), two for subject 2 (one with a
+    null value — ``count``/``sum``/``mean`` all ignore nulls), and no rows for subject 3
+    (left join → null).
+    """
+    pl.DataFrame(
+        {
+            "subject_id": [1, 1, 1, 2, 2],
+            "v": [1.0, 2.0, 4.0, 10.0, None],
+        }
+    ).write_parquet(tmp_path / "adm.parquet")
+    left = pl.LazyFrame({"subject_id": [1, 2, 3]})
+
+    jc = JoinConfig.parse({"adm": {"key": "subject_id", "cols": {"v": agg}}})
+    out = jc.apply(left, tmp_path).sort("subject_id").collect()
+    assert out["v"].to_list() == expected
+
+
+# ── Config-error paths: exact messages for common misconfiguration shapes ─────────────────────────
+
+
+def test_event_column_parse_failure_names_event_and_column():
+    """A dftly-unparsable column expression fails at parse time, naming the event and column."""
+    with pytest.raises(ValueError, match="Event 'bad' column 'v' failed to parse"):
+        EventConfig.parse("bad", {"code": "X", "time": None, "v": 'f"{$unclosed'})
+
+
+def test_table_with_no_events_errors():
+    """A table block with no event definitions is rejected at parse time."""
+    with pytest.raises(ValueError, match="Table 't' defines no events"):
+        TableConfig.parse("t", {})
+
+
+def test_table_unknown_table_keys_error():
+    """Unknown keys under ``_table`` (a likely typo of ``cols``/``join``) are rejected by name."""
+    with pytest.raises(ValueError, match=r"unknown keys under '_table': \['bogus'\]"):
+        TableConfig.parse("t", {"_table": {"bogus": 1}, "e": {"code": "X", "time": None}})
+
+
+def test_extract_events_error_names_source_block():
+    """A failure inside one event's extraction is wrapped with the ``table/event`` source block.
+
+    The referenced ``$missing`` column doesn't exist, and the failure surfaces eagerly at
+    ``extract_events`` time (the drop-accounting pass collects), already wrapped.
+    """
+    tc = TableConfig.parse("t", {"e": {"code": "X", "time": '$missing::"%Y-%m-%d"'}})
+    with pytest.raises(ValueError, match="Error extracting event t/e"):
+        tc.extract_events(pl.LazyFrame({"subject_id": [1]}))
+
+
+def test_messy_save_requires_load_source(tmp_path):
+    """``save`` on a ``parse``-built config (no source file to copy) raises the targeted error."""
+    cfg = MessyConfig.parse({"t": {"e": {"code": "X", "time": None}}})
+    with pytest.raises(ValueError, match="requires a source file path"):
+        cfg.save(tmp_path / "out.yaml")
+
+
+def test_messy_save_source_deleted_errors(tmp_path):
+    """``save`` after the loaded source file vanished raises ``FileNotFoundError`` naming both paths."""
+    cfg_fp = tmp_path / "cfg.yaml"
+    cfg_fp.write_text("t:\n  e: {code: X, time: null}\n")
+    cfg = MessyConfig.load(cfg_fp)
+    cfg_fp.unlink()
+    with pytest.raises(FileNotFoundError, match="no longer exists"):
+        cfg.save(tmp_path / "out.yaml")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -302,9 +302,9 @@ def test_download_all_fail_fast_cancels_queued_futures(tmp_path: Path):
 
     With a single-worker pool, the failing item is processed first; the remaining
     items sit queued. When ``download_all`` re-raises, ``_attempts``' ``finally``
-    cancels them, so most never run. (The one that may already be in-flight when
-    the failure surfaces is the small race margin — hence ``< n_items``, not
-    ``== 1``.)
+    cancels them, so at most a couple ever run: the small race margin is the item(s)
+    the single worker may already have picked up between the failure surfacing and
+    the cancel — hence ``<= 2``, not ``== 0``.
     """
     from concurrent.futures import ThreadPoolExecutor
 
@@ -333,7 +333,7 @@ def test_download_all_fail_fast_cancels_queued_futures(tmp_path: Path):
 
     # Without the cancel-on-early-exit ``finally`` in ``_attempts``, all 19 "ok"
     # items would drain through the single worker before the pool shut down.
-    assert len(fetched) < n_items - 1, f"expected queued futures cancelled, but {len(fetched)} ran"
+    assert len(fetched) <= 2, f"expected queued futures cancelled, but {len(fetched)} ran"
 
 
 def test_download_all_force_overwrite_discards_stale_part_when_dest_missing(tmp_path: Path):

--- a/tests/test_download_fsspec.py
+++ b/tests/test_download_fsspec.py
@@ -318,7 +318,10 @@ def test_cli_unselected_bucket_interpolations_not_resolved(tmp_path: Path):
 
     Demo users (and credential-free CI) must not need unrelated credentials in the
     environment to pull a bucket that doesn't use them: interpolations are resolved
-    per selected bucket, not across all of ``sources:``.
+    per selected bucket, not across all of ``sources:``. The narrowing covers ``key``
+    plus the always-appended ``common`` bucket — ``common``'s interpolations ARE
+    resolved (and its files staged) whichever key is selected. Both properties are
+    asserted against one CLI invocation (formerly two identical-invocation tests).
     """
     result, raw = _run_cli(tmp_path, _issue_151_spec(tmp_path), "key=demo", env=_issue_151_env(tmp_path))
     assert result.returncode == 0, (
@@ -326,6 +329,7 @@ def test_cli_unselected_bucket_interpolations_not_resolved(tmp_path: Path):
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     assert (raw / "demo.csv").read_text() == "from m_demo\n", "selected bucket must be staged"
+    assert (raw / "shared.csv").read_text() == "from m_common\n", "common bucket must be staged"
 
 
 def test_cli_selected_bucket_interpolation_failure_is_clear(tmp_path: Path):
@@ -336,14 +340,6 @@ def test_cli_selected_bucket_interpolation_failure_is_clear(tmp_path: Path):
     assert result.returncode != 0
     assert "FIX151_UNSET_CRED" in result.stdout + result.stderr, "error must name the missing env var"
     assert not raw.exists(), "nothing may be staged on a failed resolve"
-
-
-def test_cli_common_bucket_interpolation_still_resolved(tmp_path: Path):
-    """The always-appended ``common`` bucket's interpolations ARE resolved whichever key is selected — per-
-    bucket narrowing covers ``key`` plus ``common``, not ``key`` alone."""
-    result, raw = _run_cli(tmp_path, _issue_151_spec(tmp_path), "key=demo", env=_issue_151_env(tmp_path))
-    assert result.returncode == 0, f"CLI failed:\n{result.stdout}\n{result.stderr}"
-    assert (raw / "shared.csv").read_text() == "from m_common\n", "common bucket must be staged"
 
 
 def test_cli_cross_source_collision_exits_before_any_fetch(tmp_path: Path):

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -144,35 +144,6 @@ def _bare_code_events(code_col: str, codes: list[str], source_block: str) -> pl.
 # ── Metadata joining basics: attaching metadata onto extracted codes ──
 
 
-def test_extract_code_metadata_with_existing_codes():
-    """Extracted metadata joins onto event codes and merges with a pre-existing codes.parquet."""
-    messy = """\
-data:
-  measurement:
-    code: $lab_code
-    _metadata:
-      lab_meta:
-        description: title
-"""
-    with tempfile.TemporaryDirectory() as d:
-        codes_df = _run_ecm_scenario(
-            Path(d),
-            messy,
-            event_frames={"data": _bare_code_events("lab_code", ["HR", "TEMP"], "data/measurement")},
-            raw_files={
-                "lab_meta.csv": "lab_code,title,loinc\nHR,Heart Rate,8867-4\nTEMP,Temperature,8310-5\n"
-            },
-            existing_codes=pl.DataFrame({"code": ["EXISTING_CODE"], "description": ["An existing code"]}),
-        )
-
-    # Overlapping columns are coalesced, never forked into `*_right`.
-    assert "description_right" not in codes_df.columns
-    by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
-    assert by_code["EXISTING_CODE"] == "An existing code"
-    assert by_code["HR"] == "Heart Rate"
-    assert by_code["TEMP"] == "Temperature"
-
-
 def test_extract_code_metadata_multiple_files_per_prefix():
     """Multiple CSV files matching one metadata prefix are concatenated before extraction."""
     messy = """\
@@ -427,11 +398,44 @@ data:
     assert codes_df is None
 
 
-def test_metadata_without_code_components_in_events():
+def test_preexisting_codes_with_no_metadata_blocks_early_return(caplog):
+    """Documents current behavior: no ``_metadata`` blocks → early return, even with a
+    pre-existing ``codes.parquet`` in ``metadata_input_dir``.
+
+    The stage exits before the reducer runs, so the pre-existing metadata is NOT merged
+    or copied into the reducer output dir by this stage — no output ``codes.parquet`` is
+    written at all. (Whether the pre-existing file flows onward is a pipeline-wiring
+    concern for downstream stages, not this stage's.) If the early return ever changes
+    to propagate pre-existing codes, this test should be updated to pin the new shape.
+    """
+    messy = """\
+data:
+  measurement:
+    code: $lab_code
+    time: null
+"""
+    existing = pl.DataFrame({"code": ["EXISTING_CODE"], "description": ["An existing code"]})
+    with tempfile.TemporaryDirectory() as d, caplog.at_level("INFO"):
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
+            raw_files={},
+            existing_codes=existing,
+        )
+        # The early return fired, no output codes.parquet exists, and the pre-existing
+        # input file is untouched where it was.
+        assert codes_df is None
+        assert "No _metadata blocks" in caplog.text
+        input_codes = pl.read_parquet(Path(d) / "metadata_in" / "metadata" / "codes.parquet")
+        assert input_codes.equals(existing)
+
+
+def test_metadata_without_code_components_in_events(caplog):
     """Metadata with no code_components in the event data yields an empty output.
 
-    Covers the warning path: the stage completes without error, but metadata cannot be
-    joined onto codes without component provenance in the extracted data.
+    Covers the warning path: the stage completes without error, warns that there is
+    nothing to join metadata onto, and writes an explicitly empty (zero-row) table.
     """
     messy = """\
 data:
@@ -441,7 +445,7 @@ data:
       lab_meta:
         description: title
 """
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, caplog.at_level("WARNING"):
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
@@ -449,11 +453,18 @@ data:
             event_frames={"data": pl.DataFrame({"code": ["HR"], "source_block": ["data/measurement"]})},
             raw_files={"lab_meta.csv": "lab_code,title\nHR,Heart Rate\n"},
         )
-    assert len(codes_df) == 0
+    assert "nothing to join metadata onto" in caplog.text
+    assert codes_df.height == 0
+    assert "code" in codes_df.columns
 
 
-def test_extract_code_metadata_no_matching_codes():
-    """Metadata whose keys match no observed event code reduces to an empty codes.parquet."""
+def test_extract_code_metadata_no_matching_codes(caplog):
+    """Metadata whose keys match no observed event code reduces to an empty codes.parquet.
+
+    The zero-match condition is surfaced (the ``matched zero codes`` WARNING naming the
+    declaring source block), and the reduced output is explicitly empty rather than
+    silently dropping the metadata.
+    """
     messy = """\
 data:
   measurement:
@@ -462,14 +473,16 @@ data:
       lab_meta:
         description: title
 """
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, caplog.at_level("WARNING"):
         codes_df = _run_ecm_scenario(
             Path(d),
             messy,
             event_frames={"data": _bare_code_events("lab_code", ["HR"], "data/measurement")},
             raw_files={"lab_meta.csv": "lab_code,title\nNONEXISTENT,No Match\n"},
         )
-    assert len(codes_df) == 0
+    assert "matched zero codes" in caplog.text
+    assert "'data/measurement'" in caplog.text  # the warning names the declaring source block
+    assert codes_df.height == 0
 
 
 # ── Mixed-schema and multi-config mapper/reducer regressions ──
@@ -930,6 +943,71 @@ admissions:
         )
 
 
+@pytest.mark.parametrize(
+    ("metadata_block", "expected"),
+    [
+        ({"code": "label"}, r"\['code'\]"),
+        ({"code_template": "label"}, r"\['code_template'\]"),
+        ({"code": "label", "code_template": "label", "description": "label"}, r"\['code', 'code_template'\]"),
+    ],
+    ids=["code", "code_template", "both"],
+)
+def test_metadata_reserved_output_column_names_error(metadata_block, expected):
+    """A ``_metadata`` block may not redefine the pipeline-generated ``code``/``code_template`` columns.
+
+    Both are stamped by the pipeline with mandated meanings; a config trying to emit its own is rejected up
+    front with the offending name(s) listed.
+    """
+    from MEDS_extract.extract_code_metadata.extract_code_metadata import extract_metadata
+
+    with pytest.raises(ValueError, match=f"{expected} are reserved"):
+        extract_metadata(
+            pl.DataFrame({"icd": ["1"], "label": ["x"]}),
+            {"code": 'f"ICD//{$icd}"', "_metadata": metadata_block},
+        )
+
+
+def test_reducer_skips_metadata_requiring_absent_component_columns(caplog):
+    """A metadata shard whose match columns aren't all present in the extracted components is skipped with a
+    WARNING, not crashed on or silently joined wrong.
+
+    The code expression references ``$a`` and ``$b`` (match columns ``[a, b]``), but the
+    event data's ``code_components`` struct only carries ``a`` — the shape of event
+    parquets produced before a config gained a component. The reducer must name the
+    absent column(s) and the declaring source block, skip that shard, and still write a
+    (here: empty) codes.parquet.
+    """
+    messy = """\
+data:
+  event:
+    code: 'f"{$a}//{$b}"'
+    _metadata:
+      m:
+        description: title
+"""
+    with tempfile.TemporaryDirectory() as d, caplog.at_level("WARNING"):
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "data": pl.DataFrame(
+                    {
+                        "code": ["X//Y"],
+                        "code_components": [{"a": "X"}],  # no "b" component
+                        "source_block": ["data/event"],
+                    }
+                )
+            },
+            # The raw metadata itself has both match columns, so the map phase succeeds;
+            # only the reducer-side component join is impossible.
+            raw_files={"m.csv": "a,b,title\nX,Y,Some title\n"},
+        )
+    assert "requires component columns ['b'] that are absent" in caplog.text
+    assert "'data/event'" in caplog.text
+    assert "Skipping" in caplog.text
+    assert codes_df.height == 0
+
+
 def test_partial_match_zero_matches_warns(caplog):
     """A metadata join that matches zero codes emits a WARNING (minimal diagnostic).
 
@@ -1077,7 +1155,9 @@ def test_preexisting_codes_merge_coalesces_overlapping_columns():
 
     The full join used to fork overlapping columns into ``description`` + ``description_right``.
     Overlaps must coalesce into a single column with extracted values taking precedence;
-    pre-existing values survive wherever nothing was re-extracted.
+    pre-existing values survive wherever nothing was re-extracted. This also covers the
+    basic pre-existing-codes merge path (a former standalone test): extracted metadata
+    joins onto event codes while pre-existing-only rows survive intact.
     """
     messy = """\
 data:

--- a/tests/test_inprocess_pipeline.py
+++ b/tests/test_inprocess_pipeline.py
@@ -187,6 +187,32 @@ data:
         assert vals == [20.0, 40.0]
 
 
+# ── io.scan_source: the .csv.gz read path (MIMIC's native raw format) ──
+
+
+def test_scan_source_csv_gz_with_shard_events_kwargs(tmp_path):
+    """A ``.csv.gz`` source scans through ``gzip.open`` + ``read_csv`` with shard_events' kwargs.
+
+    ``shard_events`` passes ``row_index_name`` and ``infer_schema_length`` to every raw
+    scan regardless of format; the gzip branch must honor both — a row-index column is
+    prepended and the schema is inferred (not all-String).
+    """
+    import gzip
+
+    from MEDS_extract.io import scan_source
+
+    fp = tmp_path / "labs.csv.gz"
+    with gzip.open(fp, mode="wt") as f:
+        f.write("subject_id,test_name,result\n1,HR,80\n2,TEMP,36.6\n")
+
+    df = scan_source(fp, row_index_name="__row_idx__", infer_schema_length=10000).collect()
+    assert df.columns == ["__row_idx__", "subject_id", "test_name", "result"]
+    assert df["__row_idx__"].to_list() == [0, 1]
+    assert df.schema["subject_id"] == pl.Int64  # schema inferred, not all-String
+    assert df.schema["result"] == pl.Float64
+    assert df["test_name"].to_list() == ["HR", "TEMP"]
+
+
 # ── shard_events: skip files absent from the event config ──
 
 
@@ -227,6 +253,132 @@ data:
 
         assert (root / "output" / "data" / "data").exists()
         assert not (root / "output" / "data" / "extra").exists()
+
+
+def test_shard_events_csv_gz_source(tmp_path):
+    """End-to-end shard_events over a raw ``.csv.gz`` file (MIMIC-IV's native distribution format).
+
+    The gzipped CSV must resolve as a bare-file source, be row-chunked, and land as parquet sub-shards with
+    the configured columns projected and values intact.
+    """
+    import gzip
+
+    from MEDS_extract.shard_events.shard_events import main as shard_stage
+
+    event_cfg = """\
+labs:
+  lab:
+    code: $test_name
+    time: null
+    numeric_value: $result
+"""
+
+    root = tmp_path
+    raw_dir = root / "raw_cohort"
+    raw_dir.mkdir()
+    with gzip.open(raw_dir / "labs.csv.gz", mode="wt") as f:
+        f.write("subject_id,test_name,result,ignored_col\n1,HR,80,x\n1,TEMP,36.6,x\n2,HR,75,x\n")
+
+    event_cfg_fp = root / "event_cfgs.yaml"
+    event_cfg_fp.write_text(event_cfg)
+
+    cfg = _make_cfg(
+        {
+            "stage": "shard_events",
+            "stage_cfg": {
+                "data_input_dir": str(raw_dir / "data"),
+                "output_dir": str(root / "output" / "data"),
+                "row_chunksize": 2,
+                "infer_schema_length": 10000,
+            },
+            "event_conversion_config_fp": str(event_cfg_fp),
+        }
+    )
+    shard_stage.main_fn(cfg)
+
+    out_fps = sorted((root / "output" / "data" / "labs").glob("*.parquet"))
+    assert [fp.name for fp in out_fps] == ["[0-2).parquet", "[2-3).parquet"]
+    df = pl.concat([pl.read_parquet(fp, glob=False) for fp in out_fps]).sort("subject_id", "test_name")
+    # Only the config-referenced columns are projected; values and inferred dtypes intact.
+    assert df.columns == ["result", "subject_id", "test_name"]
+    assert df["subject_id"].to_list() == [1, 1, 2]
+    assert df["test_name"].to_list() == ["HR", "TEMP", "HR"]
+    assert df["result"].to_list() == [80.0, 36.6, 75.0]
+
+
+# ── split_and_shard_subjects: external splits JSON wiring ──
+
+
+def test_split_and_shard_subjects_external_splits(tmp_path):
+    """``external_splits_json_fp`` flows from ``stage_cfg`` into the written ``.shards.json``.
+
+    Externally-listed subjects land in their own named split and are excluded from the IID
+    train/tuning/held_out splits; every subject appears somewhere.
+    """
+    from MEDS_extract.split_and_shard_subjects.split_and_shard_subjects import main as sss_stage
+
+    root = tmp_path
+    input_dir = root / "input"
+    input_dir.mkdir()
+    pl.DataFrame({"subject_id": list(range(1, 11))}).write_parquet(input_dir / "patients.parquet")
+
+    event_cfg_fp = root / "event_cfgs.yaml"
+    event_cfg_fp.write_text("patients:\n  e:\n    code: X\n    time: null\n")
+
+    ext_fp = root / "external_splits.json"
+    ext_fp.write_text(json.dumps({"prospective_test": [9, 10]}))
+
+    shards_fp = root / "metadata" / ".shards.json"
+
+    cfg = _make_cfg(
+        {
+            "stage_cfg": {
+                "data_input_dir": str(input_dir),
+                "external_splits_json_fp": str(ext_fp),
+                "split_fracs": {"train": 0.8, "tuning": 0.1, "held_out": 0.1},
+                "n_subjects_per_shard": 10,
+            },
+            "event_conversion_config_fp": str(event_cfg_fp),
+            "shards_map_fp": str(shards_fp),
+        }
+    )
+    sss_stage.main_fn(cfg)
+
+    shards = json.loads(shards_fp.read_text())
+    assert set(shards) == {"prospective_test/0", "train/0", "tuning/0", "held_out/0"}
+    # The external split is honored verbatim...
+    assert set(shards["prospective_test/0"]) == {9, 10}
+    # ...its subjects are excluded from the IID splits, which partition the remainder.
+    iid = [s for k, v in shards.items() if k != "prospective_test/0" for s in v]
+    assert sorted(iid) == list(range(1, 9))
+
+
+def test_split_and_shard_subjects_external_splits_file_missing(tmp_path):
+    """A configured-but-missing external splits JSON raises ``FileNotFoundError`` naming the path."""
+    from MEDS_extract.split_and_shard_subjects.split_and_shard_subjects import main as sss_stage
+
+    root = tmp_path
+    input_dir = root / "input"
+    input_dir.mkdir()
+    pl.DataFrame({"subject_id": [1, 2, 3]}).write_parquet(input_dir / "patients.parquet")
+
+    event_cfg_fp = root / "event_cfgs.yaml"
+    event_cfg_fp.write_text("patients:\n  e:\n    code: X\n    time: null\n")
+
+    cfg = _make_cfg(
+        {
+            "stage_cfg": {
+                "data_input_dir": str(input_dir),
+                "external_splits_json_fp": str(root / "no_such_splits.json"),
+                "split_fracs": {"train": 0.8, "tuning": 0.1, "held_out": 0.1},
+                "n_subjects_per_shard": 10,
+            },
+            "event_conversion_config_fp": str(event_cfg_fp),
+            "shards_map_fp": str(root / "metadata" / ".shards.json"),
+        }
+    )
+    with pytest.raises(FileNotFoundError, match="External splits JSON file not found"):
+        sss_stage.main_fn(cfg)
 
 
 # ── finalize_MEDS_metadata: output-dir validation and overwrite handling ──
@@ -320,3 +472,18 @@ def test_finalize_MEDS_metadata_overwrite_succeeds():
         # Verify files were rewritten (not the dummy content)
         meta = json.loads((out_dir / "dataset.json").read_text())
         assert meta["dataset_name"] == "TEST"
+
+        # codes.parquet: the pre-existing dummy bytes were replaced by a VALID parquet
+        # carrying the canonical (empty — no input codes) MEDS code-metadata schema.
+        codes = pl.read_parquet(out_dir / "codes.parquet")
+        assert codes.height == 0
+        assert codes.schema["code"] == pl.String
+        assert codes.schema["description"] == pl.String
+        assert codes.schema["parent_codes"] == pl.List(pl.String)
+
+        # subject_splits.parquet: valid parquet with both shard subjects in the train split.
+        splits = pl.read_parquet(out_dir / "subject_splits.parquet")
+        assert splits.schema["subject_id"] == pl.Int64
+        assert splits.schema["split"] == pl.String
+        assert sorted(splits["subject_id"].to_list()) == [1, 2]
+        assert splits["split"].to_list() == ["train", "train"]


### PR DESCRIPTION
Test-only coverage hardening ahead of the 0.7.0 RC. **No production code changes** — the diff touches only `tests/` plus one new stage-example fixture directory (`convert_to_subject_sharded/examples/aggregated_join/`).

## Per-finding changes

1. **`.csv.gz` scan path** (io.py; MIMIC's native format, previously zero tests): `test_scan_source_csv_gz_with_shard_events_kwargs` exercises the gzip branch with `shard_events`' exact kwarg set (`row_index_name`/`infer_schema_length`), and `test_shard_events_csv_gz_source` runs the stage end-to-end over a raw `.csv.gz` file (column projection, row-chunking, inferred dtypes).
2. **`external_splits_json_fp` wiring** (split_and_shard_subjects): in-process test writes an external-splits JSON and asserts `.shards.json` honors it (external split verbatim, excluded from IID splits, full partition) + the `FileNotFoundError` branch.
3. **Aggregated join across multiple right-side chunk files**: new `convert_to_subject_sharded/examples/aggregated_join/` scenario (`cols: {deathtime: min}`, right table split into 2 chunk files with the winning min in the *second* chunk — proves aggregation runs over the concatenated multi-file scan). Auto-collected by `test_stage_examples`.
4. **`EventConfig.extract` dedup pinned**: two identical raw rows → one event (mutation-survivor for the `.unique(maintain_order=True)`).
5. **Drop-accounting message variants**: parametrized over time-only / code-only / static-event-code-only with the exact WARNING wording (the combined form was already pinned).
6. **Reserved `_metadata` output names**: `code` / `code_template` / both rejected with the offending names listed. Implemented as a parametrized unit test rather than a doctest — doctests would require a `src/` edit, which this PR deliberately avoids.
7. **Reducer match-columns-absent skip+warning**: via `_run_ecm_scenario` — a `code_components` struct missing one referenced component triggers the skip WARNING (naming the absent column and source block) and still writes an empty `codes.parquet`.
8. **Config-error paths** (join-block-not-a-mapping, event-column parse failure, table-with-no-events, unknown `_table` keys, `extract_events` source-block wrapping, both `MessyConfig.save` error paths): exact-message tests in `tests/test_config.py`. Same note as (6): written as unit tests, not parse-method doctests, to keep the diff test-only.
9. **`test_finalize_MEDS_metadata_overwrite_succeeds` strengthened**: reads back `codes.parquet` and `subject_splits.parquet` as *valid* parquet with the expected MEDS schemas and split contents (the old dummy-bytes would now fail the test).
11. **Consolidation**: `test_extract_code_metadata_with_existing_codes` folded into `test_preexisting_codes_merge_coalesces_overlapping_columns` (verified fully subsumed: no-`_right`-fork, pre-existing-only survival, extracted-join all covered); the two identical-invocation CLI bucket-interpolation tests merged into one invocation asserting both properties.
12. **`JoinConfig.apply` success cases parametrized** over `count`/`sum`/`mean` (only `min` was exercised; `max` is covered by the String-dtype checks test).
13. **Fail-fast cancel bound tightened** to `<= 2` in `test_download_all_fail_fast_cancels_queued_futures` (1-worker pool; stable across repeated local runs).
14. **Zero-match metadata tests given independent teeth**: assert the `matched zero codes` / `nothing to join metadata onto` log messages (including the declaring source block) and explicit empty-frame heights.
15. **Early-return shape documented**: pre-existing `codes.parquet` + no `_metadata` blocks → the stage exits before the reducer, writes no output `codes.parquet`, and leaves the pre-existing input untouched (asserted as current behavior, with a comment to update if the early return ever changes).

*(There was no item 10 in the source finding list.)*

## Results

- Full suite green: **177 passed** (was 156 on `dev` with the `download` extra), including the auto-collected `aggregated_join` scenario.
- Coverage (branch, with `download` extra): **97% → 98%** overall (44 → 22 missed statements). Per-module: `config.py` 95→98%, `io.py` 88→93%, `split_and_shard_subjects.py` 93→100%, `extract_code_metadata.py` 97→98%.
- Pre-commit clean; `origin/dev` (docs/CI commits #158/#159) merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)