### PR TITLE
PhysioNetSource: default a Wget-prefixed User-Agent; make the /files/ 403 gate legible (#174)

### DIFF
--- a/src/MEDS_extract/download/README.md
+++ b/src/MEDS_extract/download/README.md
@@ -70,6 +70,14 @@ sources:
         - https://raw.githubusercontent.com/.../concept_map.csv
 ```
 
+Basic auth alone is not enough for PhysioNet: physionet.org serves credentialed
+`/files/` paths only to clients whose `User-Agent` starts with `Wget/<version>`
+(a prefix match — anything appended after is preserved), and rejects other UAs
+with a 403 *before* credentials are considered. `PhysioNetSource` therefore
+defaults its client's UA to `Wget/<version> MEDS-Extract/<version>` — passing the
+gate while staying honestly identified. A `headers: {User-Agent: ...}` entry in
+the source config overrides it completely.
+
 and `meds-extract-download` stages it (Hydra dotlist overrides, one command):
 
 ```bash
@@ -129,16 +137,16 @@ The rest of this document walks through the pieces behind that API.
 
 ## Files
 
-| File                                             | Responsibility                                                                                                                                                                         |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`source.py`](source.py)                         | The `Source` ABC, the `RemoteFile` manifest row, `ChecksumError`, `sha256_of`, `validate_unique_destinations`, and the whole orchestration loop (`download_all` + helpers).            |
-| [`backends/http.py`](backends/http.py)           | `HTTPSource` — explicit list of URLs. tenacity-retried manifest GETs + streaming, `.part`-file Range-resume download, `Content-Range` validation. No crawling.                         |
-| [`backends/physionet.py`](backends/physionet.py) | `PhysioNetSource(HTTPSource)` — discovers its file list from the `SHA256SUMS.txt` manifest every PhysioNet release publishes. Overrides `_list_files` (plus its constructor).          |
-| [`backends/fsspec.py`](backends/fsspec.py)       | `FsspecSource` — any `fsspec` protocol via `universal_pathlib` (`file://`, `s3://`, `gs://`, …). For re-runs against a pre-downloaded local / cloud mirror.                            |
-| [`spec.py`](spec.py)                             | `source_from_config` / `sources_from_spec` — turn raw `sources:` YAML entries into concrete `Source` instances. The one place the `type:` → class registry lives.                      |
-| [`cli.py`](cli.py)                               | `meds-extract-download` — the Hydra entry point. Resolves the spec, builds + cross-validates the sources, owns the shared thread pool, drives every source, exits non-zero on failure. |
-| [`backends/__init__.py`](backends/__init__.py)   | Lazily re-exports the three backend classes (PEP 562), so the HTTP stack is only imported when actually used.                                                                          |
-| [`__init__.py`](__init__.py)                     | Public surface: `Source`, `RemoteFile`, `ChecksumError`, the three backends, `source_from_config`, `sources_from_spec`, `validate_unique_destinations`.                                |
+| File                                             | Responsibility                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`source.py`](source.py)                         | The `Source` ABC, the `RemoteFile` manifest row, `ChecksumError`, `sha256_of`, `validate_unique_destinations`, and the whole orchestration loop (`download_all` + helpers).                                                                                                                                                                       |
+| [`backends/http.py`](backends/http.py)           | `HTTPSource` — explicit list of URLs. tenacity-retried manifest GETs + streaming, `.part`-file Range-resume download, `Content-Range` validation. No crawling.                                                                                                                                                                                    |
+| [`backends/physionet.py`](backends/physionet.py) | `PhysioNetSource(HTTPSource)` — discovers its file list from the `SHA256SUMS.txt` manifest every PhysioNet release publishes. Overrides `_list_files` (plus its constructor). Defaults the client's `User-Agent` to a `Wget/<version>`-prefixed string (physionet's `/files/` gate) and turns the gate's challenge-less 403 into a legible error. |
+| [`backends/fsspec.py`](backends/fsspec.py)       | `FsspecSource` — any `fsspec` protocol via `universal_pathlib` (`file://`, `s3://`, `gs://`, …). For re-runs against a pre-downloaded local / cloud mirror.                                                                                                                                                                                       |
+| [`spec.py`](spec.py)                             | `source_from_config` / `sources_from_spec` — turn raw `sources:` YAML entries into concrete `Source` instances. The one place the `type:` → class registry lives.                                                                                                                                                                                 |
+| [`cli.py`](cli.py)                               | `meds-extract-download` — the Hydra entry point. Resolves the spec, builds + cross-validates the sources, owns the shared thread pool, drives every source, exits non-zero on failure.                                                                                                                                                            |
+| [`backends/__init__.py`](backends/__init__.py)   | Lazily re-exports the three backend classes (PEP 562), so the HTTP stack is only imported when actually used.                                                                                                                                                                                                                                     |
+| [`__init__.py`](__init__.py)                     | Public surface: `Source`, `RemoteFile`, `ChecksumError`, the three backends, `source_from_config`, `sources_from_spec`, `validate_unique_destinations`.                                                                                                                                                                                           |
 
 ## Architecture
 

