### PR TITLE
extract_code_metadata: assume clean 0.7 usage; remove 0.6-boundary defensive code

### DIFF
--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -110,9 +110,9 @@ def validate_event_data_schema(data_schema: pl.Schema) -> bool:
     absence is allowed and reported as ``False``.
 
     When components ARE present, ``source_block`` must be too: ``EventConfig.extract``
-    stamps it on every row unconditionally, so its absence means the events were produced
-    by a pre-0.7 extraction pipeline — and without it, metadata joins cannot be scoped to
-    the event that declared them (one event's metadata would silently attach to other
+    stamps both on every row together, so an input carrying one without the other is
+    malformed — and without ``source_block``, metadata joins cannot be scoped to the
+    event that declared them (one event's metadata would silently attach to other
     events' codes sharing a component value).
 
     Examples:
@@ -137,8 +137,9 @@ def validate_event_data_schema(data_schema: pl.Schema) -> bool:
     if SOURCE_BLOCK_COL not in data_schema:
         raise ValueError(
             f"Extracted event data carries 'code_components' but no {SOURCE_BLOCK_COL!r} "
-            "column. These events were produced by a pre-0.7 convert_to_MEDS_events; "
-            "re-run the extraction pipeline before extracting code metadata."
+            "column. convert_to_MEDS_events stamps both together, so this input is not a "
+            "valid extracted-events directory; re-run the extraction pipeline before "
+            "extracting code metadata."
         )
     return True
 
@@ -613,7 +614,7 @@ def main(cfg: DictConfig):
     all_data = pl.concat(all_event_dfs, how="diagonal_relaxed")
 
     # Schema validation runs in EVERY worker (it's a cheap metadata-only check) so a
-    # pre-0.7 events layout fails loudly everywhere — but the component map itself is
+    # malformed events layout fails loudly everywhere — but the component map itself is
     # only materialized by the reducer (worker 0) below: it is a full-dataset
     # scan/unique/collect that the N-1 map-only workers never use.
     has_code_components = validate_event_data_schema(all_data.collect_schema())
@@ -790,8 +791,7 @@ def main(cfg: DictConfig):
     #     deduplicated in first-seen order. Mapper rows always carry parent_codes as a
     #     nullable scalar String (one dftly expression -> at most one parent per
     #     metadata row; ``_MAPPER_MANDATORY_TYPES`` enforces the cast), so the
-    #     aggregation assumes the scalar shape. A List-typed column here means a stale
-    #     pre-0.7 partial parquet was reused — re-run the extraction pipeline.
+    #     aggregation assumes the scalar shape.
     #   - ``code_template``: String. One code has exactly one template; distinct templates
     #     colliding on one code is a config error and raises below.
     #   - every other metadata column: List(String), nulls dropped, distinct values sorted
@@ -800,19 +800,11 @@ def main(cfg: DictConfig):
     reduced_schema = reduced.collect_schema()
     aggs = {}
     for c in metadata_cols:
-        if c == CodeMetadataSchema.description_name:
-            aggs[c] = pl.col(c).drop_nulls().unique(maintain_order=True)
-        elif c == CodeMetadataSchema.parent_codes_name:
-            if isinstance(reduced_schema[c], pl.List):
-                raise ValueError(
-                    "parent_codes is List-typed in a partial metadata parquet, but the 0.7 "
-                    "mapper always writes it as a scalar String — this indicates a stale "
-                    "partial file written by a pre-0.7 version was reused (do_overwrite=False "
-                    "skips existing outputs). Re-run the extraction pipeline with a clean "
-                    "output directory."
-                )
-            aggs[c] = pl.col(c).drop_nulls().unique(maintain_order=True)
-        elif c == "code_template":
+        if (
+            c == CodeMetadataSchema.description_name
+            or c == CodeMetadataSchema.parent_codes_name
+            or c == "code_template"
+        ):
             aggs[c] = pl.col(c).drop_nulls().unique(maintain_order=True)
         elif isinstance(reduced_schema[c], pl.List):
             aggs[c] = pl.col(c).explode().cast(pl.String).drop_nulls().unique().sort()

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -787,10 +787,11 @@ def main(cfg: DictConfig):
     #   - ``description``: String, distinct non-null values joined with
     #     ``description_separator`` in canonical config order.
     #   - ``parent_codes``: List(String), unioned across rows/sources, nulls dropped,
-    #     deduplicated in first-seen order. Mapper rows carry parent_codes as a
+    #     deduplicated in first-seen order. Mapper rows always carry parent_codes as a
     #     nullable scalar String (one dftly expression -> at most one parent per
-    #     metadata row); a List-typed column (e.g. a shard written by an older
-    #     mapper) is flattened first.
+    #     metadata row; ``_MAPPER_MANDATORY_TYPES`` enforces the cast), so the
+    #     aggregation assumes the scalar shape. A List-typed column here means a stale
+    #     pre-0.7 partial parquet was reused — re-run the extraction pipeline.
     #   - ``code_template``: String. One code has exactly one template; distinct templates
     #     colliding on one code is a config error and raises below.
     #   - every other metadata column: List(String), nulls dropped, distinct values sorted
@@ -803,9 +804,14 @@ def main(cfg: DictConfig):
             aggs[c] = pl.col(c).drop_nulls().unique(maintain_order=True)
         elif c == CodeMetadataSchema.parent_codes_name:
             if isinstance(reduced_schema[c], pl.List):
-                aggs[c] = pl.col(c).explode().drop_nulls().unique(maintain_order=True)
-            else:
-                aggs[c] = pl.col(c).drop_nulls().unique(maintain_order=True)
+                raise ValueError(
+                    "parent_codes is List-typed in a partial metadata parquet, but the 0.7 "
+                    "mapper always writes it as a scalar String — this indicates a stale "
+                    "partial file written by a pre-0.7 version was reused (do_overwrite=False "
+                    "skips existing outputs). Re-run the extraction pipeline with a clean "
+                    "output directory."
+                )
+            aggs[c] = pl.col(c).drop_nulls().unique(maintain_order=True)
         elif c == "code_template":
             aggs[c] = pl.col(c).drop_nulls().unique(maintain_order=True)
         elif isinstance(reduced_schema[c], pl.List):

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -60,6 +60,8 @@ def _run_ecm_scenario(
     existing_codes: pl.DataFrame | None = None,
     description_separator: str = "\n",
     worker: int = 0,
+    do_overwrite: bool = True,
+    stale_partials: dict[str, pl.DataFrame] | None = None,
 ) -> pl.DataFrame | None:
     """Run the extract_code_metadata stage over synthetic event shards and raw metadata files.
 
@@ -69,8 +71,13 @@ def _run_ecm_scenario(
     text content (written verbatim) or a DataFrame (written as parquet). ``existing_codes``,
     when given, is written as a pre-existing ``metadata/codes.parquet`` for the reducer to
     merge with. ``worker`` selects the MR worker id (worker 0 is the reducer; any other id
-    runs the map phase only). Returns the reduced ``codes.parquet`` as a DataFrame, or
-    ``None`` if the stage exited without writing one (a non-reducer worker).
+    runs the map phase only). ``stale_partials`` maps partial-shard basenames (e.g.
+    ``"<prefix>_0.parquet"``) to frames pre-seeded into the stage output directory before
+    the run — combined with ``do_overwrite=False``, this simulates the resumption path
+    where ``rwlock_wrap`` skips recomputation and the reducer consumes a partial file
+    written by an earlier (possibly older) run. Returns the reduced ``codes.parquet`` as
+    a DataFrame, or ``None`` if the stage exited without writing one (a non-reducer
+    worker).
     """
     from MEDS_extract.extract_code_metadata.extract_code_metadata import main as ecm_stage
 
@@ -109,9 +116,13 @@ def _run_ecm_scenario(
     out_dir = root / "metadata_out" / "metadata"
     out_dir.mkdir(parents=True)
 
+    for basename, frame in (stale_partials or {}).items():
+        frame.write_parquet(out_dir / basename)
+
     cfg = _make_cfg(
         {
             "worker": worker,
+            "do_overwrite": do_overwrite,
             "input_dir": str(raw_dir),
             "stage_cfg": {
                 "data_input_dir": str(root / "events"),
@@ -841,6 +852,52 @@ diagnoses:
     )
     # The metadata itself (description) still attached to all three codes.
     assert codes_df.filter(pl.col("description").is_not_null()).height == 3
+
+
+def test_stale_list_typed_parent_codes_partial_fails_loudly():
+    """A stale partial parquet with List-typed ``parent_codes`` must raise, not be flattened.
+
+    The 0.7 mapper unconditionally casts ``parent_codes`` to a scalar String
+    (``_MAPPER_MANDATORY_TYPES``), so the only way the reducer can see a List-typed
+    ``parent_codes`` is a stale partial file written by a pre-0.7 mapper and reused via
+    ``rwlock_wrap(do_overwrite=False)`` skipping existing outputs. The reducer used to
+    silently flatten that shape; consistent with the 0.7 breaking cut (pre-0.7 *event*
+    data already hard-fails schema validation), it now raises with re-run guidance
+    instead of quietly accepting stale intermediates.
+    """
+    messy = """\
+labs:
+  lab:
+    code: $itemid
+    _metadata:
+      d_labs:
+        itemid: $itemid
+        parent_codes: $parent
+"""
+    stale_partial = pl.DataFrame(
+        {
+            "itemid": ["A", "B"],
+            "code_template": ["$itemid", "$itemid"],
+            "parent_codes": [["P//1", "P//stale"], ["P//2"]],
+        },
+        schema={
+            "itemid": pl.String,
+            "code_template": pl.String,
+            "parent_codes": pl.List(pl.String),
+        },
+    )
+    with (
+        tempfile.TemporaryDirectory() as d,
+        pytest.raises(ValueError, match="parent_codes is List-typed"),
+    ):
+        _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={"labs": _bare_code_events("itemid", ["A", "B"], "labs/lab")},
+            raw_files={"d_labs.parquet": pl.DataFrame({"itemid": ["A", "B"], "parent": ["P//1", "P//2"]})},
+            do_overwrite=False,
+            stale_partials={"d_labs_0.parquet": stale_partial},
+        )
 
 
 def test_mixed_full_and_partial_match_from_same_metadata_prefix():

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -60,8 +60,6 @@ def _run_ecm_scenario(
     existing_codes: pl.DataFrame | None = None,
     description_separator: str = "\n",
     worker: int = 0,
-    do_overwrite: bool = True,
-    stale_partials: dict[str, pl.DataFrame] | None = None,
 ) -> pl.DataFrame | None:
     """Run the extract_code_metadata stage over synthetic event shards and raw metadata files.
 
@@ -71,13 +69,8 @@ def _run_ecm_scenario(
     text content (written verbatim) or a DataFrame (written as parquet). ``existing_codes``,
     when given, is written as a pre-existing ``metadata/codes.parquet`` for the reducer to
     merge with. ``worker`` selects the MR worker id (worker 0 is the reducer; any other id
-    runs the map phase only). ``stale_partials`` maps partial-shard basenames (e.g.
-    ``"<prefix>_0.parquet"``) to frames pre-seeded into the stage output directory before
-    the run — combined with ``do_overwrite=False``, this simulates the resumption path
-    where ``rwlock_wrap`` skips recomputation and the reducer consumes a partial file
-    written by an earlier (possibly older) run. Returns the reduced ``codes.parquet`` as
-    a DataFrame, or ``None`` if the stage exited without writing one (a non-reducer
-    worker).
+    runs the map phase only). Returns the reduced ``codes.parquet`` as a DataFrame, or
+    ``None`` if the stage exited without writing one (a non-reducer worker).
     """
     from MEDS_extract.extract_code_metadata.extract_code_metadata import main as ecm_stage
 
@@ -116,13 +109,9 @@ def _run_ecm_scenario(
     out_dir = root / "metadata_out" / "metadata"
     out_dir.mkdir(parents=True)
 
-    for basename, frame in (stale_partials or {}).items():
-        frame.write_parquet(out_dir / basename)
-
     cfg = _make_cfg(
         {
             "worker": worker,
-            "do_overwrite": do_overwrite,
             "input_dir": str(raw_dir),
             "stage_cfg": {
                 "data_input_dir": str(root / "events"),
@@ -852,52 +841,6 @@ diagnoses:
     )
     # The metadata itself (description) still attached to all three codes.
     assert codes_df.filter(pl.col("description").is_not_null()).height == 3
-
-
-def test_stale_list_typed_parent_codes_partial_fails_loudly():
-    """A stale partial parquet with List-typed ``parent_codes`` must raise, not be flattened.
-
-    The 0.7 mapper unconditionally casts ``parent_codes`` to a scalar String
-    (``_MAPPER_MANDATORY_TYPES``), so the only way the reducer can see a List-typed
-    ``parent_codes`` is a stale partial file written by a pre-0.7 mapper and reused via
-    ``rwlock_wrap(do_overwrite=False)`` skipping existing outputs. The reducer used to
-    silently flatten that shape; consistent with the 0.7 breaking cut (pre-0.7 *event*
-    data already hard-fails schema validation), it now raises with re-run guidance
-    instead of quietly accepting stale intermediates.
-    """
-    messy = """\
-labs:
-  lab:
-    code: $itemid
-    _metadata:
-      d_labs:
-        itemid: $itemid
-        parent_codes: $parent
-"""
-    stale_partial = pl.DataFrame(
-        {
-            "itemid": ["A", "B"],
-            "code_template": ["$itemid", "$itemid"],
-            "parent_codes": [["P//1", "P//stale"], ["P//2"]],
-        },
-        schema={
-            "itemid": pl.String,
-            "code_template": pl.String,
-            "parent_codes": pl.List(pl.String),
-        },
-    )
-    with (
-        tempfile.TemporaryDirectory() as d,
-        pytest.raises(ValueError, match="parent_codes is List-typed"),
-    ):
-        _run_ecm_scenario(
-            Path(d),
-            messy,
-            event_frames={"labs": _bare_code_events("itemid", ["A", "B"], "labs/lab")},
-            raw_files={"d_labs.parquet": pl.DataFrame({"itemid": ["A", "B"], "parent": ["P//1", "P//2"]})},
-            do_overwrite=False,
-            stale_partials={"d_labs_0.parquet": stale_partial},
-        )
 
 
 def test_mixed_full_and_partial_match_from_same_metadata_prefix():


### PR DESCRIPTION
From the dead-code audit of `dev` (at 5b0ec8a), reworked per the maintainer's decision: **assume all usage is clean on 0.7 alone** — there is no concern for resuming a 0.6-started extraction, so defensive code guarding that intermediate-state boundary is deleted outright.

## The invariant

The 0.7 mapper (`extract_metadata`) unconditionally casts `parent_codes` to a scalar `pl.String` via `_MAPPER_MANDATORY_TYPES` before writing any partial shard (verified empirically: an end-to-end scenario run shows the partial's schema as `{itemid: String, code_template: String, parent_codes: String}`). The reducer now simply assumes that invariant; the aggregation-block comment states it.

## Removed

1. **The `parent_codes`-specific List-flattening arm** in the reducer aggregation. It was reachable only via a stale pre-0.7 partial parquet reused through `rwlock_wrap(do_overwrite=False)` skipping existing outputs — a non-scenario under clean 0.7 usage. With the arm gone, the `description` / `parent_codes` / `code_template` branches have identical bodies and ruff (SIM114) merges them into one.
2. **Version-migration framing in `validate_event_data_schema`** and the worker-side comment that invokes it. The check itself stays — `code_components` present without `source_block` is genuinely malformed input (`EventConfig.extract` stamps both together, and without `source_block` metadata joins cannot be scoped) — but its error text and docstring now describe that pairing invariant in plain schema-validation language instead of "produced by a pre-0.7 convert_to_MEDS_events".

## Deliberately kept

- **The generic List arm** (`elif isinstance(reduced_schema[c], pl.List)`) for arbitrary metadata columns. It is genuinely reachable: parquet metadata sources keep their intrinsic dtypes and only MEDS-sentinel columns are cast by the mapper, so a `List(String)` source column flows into the reducer. Verified empirically end-to-end: a parquet metadata source with a `List(String)` `synonyms` column produced a correctly exploded/deduped/sorted `List(String)` output via this arm.
- **Config-syntax migration aids** in `config.py` (`_match_on` leftovers, legacy `parent_codes` list forms, `{col}` interpolation guidance) — those are config-migration errors, not stale-intermediate tolerance, and were reviewed and kept in #165.

## Sweep result

Swept `src/` for any other defensive code guarding the 0.6→0.7 intermediate-state boundary ("older mapper" / "pre-0.7" / "older version" tolerances, List-dtype tolerance branches, stale-shard handling): **nothing else found** beyond the two items above. (`download/source.py`'s stale-`.part` handling is download resumption logic, unrelated to the version boundary.)

## Testing

- Full suite with all extras from the repo root: 186 passed, 2 deselected (opt-in integration), two consecutive runs.
- `pre-commit run --all-files`: two consecutive clean runs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)