### PR TITLE
Make download fail-fast actually stop queued work; fix the flaky bound

### DIFF
--- a/src/MEDS_extract/download/source.py
+++ b/src/MEDS_extract/download/source.py
@@ -26,6 +26,7 @@ import itertools
 import logging
 import posixpath
 import re
+import threading
 import time
 from abc import ABC, abstractmethod
 from concurrent.futures import FIRST_COMPLETED, Executor, wait
@@ -50,6 +51,16 @@ _SHA256_RE = re.compile(r"[0-9a-fA-F]{64}")
 # dict slots), so submitting a 377k-row manifest (MIMIC-CXR-JPG scale) up-front would
 # hold ~780 MB for the whole run; a bounded sliding window keeps that O(window).
 _MAX_PENDING_SUBMITS = 1024
+
+
+class _AbortedError(Exception):
+    """Raised by a queued fetch that started after fail-fast tripped.
+
+    Never surfaces: fail-fast means the consumer has already raised, so these results
+    are discarded. It exists so an aborted fetch is distinguishable from a real
+    transport failure if one is ever inspected.
+    """
+
 
 # ``download_all`` emits an INFO progress line at most this often during the fetch
 # loop, so multi-hour transfers are observable at the default log level without
@@ -472,7 +483,10 @@ class Source(ABC):
         # ``closing`` guarantees the generator's ``finally`` runs even when the loop
         # exits early via ``raise`` (fail-fast) — in pooled mode that ``finally`` is
         # what cancels the still-queued futures so "fail fast" actually stops the run.
-        attempts = self._attempts(self._iter_attempts(items, dest_dir, do_overwrite), pool)
+        # Tripped the moment a fetch fails, so queued work stops before the unwind
+        # reaches the generator's teardown. See ``_attempts``.
+        abort = threading.Event()
+        attempts = self._attempts(self._iter_attempts(items, dest_dir, do_overwrite), pool, abort)
         try:
             with closing(attempts):
                 for item, run in attempts:
@@ -485,6 +499,7 @@ class Source(ABC):
                         e.add_note(f"while fetching {item.rel_path!r} from {item.source_path!r}")
                         n_failed += 1
                         if not continue_on_error:
+                            abort.set()
                             raise
                         logger.exception(f"Failed to fetch {item.rel_path}")
                         errors.append(e)
@@ -988,6 +1003,7 @@ class Source(ABC):
     def _attempts(
         items_to_fetch: Iterable[tuple[RemoteFile, Callable[[], tuple[str, int]]]],
         pool: Executor | None,
+        abort: threading.Event,
     ) -> Iterator[tuple[RemoteFile, Callable[[], tuple[str, int]]]]:
         """Dispatch ``(item, callable)`` pairs sequentially or through a pool.
 
@@ -1000,18 +1016,49 @@ class Source(ABC):
         O(manifest): each pending Future costs ~2 KB, which adds up to
         hundreds of MB on 100k+-row manifests if submitted all at once.
 
-        Fail-fast in parallel mode: if the caller raises out of its loop on
-        the first failure, the ``finally`` cancels every still-queued future
-        so the rest of the bundle halts immediately. Already-running and
-        already-done futures are unaffected (``cancel`` is a no-op on those).
-        The caller must wrap the generator in :func:`contextlib.closing` to
-        guarantee the ``finally`` runs.
+        Fail-fast in parallel mode: if the caller raises out of its loop on the first
+        failure, the ``finally`` halts the rest of the bundle. That takes TWO
+        mechanisms, because either alone leaks work:
+
+        - ``Future.cancel()`` stops futures that have not started. It is a no-op on a
+          future already running — there is no way to interrupt a thread mid-fetch.
+        - An **abort flag**, checked at the top of every queued fetch, stops the ones
+          that start between the failure surfacing and the cancel landing. Without it,
+          a worker freed by the failure immediately picks up the next queued item and
+          runs it to completion, and with a window of :data:`_MAX_PENDING_SUBMITS`
+          there can be many such items — each one a real transfer in production.
+
+        WHEN the flag is set is what makes it effective. ``download_all`` trips it the
+        instant a fetch raises, before re-raising — not here in the ``finally``. Waiting
+        for teardown leaves the worker free to drain queued items during the unwind:
+        measured on a loaded box with microsecond-fast fetches, that leaked up to 15 of
+        19 queued items. Tripping it at detection cuts the leak to the fetches already
+        in flight, which nothing short of killing threads could stop.
+
+        This ``finally`` still sets it, covering early exits that are not failures (a
+        caller ``break``), and cancels the queue either way.
+
+        The caller must wrap the generator in :func:`contextlib.closing` to guarantee
+        the ``finally`` runs.
         """
         if pool is None:
             yield from items_to_fetch
             return
         item_iter = iter(items_to_fetch)
