### PR TITLE
Remove dead code: unused logger, stranded parameters; declare direct deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,13 @@ dependencies = [
   "polars>=1.26",
   "pyarrow",
   "hydra-core",
+  "omegaconf",
   "numpy",
   "meds~=0.4.0",
   "MEDS-transforms>=0.6.7,<0.7",
   "universal_pathlib>=0.3.10",
   "dftly>=0.5.0,<0.6",
+  "yaml_to_disk>=0.0.4",
 ]
 
 [dependency-groups]

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -1481,13 +1481,13 @@ class TableConfig:
         """
         return resolve_source_files(dir, self.input_prefix)
 
-    def scan(self, dir: Path | UPath, **scan_kwargs: Any) -> pl.LazyFrame:
+    def scan(self, dir: Path | UPath) -> pl.LazyFrame:
         """Scan every source file for this table under ``dir``, apply the join.
 
         The unified entry point that every stage should use to read a table's data. Auto-detects the layout
         (bare file vs sub-sharded directory), dispatches on format, and applies the join if configured.
         """
-        df = scan_source(self.source_files(dir), **scan_kwargs)
+        df = scan_source(self.source_files(dir))
         if self.join is not None:
             df = self.join.apply(df, dir)
         return df
@@ -1849,15 +1849,14 @@ class MessyConfig:
     def iter_tables(self) -> Iterator[TableConfig]:
         return iter(self.tables)
 
-    def shuffled_tables(self, seed: int | None = None) -> list[TableConfig]:
+    def shuffled_tables(self) -> list[TableConfig]:
         """Return tables in randomized order.
 
         Used by stages that iterate tables to spread parallel worker load — without shuffling, every worker
         would contend on the same first table.
         """
-        rng = random.Random(seed)
         tables = list(self.tables)
-        rng.shuffle(tables)
+        random.Random().shuffle(tables)
         return tables
 
     @property

--- a/src/MEDS_extract/io.py
+++ b/src/MEDS_extract/io.py
@@ -11,7 +11,6 @@ This module is the *one* place in the pipeline where file-format dispatch
 from __future__ import annotations
 
 import gzip
-import logging
 import warnings
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any
@@ -21,8 +20,6 @@ from upath import UPath
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-
-logger = logging.getLogger(__name__)
 
 # Supported external-table formats. No priority order — if a prefix resolves to
 # more than one layout simultaneously (e.g. both a ``foo.parquet`` file and a

--- a/uv.lock
+++ b/uv.lock
@@ -703,9 +703,11 @@ dependencies = [
     { name = "meds" },
     { name = "meds-transforms" },
     { name = "numpy" },
+    { name = "omegaconf" },
     { name = "polars" },
     { name = "pyarrow" },
     { name = "universal-pathlib" },
+    { name = "yaml-to-disk" },
 ]
 
 [package.optional-dependencies]
@@ -751,10 +753,12 @@ requires-dist = [
     { name = "meds", specifier = "~=0.4.0" },
     { name = "meds-transforms", specifier = ">=0.6.7,<0.7" },
     { name = "numpy" },
+    { name = "omegaconf" },
     { name = "polars", specifier = ">=1.26" },
     { name = "pyarrow" },
     { name = "tenacity", marker = "extra == 'download'", specifier = ">=8" },
     { name = "universal-pathlib", specifier = ">=0.3.10" },
+    { name = "yaml-to-disk", specifier = ">=0.0.4" },
 ]
 provides-extras = ["local-parallelism", "slurm-parallelism", "download"]
 


### PR DESCRIPTION
Mechanical cleanup from a dead-code audit of `dev` (at 5b0ec8a). Each finding was re-verified against the current tree before deletion.

## Changes

1. **`src/MEDS_extract/io.py`** — delete the module-level `logger = logging.getLogger(__name__)` and the `import logging` that fed it. Verified: no `logger`/`logging` use anywhere else in the module.
2. **`src/MEDS_extract/config.py` — `MessyConfig.shuffled_tables`** — remove the `seed: int | None = None` parameter. Verified: both callers (`convert_to_MEDS_events.py:57`, `convert_to_subject_sharded.py:64`) call it with no arguments. Runtime behavior is unchanged: the body still uses a fresh, unseeded `random.Random()` instance per call (exactly what `random.Random(None)` did), so no coupling to the global RNG is introduced.
3. **`src/MEDS_extract/config.py` — `TableConfig.scan`** — remove the `**scan_kwargs` passthrough. Verified: the sole caller (`split_and_shard_subjects.py:241`) passes none.
4. **`pyproject.toml`** — add `omegaconf` and `yaml_to_disk>=0.0.4` to `[project.dependencies]`. Both are imported directly by src modules (`from yaml_to_disk import yaml_disk` in `_stage_example.py`; `omegaconf` in ~10 files) but previously reached the environment only transitively (omegaconf via hydra-core; yaml_to_disk via the dev dependency group — meaning a plain `pip install MEDS_extract` would break on `import MEDS_extract._stage_example`). Pin styles match neighbors: `omegaconf` unpinned like `hydra-core`; `yaml_to_disk>=0.0.4` matches the existing dev-group floor and the version uv.lock already resolves (0.0.4). `uv lock` regenerated with no version churn — only the two dependency-list entries changed.

## Notes

- The stale `src/MEDS_extract.egg-info/` build artifact existed on disk but was **untracked** in git, so there is no deletion to commit; it has been removed from the local disk. `.gitignore` already contains a `*.egg-info/` rule (line 24), so no gitignore change was needed.

## Verification

- Full test suite: 149 passed, 1 deselected (integration, opt-in) — run twice.
- `pre-commit run --all-files`: two consecutive clean runs, no files modified.
- Changed-line coverage: the retained bodies of `shuffled_tables` and `scan` are executed by the existing suite (verified via coverage JSON on the exact changed lines).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)