--- a/src/MEDS_extract/download/backends/physionet.py
+++ b/src/MEDS_extract/download/backends/physionet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
@@ -13,6 +14,26 @@ if TYPE_CHECKING:
 
     import httpx
     from tenacity.wait import wait_base
+
+
+def _default_user_agent() -> str:
+    """The default ``User-Agent`` for :class:`PhysioNetSource`-built clients.
+
+    physionet.org serves credentialed ``/files/`` paths **only** to clients whose
+    User-Agent starts with ``Wget/<version>`` — a prefix match, with anything appended
+    after preserved. So the default leads with a ``Wget/<version>`` token to pass the
+    gate, then appends this package's real identity rather than impersonating wget
+    outright.
+
+    Examples:
+        >>> _default_user_agent()
+        'Wget/1.21.4 MEDS-Extract/...'
+    """
+    try:
+        pkg_version = version("MEDS_extract")
+    except PackageNotFoundError:  # pragma: no cover — metadata absent only in odd installs
+        pkg_version = "unknown"
+    return f"Wget/1.21.4 MEDS-Extract/{pkg_version}"
 
 
 class PhysioNetSource(HTTPSource):
@@ -27,7 +48,15 @@ class PhysioNetSource(HTTPSource):
 
     Credential plumbing for restricted datasets (MIMIC-IV, eICU, etc.) is HTTP Basic auth
     via the ``username`` / ``password`` kwargs; open datasets (MIMIC-IV demo) need
-    neither.
+    neither. Basic auth alone is **not** sufficient, though: physionet.org serves
+    credentialed ``/files/`` paths only to clients whose ``User-Agent`` starts with
+    ``Wget/<version>`` (their documented bulk-download tool). The gate is a prefix
+    match — anything appended after the ``Wget/<version>`` token is preserved — and it
+    rejects with a 403 *before* credentials are considered, with no ``WWW-Authenticate``
+    challenge, so a wrong UA is otherwise indistinguishable from wrong credentials. To
+    pass the gate while staying honestly identified, clients built here default to
+    ``Wget/<version> MEDS-Extract/<version>`` (see ``_default_user_agent``); a
+    user-supplied ``headers={"User-Agent": ...}`` wins completely.
 
     Args:
         base_url: The PhysioNet release URL, with or without trailing slash — e.g.
@@ -38,9 +67,10 @@ class PhysioNetSource(HTTPSource):
             one is built via :meth:`HTTPSource._make_client` with the supplied auth.
         headers, timeout, max_attempts, transport, retry_wait: Forwarded to
             :meth:`HTTPSource._make_client` when ``client`` is not provided.
-            ``headers`` is rarely needed for PhysioNet — Basic auth covers the
-            credentialed releases — but it's passed through for symmetry with
-            :class:`HTTPSource`.
+            Unless ``headers`` supplies its own ``User-Agent``, the default described
+            above is injected — physionet's ``/files/`` gate makes the UA
+            load-bearing here, unlike plain :class:`HTTPSource` (which keeps httpx's
+            stock UA).
         include, exclude: Optional :mod:`fnmatch` globs applied to the manifest —
             e.g. ``include=["hosp/*.csv.gz"]`` stages only the hospital tables from
             a release that also bundles data the ETL never reads. See
@@ -110,6 +140,13 @@ class PhysioNetSource(HTTPSource):
             )
         self._base_url = base_url if base_url.endswith("/") else base_url + "/"
         auth = (username, password) if username is not None else None
