### PR TITLE
CI: actually check coverage, and move off the deprecated Codecov action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
         # take when they install only the base deps. ``conftest.py`` skips the download
         # module + its doctests when ``httpx`` / ``tenacity`` aren't importable.
         run: |
-          uv run pytest -v --cov=src --cov-report=xml
+          uv run pytest -v --cov=src --cov-report=xml --junitxml=junit.xml
 
       - name: Upload coverage to Codecov
         # ``flags: core`` tags the upload so Codecov merges the two jobs' coverage under
@@ -44,9 +44,11 @@ jobs:
           flags: core
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: junit.xml
           flags: core
 
   run_tests_download:
@@ -75,7 +77,7 @@ jobs:
         run: |
           uv run --extra download pytest -v \
             tests/test_download.py src/MEDS_extract/download/ \
-            --cov=src/MEDS_extract/download --cov-report=xml
+            --cov=src/MEDS_extract/download --cov-report=xml --junitxml=junit.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -84,9 +86,11 @@ jobs:
           flags: download
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: junit.xml
           flags: download
 
   run_tests_parallelism:
@@ -122,7 +126,7 @@ jobs:
         # the package works on a base install, which does NOT carry a launcher plugin.
         run: |
           uv run --extra local_parallelism pytest -v -m parallelism \
-            --cov=src --cov-report=xml
+            --cov=src --cov-report=xml --junitxml=junit.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -131,9 +135,11 @@ jobs:
           flags: parallelism
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: junit.xml
           flags: parallelism
 
   integration_tests:
@@ -175,7 +181,7 @@ jobs:
         run: |
           uv run --extra download pytest -v -m integration \
             --reruns 2 --reruns-delay 60 \
-            --cov=src --cov-report=xml
+            --cov=src --cov-report=xml --junitxml=junit.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -184,7 +190,9 @@ jobs:
           flags: integration
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: junit.xml
           flags: integration

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+junit.xml
 *.cover
 *.py,cover
 .hypothesis/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,43 @@
+# Codecov configuration.
+#
+# Without this file Codecov uploads were still happening, but nothing *checked* them:
+# no `codecov/project` or `codecov/patch` status appeared on a PR, so a change could
+# drop coverage and CI stayed green. The `status` block below is what turns the
+# uploads into PR checks.
+#
+# Coverage arrives from four CI jobs, each tagged with a flag (see
+# `.github/workflows/tests.yaml`). Codecov merges them per commit by taking the union
+# of covered lines, so a job that exercises only part of the tree (e.g. `download`)
+# does not drag the total down.
+
+coverage:
+  status:
+    project:
+      default:
+        # `auto` = "don't do worse than the parent commit". The threshold allows small
+        # dips (a refactor that deletes covered lines, say) without failing the PR.
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # New/changed lines specifically. The suite sits near 98%, so this asks new
+        # code to be tested without demanding perfection on every diff.
+        target: 90%
+        threshold: 0%
+
+comment:
+  layout: "condensed_header, diff, flags, components"
+  # Post even when coverage is unchanged, so the absence of a comment is never
+  # ambiguous between "no change" and "the upload silently failed".
+  require_changes: false
+
+flag_management:
+  default_rules:
+    # A flag's coverage persists when its job did not run for a commit. Without this,
+    # a commit that skips (say) the integration job would look like a coverage drop.
+    carryforward: true
+  individual_flags:
+    - name: core
+    - name: download
+    - name: parallelism
+    - name: integration


### PR DESCRIPTION
Answers "are we actually checking codecov on the PRs?" — **no, we were not.** Coverage was being uploaded and then ignored.

## 1. Coverage was uploaded but never gated

All four jobs upload `coverage.xml` with a flag, and those uploads succeed. But with no `codecov.yml` in the repo, no `codecov/project` or `codecov/patch` status was ever posted — `gh pr checks 185` lists none. Coverage could drop to any level and CI stayed green.

New `codecov.yml` adds:

| setting | value | why |
| --- | --- | --- |
| `project` | `target: auto`, `threshold: 1%` | don't regress vs. the parent, but tolerate small dips (e.g. a refactor deleting covered lines) |
| `patch` | `target: 90%` | new/changed lines get tested; the suite sits near 98% |
| `comment` | `require_changes: false` | a missing comment can't be confused with "no change" |
| `flag_management` | `carryforward: true` | a commit whose integration job didn't run shouldn't read as a regression |

Targets are deliberately mild and easy to tune.

## 2. The test-results upload had nothing to upload

No pytest invocation passed `--junitxml`, so every run reported:

> ⚠️ **JUnit XML file not found** — The CLI was unable to find any JUnit XML files to upload.

That's the bot comment on every PR. It also isn't merely cosmetic: it turned #185's integration job red *after the tests themselves passed* (step 4 success, step 6 failure). Every pytest call now writes `junit.xml`, which also joins `coverage.xml` in `.gitignore`.

## 3. The action is deprecated

Codecov's warning, verbatim from the run annotations:

> This action is being deprecated in favor of 'codecov-action'. The 'codecov-action' should and can be run at least once for coverage and once for test results. Please update CI accordingly to use 'codecov-action@v5' with 'report_type: test_results'.

plus `Node.js 20 is deprecated ... codecov/test-results-action@v1`. All four steps move to `codecov/codecov-action@v6` with `report_type: test_results`, matching the coverage steps already on v6.

## Verification

- Both YAML files parse; each job has exactly one coverage upload and one test-results upload.
- `pytest --junitxml=junit.xml` verified to emit valid XML (`tests=25 failures=0 errors=0`).

Once this lands, `codecov/project` and `codecov/patch` should start appearing as PR checks — that's the visible confirmation coverage is being enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)