-        pending = {pool.submit(run): item for item, run in itertools.islice(item_iter, _MAX_PENDING_SUBMITS)}
+
+        def guarded(run: Callable[[], tuple[str, int]]) -> Callable[[], tuple[str, int]]:
+            """Wrap a fetch so it becomes a no-op once fail-fast has tripped."""
+
+            def _run() -> tuple[str, int]:
+                if abort.is_set():
+                    raise _AbortedError
+                return run()
+
+            return _run
+
+        pending = {
+            pool.submit(guarded(run)): item for item, run in itertools.islice(item_iter, _MAX_PENDING_SUBMITS)
+        }
         try:
             while pending:
                 done, _ = wait(pending, return_when=FIRST_COMPLETED)
@@ -1024,9 +1071,12 @@ class Source(ABC):
                     nxt = next(item_iter, None)
                     if nxt is not None:
                         nxt_item, nxt_run = nxt
-                        pending[pool.submit(nxt_run)] = nxt_item
+                        pending[pool.submit(guarded(nxt_run))] = nxt_item
                     yield item, fut.result
         finally:
+            # Flag first, then cancel: a future that slips past ``cancel`` still sees
+            # the flag and returns without fetching.
+            abort.set()
             for fut in pending:
                 fut.cancel()
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -22,6 +22,7 @@ behavior is all exercised against the real client code path.
 from __future__ import annotations
 
 import hashlib
+import time
 from typing import TYPE_CHECKING
 
 import httpx
@@ -304,14 +305,17 @@ def test_download_all_fail_fast_cancels_queued_futures(tmp_path: Path):
     items sit queued. When ``download_all`` re-raises, ``_attempts``' ``finally``
     cancels them.
 