+        # Inject the Wget-prefixed default UA (see class docstring) unless the caller
+        # supplied their own — header names are case-insensitive on the wire, so the
+        # presence check must be too. ``headers`` is only consumed by ``_make_client``,
+        # so an injected ``client=`` is untouched (its headers are the caller's).
+        headers = dict(headers) if headers else {}
+        if not any(k.lower() == "user-agent" for k in headers):
+            headers["User-Agent"] = _default_user_agent()
         super().__init__(
             urls=None,
             client=client,
@@ -129,6 +166,22 @@ class PhysioNetSource(HTTPSource):
         # errors), so the manifest GET retries identically for built and injected
         # clients; 4xx comes back unwrapped and fails fast here.
         r = self._get(sums_url)
+        # physionet's ``/files/`` UA gate rejects with a 403 *before* credentials are
+        # considered, and — unlike a genuine auth failure — without a
+        # ``WWW-Authenticate`` challenge. Surface that case legibly instead of a bare
+        # ``HTTPStatusError`` indistinguishable from bad credentials. A 403 *with* a
+        # challenge is a real auth failure and keeps the ordinary 4xx path below.
+        if r.status_code == 403 and "WWW-Authenticate" not in r.headers:
+            sent_ua = r.request.headers.get("User-Agent", "<none>")
+            raise ValueError(
+                f"{type(self).__name__}: got 403 with no WWW-Authenticate challenge for "
+                f"{sums_url}. physionet.org serves credentialed /files/ paths only to "
+                f"clients whose User-Agent starts with 'Wget/<version>' (prefix match; "
+                f"anything appended after is preserved), and rejects other UAs before "
+                f"credentials are considered. This client sent User-Agent: {sent_ua!r}. "
+                f"If that is already Wget/-prefixed, the likely cause is missing "
+                f"credentials or an unsigned data-use agreement for this dataset."
+            )
         r.raise_for_status()
         for entry in self._parse_sha256sums(r.text):
             yield RemoteFile(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -695,6 +695,80 @@ def test_physionet_basic_auth_sent_on_wire(tmp_path: Path):
     assert all(h == expected for h in seen_auth)
 
 
+# ── PhysioNet User-Agent gate (#174) ─────────────────────────────────────────────────
+#
+# physionet.org serves credentialed ``/files/`` paths ONLY to clients whose User-Agent
+# starts with ``Wget/<version>`` (prefix match; anything appended is preserved). The
+# resulting 403 arrives before credentials are considered and carries no
+# ``WWW-Authenticate`` challenge, so it is byte-identical to a bad-credential failure.
+# These tests assert what WE send (the outgoing requests' User-Agent) — they do not
+# pin upstream's 403 responses, which we can't verify from a mock.
+
+
+def test_physionet_default_user_agent_is_wget_prefixed():
+    """``PhysioNetSource``'s built client must default to a ``Wget/``-prefixed, honestly-identified User-Agent
+    — otherwise every credentialed release 403s.
+
+    Constructed via the public ``transport=`` kwarg (NOT ``client=``) so the real
+    header-construction path in ``_make_client`` is exercised on the wire.
+    """
+    manifest = f"{_sha(b'x')}  a.csv\n"
+    seen_ua: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_ua.append(request.headers.get("User-Agent"))
+        return httpx.Response(200, text=manifest)
+
+    with PhysioNetSource(
+        base_url="https://physionet.org/files/demo/1.0",
+        transport=httpx.MockTransport(handler),
+    ) as src:
+        assert [f.rel_path for f in src.files] == ["a.csv"]
+
+    assert len(seen_ua) == 1
+    ua = seen_ua[0]
+    assert ua is not None
+    assert ua.startswith("Wget/"), f"UA must be Wget/-prefixed for physionet's gate, got {ua!r}"
+    assert "MEDS-Extract/" in ua, f"UA must still honestly identify this package, got {ua!r}"
+
+
+def test_physionet_user_agent_override_wins():
+    """A user-supplied ``headers={'User-Agent': ...}`` must win completely over the default."""
+    manifest = f"{_sha(b'x')}  a.csv\n"
+    seen_ua: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_ua.append(request.headers.get("User-Agent"))
+        return httpx.Response(200, text=manifest)
+
+    with PhysioNetSource(
+        base_url="https://physionet.org/files/demo/1.0",
+        headers={"User-Agent": "custom"},
+        transport=httpx.MockTransport(handler),
+    ) as src:
+        assert [f.rel_path for f in src.files] == ["a.csv"]
+
+    assert seen_ua == ["custom"]
+
+
+def test_http_source_default_user_agent_unchanged():
+    """The ``Wget/`` default is a PhysioNet-only concern — plain :class:`HTTPSource` keeps httpx's stock User-
+    Agent, so the fix doesn't leak to other endpoints."""
+    seen_ua: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_ua.append(request.headers.get("User-Agent"))
+        return httpx.Response(200, content=b"x")
+
+    with HTTPSource(
+        urls=["https://example.com/a.csv"],
+        transport=httpx.MockTransport(handler),
+    ) as src:
+        assert src._get("https://example.com/a.csv").status_code == 200
+
+    assert seen_ua == [f"python-httpx/{httpx.__version__}"]
+
+
 def test_download_all_pooled_multiworker_end_to_end(tmp_path: Path):
     """Real multi-worker parallelism through a real backend: concurrent
     ``_fetch_one`` staging (shared client, sibling-dir mkdir races, per-file


### PR DESCRIPTION
Refs #174

## The gate

physionet.org serves credentialed `/files/` paths **only** to clients whose `User-Agent` starts with `Wget/<version>` — a **prefix** match, with anything appended after the token preserved. The rejection is a 403 issued *before* credentials are considered, carrying no `WWW-Authenticate` challenge, so "wrong password", "unsigned DUA", and "your HTTP client is not wget" were byte-identical failures. `PhysioNetSource` sent httpx's stock UA (`python-httpx/0.28.1`), so every credentialed release through this backend 403'd no matter how correct the credentials were (the public demo buckets are served to any UA, which is why demo-only CI never caught it).

## The fix

1. **Wget-prefixed, honestly-identified default UA.** Clients built by `PhysioNetSource` now default to `Wget/1.21.4 MEDS-Extract/<version>` (`<version>` from `importlib.metadata`, `"unknown"` if metadata is unavailable). Since the gate is a prefix match that preserves appended content, we lead with the `Wget/<version>` token to pass the gate and append our real identity rather than impersonating wget outright. A user-supplied `headers={"User-Agent": ...}` wins completely (presence check is case-insensitive, matching wire semantics). The default is injected in `PhysioNetSource.__init__` only — plain `HTTPSource` keeps httpx's stock UA, and an injected `client=` is left untouched.
2. **Legible failure.** A manifest-GET 403 with no `WWW-Authenticate` challenge now raises a `ValueError` naming the UA gate, the UA actually sent, and the URL — and, when the UA is already Wget-prefixed, pointing at missing credentials / an unsigned data-use agreement as the likely cause. A 403 *with* a challenge keeps the ordinary `HTTPStatusError` path.
3. **Docs corrected.** The docstring claim that Basic auth alone covers credentialed releases ("`headers` is rarely needed") is replaced with documentation of the gate and the new default; `download/README.md` documents it where the PhysioNet source config is shown. The top-level README carries no such claim (checked).

## Tests

Tests assert what **we** send, captured at the request level via the public `transport=` seam (exercising the real `_make_client` header path on the wire):

- `test_physionet_default_user_agent_is_wget_prefixed` — the manifest GET's UA starts with `Wget/` and carries `MEDS-Extract/`. **Fails on unpatched dev** with `UA must be Wget/-prefixed for physionet's gate, got 'python-httpx/0.28.1'` — the demonstrating test.
- `test_physionet_user_agent_override_wins` — `headers={"User-Agent": "custom"}` produces exactly `custom`.
- `test_http_source_default_user_agent_unchanged` — `HTTPSource` requests keep `python-httpx/<version>`, pinning that the default doesn't leak.

Deliberately **not** tested: the legible-403 branch itself. Feeding our code a synthetic 403-without-`WWW-Authenticate` would pin an assumption about physionet's upstream response shape that a mock can't verify, so that branch (the `raise ValueError` body in `_list_files`, 2 statements) is honestly uncovered rather than covered by a synthetic upstream response. `download/` module coverage is otherwise complete (backends/physionet.py at 95%, those 2 statements being the miss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
