### PR TITLE
Make do_overwrite stand down non-zero workers instead of racing them (#194)

### DIFF
--- a/src/MEDS_extract/_parallelism.py
+++ b/src/MEDS_extract/_parallelism.py
@@ -1,0 +1,93 @@
+"""Guard for the one configuration where parallel workers cannot safely share work.
+
+Every map stage divides work the same way: all workers walk the same list of
+``(input -> output)`` pairs, and :func:`~MEDS_transforms.mapreduce.rwlock.rwlock_wrap`
+makes the first worker to produce an output the only one that computes it — the rest
+hit the "output exists, return" branch and move on.
+
+``do_overwrite=True`` disables exactly that branch. Instead of skipping, every worker
+unlinks the finished output and recomputes it, so N workers do somewhere between 1x
+and Nx the work rather than 1/N of it each. (The ``FileLock`` still prevents two
+workers computing the same output *simultaneously* — the second gets a ``Timeout``
+and moves on — so duplication happens whenever a worker arrives after another has
+finished, which is common given each worker shuffles its list independently.)
+
+In a pure map stage that is only waste. In ``extract_code_metadata`` it is also a
+crash: that stage reduces its own map outputs in the same invocation, and
+``rwlock_wrap`` unlinks *before* taking its lock, so a straggler can delete a partial
+the reducer has already validated (#194).
+
+Rather than let either happen, a run that sets ``do_overwrite`` runs single-worker.
+That is a real cost — the caller asked for parallelism and does not get it — so the
+warning names the alternative that does parallelize.
+
+The proper fix belongs upstream: if ``rwlock_wrap``'s cache could distinguish "this
+output was produced during THIS run" from "left over from a previous one", every
+worker could safely skip a sibling's fresh output while still discarding stale ones,
+and ``do_overwrite`` would parallelize normally. Nothing available to a stage
+identifies a run — hydra's ``sweep.dir`` is overridden to a fixed per-stage log
+directory here, and ``job.num``/``job.id`` are per-worker — so this cannot be fixed
+from inside a stage. Tracked upstream in mmcdermott/MEDS_transforms.
+
+Note this is a property of the cache-based work division, NOT of parallelism itself:
+work partitioned by worker index would be perfectly safe to overwrite. That would
+need the worker *count*, which no stage config exposes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from omegaconf import DictConfig
+
+logger = logging.getLogger(__name__)
+
+
+def exit_for_overwrite(cfg: DictConfig) -> bool:
+    """Should this worker stop immediately because ``do_overwrite`` disables sharing?
+
+    ``True`` for every worker except worker 0 when ``do_overwrite`` is set. Worker 0
+    then performs the whole stage alone, which is correct but serial. Returns ``False``
+    for any ordinary run, so a serial run (``worker`` defaults to 0) and every
+    ``do_overwrite=False`` run are untouched.
+
+    Args:
+        cfg: The stage config. Reads ``do_overwrite`` and ``worker``, both of which
+            MEDS-transforms always supplies.
+
+    Examples:
+        >>> from omegaconf import OmegaConf
+        >>> cfg = OmegaConf.create({"do_overwrite": False, "worker": 0})
+        >>> exit_for_overwrite(cfg)
+        False
+
+        A parallel run WITHOUT ``do_overwrite`` is the normal case — every worker
+        participates:
+
+        >>> exit_for_overwrite(OmegaConf.create({"do_overwrite": False, "worker": 3}))
+        False
+
+        Worker 0 always participates, so the stage still runs to completion:
+
+        >>> exit_for_overwrite(OmegaConf.create({"do_overwrite": True, "worker": 0}))
+        False
+
+        Any other worker stands down when ``do_overwrite`` is set:
+
+        >>> exit_for_overwrite(OmegaConf.create({"do_overwrite": True, "worker": 1}))
+        True
+    """
+    if not (cfg.get("do_overwrite", False) and cfg.get("worker", 0) != 0):
+        return False
+
+    logger.warning(
+        f"do_overwrite=True disables parallel work-sharing, so worker {cfg.worker} is standing "
+        "down and worker 0 will run this stage alone. Workers divide work by skipping outputs a "
+        "sibling already produced, which do_overwrite switches off — leaving every worker to "
+        "redo every output (and, in extract_code_metadata, to delete partials the reducer is "
+        "reading). To re-extract from scratch WITH parallelism, delete the stage's output "
+        "directory and run without do_overwrite instead."
+    )
+    return True

--- a/src/MEDS_extract/convert_to_MEDS_events/convert_to_MEDS_events.py
+++ b/src/MEDS_extract/convert_to_MEDS_events/convert_to_MEDS_events.py
@@ -18,6 +18,7 @@ from MEDS_transforms.stages import Stage
 from omegaconf import DictConfig
 from upath import UPath
 
+from .._parallelism import exit_for_overwrite
 from .._stage_example import MEDSExtractStageExample
 from ..config import MessyConfig
 from ..io import scan_source
@@ -34,6 +35,11 @@ def main(cfg: DictConfig):
     All arguments are specified through the command line into the ``cfg`` object
     through Hydra.
     """
+    # ``do_overwrite`` turns off the output-exists skip that divides work between
+    # workers; see :mod:`MEDS_extract._parallelism`.
+    if exit_for_overwrite(cfg):
+        return
+
     input_dir = UPath(cfg.stage_cfg.data_input_dir)
     out_dir = UPath(cfg.stage_cfg.output_dir)
 

--- a/src/MEDS_extract/convert_to_parquet/convert_to_parquet.py
+++ b/src/MEDS_extract/convert_to_parquet/convert_to_parquet.py
@@ -50,6 +50,7 @@ from MEDS_transforms.mapreduce.rwlock import rwlock_wrap
 from MEDS_transforms.stages import Stage
 from upath import UPath
 
+from .._parallelism import exit_for_overwrite
 from .._stage_example import MEDSExtractStageExample
 from ..config import MessyConfig
 from ..io import _format_family, convert_csv_to_parquet, resolve_source_files
@@ -156,6 +157,11 @@ def main(cfg: DictConfig):
     sleight of hand is exactly what made the pipeline unrunnable without it (#186).
     Naming ``input_dir`` explicitly keeps raw-data resolution in one honest place.
     """
+    # ``do_overwrite`` turns off the output-exists skip that divides work between
+    # workers; see :mod:`MEDS_extract._parallelism`.
+    if exit_for_overwrite(cfg):
+        return
+
     input_dir = UPath(cfg.input_dir)
     out_dir = UPath(cfg.stage_cfg.output_dir)
 

--- a/src/MEDS_extract/convert_to_subject_sharded/convert_to_subject_sharded.py
+++ b/src/MEDS_extract/convert_to_subject_sharded/convert_to_subject_sharded.py
@@ -33,6 +33,7 @@ from MEDS_transforms.mapreduce.rwlock import rwlock_wrap
 from MEDS_transforms.stages import Stage
 from omegaconf import DictConfig
 
+from .._parallelism import exit_for_overwrite
 from .._stage_example import MEDSExtractStageExample
 from ..config import MessyConfig, TableConfig
 from ..io import scan_source
@@ -49,6 +50,11 @@ def main(cfg: DictConfig):
     All arguments come through the Hydra ``cfg`` object; this stage has no
     stage-specific options beyond the global ``MESSY_config_fp``.
     """
+    # ``do_overwrite`` turns off the output-exists skip that divides work between
+    # workers; see :mod:`MEDS_extract._parallelism`.
+    if exit_for_overwrite(cfg):
+        return
+
     input_dir = Path(cfg.stage_cfg.data_input_dir)
     subject_subsharded_dir = Path(cfg.stage_cfg.output_dir)
 

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -17,6 +17,7 @@ from MEDS_transforms.stages import Stage
 from omegaconf import DictConfig
 from upath import UPath
 
+from .._parallelism import exit_for_overwrite
 from .._stage_example import MEDSExtractStageExample
 from ..config import SOURCE_BLOCK_COL, CompiledMetadataBlock, MessyConfig, compile_metadata_block
 from ..io import _format_family, resolve_source_files, scan_source
@@ -588,6 +589,11 @@ def main(cfg: DictConfig):
 
     stage_input_dir = Path(cfg.stage_cfg.data_input_dir)
     partial_metadata_dir = Path(cfg.stage_cfg.output_dir)
+    # ``do_overwrite`` turns off the output-exists skip that divides work between
+    # workers; see :mod:`MEDS_extract._parallelism`.
+    if exit_for_overwrite(cfg):
+        return
+
     raw_input_dir = UPath(cfg.input_dir)
 
     messy_cfg = MessyConfig.load(cfg.MESSY_config_fp)

--- a/tests/test_inprocess_pipeline.py
+++ b/tests/test_inprocess_pipeline.py
@@ -10,6 +10,7 @@ functions themselves.
 """
 
 import json
+import logging
 import tempfile
 from pathlib import Path
 
@@ -560,3 +561,62 @@ def test_finalize_MEDS_metadata_overwrite_succeeds():
         assert splits.schema["split"] == pl.String
         assert sorted(splits["subject_id"].to_list()) == [1, 2]
         assert splits["split"].to_list() == ["train", "train"]
+
+
+# ── do_overwrite / parallelism guard ──
+
+
+@pytest.mark.parametrize(
+    ("do_overwrite", "worker", "should_run"),
+    [
+        (False, 0, True),  # ordinary serial run
+        (False, 1, True),  # ordinary parallel run — every worker participates
+        (True, 0, True),  # worker 0 always runs, so the stage still completes
+        (True, 1, False),  # stands down: do_overwrite disables work-sharing
+    ],
+)
+def test_overwrite_guard_stands_down_only_for_nonzero_workers(
+    tmp_path, caplog, do_overwrite: bool, worker: int, should_run: bool
+):
+    """``do_overwrite=True`` makes every worker but 0 exit before doing any work.
+
+    Guards the fix for #194. Parametrized over the full truth table because the risk is
+    a guard that is too eager: a serial run (``worker`` defaults to 0) and any ordinary
+    parallel run must be completely unaffected, or the guard would silently halve the
+    pipeline. ``convert_to_parquet`` stands in for all four map stages — they share one
+    helper, whose own behavior is pinned by its doctests.
+    """
+    from MEDS_extract.convert_to_parquet.convert_to_parquet import main as convert_stage
+
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    pl.DataFrame({"subject_id": [1], "test_name": ["HR"]}).write_parquet(raw_dir / "labs.parquet")
+    messy_fp = tmp_path / "messy.yaml"
+    messy_fp.write_text("labs:\n  lab:\n    code: $test_name\n    time: null\n")
+
+    cfg = _make_cfg(
+        {
+            "stage": "convert_to_parquet",
+            "input_dir": str(raw_dir),
+            "do_overwrite": do_overwrite,
+            "worker": worker,
+            "stage_cfg": {
+                "data_input_dir": str(raw_dir / "data"),
+                "output_dir": str(tmp_path / "out"),
+            },
+            "MESSY_config_fp": str(messy_fp),
+        }
+    )
+    with caplog.at_level(logging.WARNING):
+        convert_stage.main_fn(cfg)
+
+    produced = (tmp_path / "out" / "labs.parquet").exists()
+    assert produced is should_run, (
+        f"do_overwrite={do_overwrite}, worker={worker}: expected "
+        f"{'output' if should_run else 'no output'}, got {'output' if produced else 'none'}"
+    )
+    if not should_run:
+        # The warning must name the parallel alternative, or a user just loses throughput
+        # with no idea why.
+        assert "standing down" in caplog.text
+        assert "delete the stage's output directory" in caplog.text


### PR DESCRIPTION
Fixes #194.

## The general problem (not metadata-specific)

Every map stage divides work the same way: all workers walk the same `(input -> output)` list, and `rwlock_wrap` makes the first worker to produce an output the only one that computes it — the rest hit its "output exists, return" branch.

`do_overwrite=True` disables **exactly that branch**:

```python
if out_fp_checker(out_fp):
    if do_overwrite:
        out_fp.unlink()   # delete and recompute — every worker, every output
    else:
        return False      # ← the cache hit that divides work between workers
```

So N workers do somewhere between 1× and N× the work rather than 1/N each. The `FileLock` only prevents two workers computing one output *simultaneously* (the second gets `Timeout` and moves on), so duplication happens whenever a worker arrives after another has finished — common, since each shuffles its list independently.

In a pure map stage that is pure waste. In `extract_code_metadata` it is also a **crash**, because that stage reduces its own map outputs in the same invocation and `rwlock_wrap` unlinks *before* taking its lock — so a straggler deletes a partial the reducer has already validated:

```
FileNotFoundError: .../extract_code_metadata/medication_classes_0.parquet
```

## The change

A run that sets `do_overwrite` runs single-worker: workers != 0 warn and return before doing any work. Applied to **all four map stages**, since the wasted work affects all of them and only the crash was metadata-specific.

The warning names the alternative that *does* parallelize — delete the stage's output directory and run without `do_overwrite` — because otherwise someone who asked for 16 workers silently gets one, with no explanation for the longer run.

## Verification

| check | result |
|---|---|
| `do_overwrite=True` + 2 workers | **0/12 failures** (crashed 1/12 before) |
| guard actually fires | confirmed in all four stages' worker-1 logs, 8 warnings |
| parallelism *without* `do_overwrite` | untouched — both workers in every stage, 0 warnings |
| serial runs | untouched (`worker` defaults to 0) |
| suite | 233 pass |

A parametrized truth table over `(do_overwrite, worker)` pins that the guard is not over-eager — the risk with a change like this is silently halving a healthy pipeline, so all four combinations are asserted.

## Why this is a stopgap, and what the real fix is

If `rwlock_wrap`'s cache could distinguish *"produced during THIS run"* from *"left over from a previous one"*, every worker could skip a sibling's fresh output while still discarding stale ones — and `do_overwrite` would parallelize normally.

Nothing available to a stage identifies a run. I checked: hydra's `sweep.dir` is a shared timestamped path in a plain hydra app, but MEDS-transforms overrides it to `${log_dir}` — the same directory every run — and `job.num`/`job.id` are per-worker. So this cannot be fixed from inside a stage.

Worth stating explicitly so it doesn't calcify: this is a property of the **cache-based work division**, not of parallelism itself. Work partitioned by worker index would be perfectly safe to overwrite; that needs the worker *count*, which no stage config exposes.

Filed upstream against MEDS-transforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