-    What is asserted is the *semantic* — the run halts and the bulk of the queue never
-    executes — not an exact count. ``Executor.shutdown(cancel_futures=True)`` can only
-    cancel futures that have not STARTED, so the number that slip through is however
-    many the worker picks up between the failure surfacing and the cancel landing. That
-    window widens with CPU contention: on a loaded 8-core box this test ran 4, 4, and 10
-    of the 19 queued items across 20 runs, so the previous ``<= 2`` bound failed ~15% of
-    the time. Anything tighter than "not everything drained" is a timing assumption, not
-    a property of the code.
+    Cancellation takes two mechanisms and this pins both: ``Future.cancel()`` for the
+    queued futures, and ``download_all``'s abort flag for the ones a freed worker starts
+    during the unwind (``cancel`` cannot touch a running future). What survives is only
+    what is already in flight — with one worker, at most one fetch.
+
+    The ``time.sleep`` matters. A fetch that returns in microseconds lets the worker
+    race far ahead of the main thread while it is descheduled, which is an artifact of
+    the fake, not a property of the code: measured on a loaded box, an instant fetch
+    leaked up to 8 of 19 items, while a 2 ms fetch (still orders of magnitude faster
+    than a real transfer) leaked at most 1 across 40 trials. Modelling a plausible
+    transfer cost is what makes the strong bound below both meaningful and stable.
     """
     from concurrent.futures import ThreadPoolExecutor
 
@@ -332,17 +336,18 @@ def test_download_all_fail_fast_cancels_queued_futures(tmp_path: Path):
         def _pull(self, source_path, target):
             if source_path == "bad":
                 raise RuntimeError("transport boom")
+            time.sleep(0.002)  # a real transfer is never instant; see docstring
             fetched.append(target.name)
             target.write_text("ok")
 
     with ThreadPoolExecutor(max_workers=1) as pool, pytest.raises(RuntimeError, match="transport boom"):
         FailFirstSource().download_all(tmp_path, pool=pool)
 
-    # Without the cancel-on-early-exit ``finally`` in ``_attempts``, all 19 "ok" items
-    # would drain through the single worker before the pool shut down. Cancelling even
-    # one proves the finally ran; the exact number is scheduler-dependent (see docstring).
-    assert len(fetched) < n_items - 1, (
-        f"expected queued futures to be cancelled, but {len(fetched)} of {n_items - 1} ran"
+    # Without cancellation all 19 "ok" items would drain through the single worker.
+    # One worker means at most one fetch can be in flight when the failure lands; the
+    # bound allows a second for scheduler slack (observed max across 40 loaded trials: 1).
+    assert len(fetched) <= 2, (
+        f"expected all but the in-flight fetch to be cancelled, but {len(fetched)} of {n_items - 1} ran"
     )
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -302,9 +302,16 @@ def test_download_all_fail_fast_cancels_queued_futures(tmp_path: Path):
 
     With a single-worker pool, the failing item is processed first; the remaining
     items sit queued. When ``download_all`` re-raises, ``_attempts``' ``finally``
-    cancels them, so at most a couple ever run: the small race margin is the item(s)
-    the single worker may already have picked up between the failure surfacing and
-    the cancel — hence ``<= 2``, not ``== 0``.
+    cancels them.
+
+    What is asserted is the *semantic* — the run halts and the bulk of the queue never
+    executes — not an exact count. ``Executor.shutdown(cancel_futures=True)`` can only
+    cancel futures that have not STARTED, so the number that slip through is however
+    many the worker picks up between the failure surfacing and the cancel landing. That
+    window widens with CPU contention: on a loaded 8-core box this test ran 4, 4, and 10
+    of the 19 queued items across 20 runs, so the previous ``<= 2`` bound failed ~15% of
+    the time. Anything tighter than "not everything drained" is a timing assumption, not
+    a property of the code.
     """
     from concurrent.futures import ThreadPoolExecutor
 
@@ -331,9 +338,12 @@ def test_download_all_fail_fast_cancels_queued_futures(tmp_path: Path):
     with ThreadPoolExecutor(max_workers=1) as pool, pytest.raises(RuntimeError, match="transport boom"):
         FailFirstSource().download_all(tmp_path, pool=pool)
 
-    # Without the cancel-on-early-exit ``finally`` in ``_attempts``, all 19 "ok"
-    # items would drain through the single worker before the pool shut down.
-    assert len(fetched) <= 2, f"expected queued futures cancelled, but {len(fetched)} ran"
+    # Without the cancel-on-early-exit ``finally`` in ``_attempts``, all 19 "ok" items
+    # would drain through the single worker before the pool shut down. Cancelling even
+    # one proves the finally ran; the exact number is scheduler-dependent (see docstring).
+    assert len(fetched) < n_items - 1, (
+        f"expected queued futures to be cancelled, but {len(fetched)} of {n_items - 1} ran"
+    )
 
 
 def test_download_all_force_overwrite_discards_stale_part_when_dest_missing(tmp_path: Path):

--- a/tests/test_run_example.py
+++ b/tests/test_run_example.py
@@ -53,9 +53,29 @@ def _debug(root: Path, run: subprocess.CompletedProcess) -> str:
     log_fp = root / ".logs" / "pipeline.log"
     log = log_fp.read_text(encoding="utf-8") if log_fp.exists() else "(pipeline.log did not exist)"
     return (
-        f"root tree:\n{sio.getvalue()}\n\npipeline log:\n{log}\n\n"
+        f"root tree:\n{sio.getvalue()}\n\npipeline log:\n{log}\n"
+        f"{_stage_worker_logs(root)}\n"
         f"returncode={run.returncode}\nstdout:\n{run.stdout}\nstderr:\n{run.stderr}"
     )
+
+
+def _stage_worker_logs(root: Path, tail_lines: int = 40) -> str:
+    """Tail every per-worker stage log under ``root``.
+
+    The pipeline runner reports a stage failure as ``ValueError: Stage <name> failed
+    ... with return code 1``, which says nothing about WHY. The child's actual traceback
+    is only in ``<root>/<stage>/.logs/<worker>/*.log``, and this test's tmpdir is gone by
+    the time anyone reads the failure. Rare, load-sensitive stage failures are therefore
+    undiagnosable unless the logs are surfaced at failure time — see #194.
+    """
+    if not root.exists():
+        return ""
+    out = []
+    for fp in sorted(root.glob("*/.logs/*/*.log")):
+        lines = fp.read_text(encoding="utf-8", errors="replace").splitlines()
+        body = "\n".join(lines[-tail_lines:])
+        out.append(f"--- {fp.relative_to(root)} (last {tail_lines} lines) ---\n{body}")
+    return "\n\nper-worker stage logs:\n" + "\n".join(out) if out else ""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Started as a flaky-test fix; became a small product fix once I measured *why* the test was flaky.

## The real finding

`Future.cancel()` only stops futures that have not **started**. `_attempts` submits a window of `_MAX_PENDING_SUBMITS` (**1024**) futures, so when a fetch fails, a worker freed by that failure immediately picks up the next queued item and runs it to completion. In production each of those is a real transfer — after the run has already decided to abort. The "fail fast" in the docstring was only half true.

Adds a cooperative abort: a `threading.Event` checked at the top of every queued fetch, tripped by `download_all` the instant a fetch raises (before re-raising). The generator's `finally` still trips it too — covering a caller `break` — and cancels the queue either way. What survives is only what is already in flight.

Measured, single worker, 40 trials on a loaded 8-core box:

| | queued items that still ran (of 19) |
|---|---|
| before | up to **15** |
| abort set at generator teardown | up to 8 |
| **abort set at detection** | up to **1** (mean 0.72) |

Setting it at detection rather than teardown matters: during the unwind, a worker with microsecond-fast tasks drains a lot.

## The test was also lying to itself

Its fake `_pull` returned in microseconds, which lets the worker race far ahead of a descheduled main thread — a property of the fake, not the code. It now sleeps 2 ms, still orders of magnitude faster than a real transfer.

That makes the aggressive bound honest again:

| bound | under identical load |
|---|---|
| `<= 2` (original) | **3/20 failed** |
| `< n_items - 1` (my first fix — too loose, correctly rejected in review) | 0/20 |
| **`<= 2` + product fix + realistic fetch** | **0/25 failed** |

## On complexity

~34 non-comment lines, no API change (`_attempts` is a private static method), no new abstraction. I'd argue it earns that: it is what makes the strong assertion possible. With the old behavior, no bound tighter than "not everything drained" would hold — and that loose bound is exactly what should not ship.

## Also included

Per-worker stage logs are now tailed into the example test's failure output. The runner reports only `Stage <name> failed ... return code 1`; the child's traceback lives in `<root>/<stage>/.logs/<worker>/*.log`, inside a tmpdir deleted before anyone reads it — which is why #194 has no traceback. The next occurrence will carry one.

228 tests pass; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
