### PR TITLE
Docs: correct the parquet-hardlink claim; fix two dead cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,9 +1453,10 @@ The `metadata/codes.parquet` file also includes:
 ### Performance Optimization
 
 - **Convert very large inputs to parquet ahead of time** if you re-run the pipeline often.
-    `convert_to_parquet` hardlinks parquet sources instead of rewriting them, so a pre-converted input
-    makes the ingest stage effectively free. It is not required — the stage converts csv/csv.gz in
-    bounded memory regardless.
+    `convert_to_parquet` hardlinks a parquet source instead of rewriting it when the file carries only
+    the columns your MESSY config reads — so prune pre-converted files to those columns to make the
+    ingest stage effectively free (an unpruned parquet is rewritten with the projection applied). It is
+    not required — the stage converts csv/csv.gz in bounded memory regardless.
 - **Use parallel processing** for faster extraction via the typical MEDS-Transforms parallelization
     options.
 

--- a/docs/ingestion_pathways.md
+++ b/docs/ingestion_pathways.md
@@ -195,9 +195,10 @@ the MESSY config references projected in. A single raw `labs_vitals.csv` becomes
 a single `labs_vitals.parquet` — there is no row-range chunking, so downstream
 globbing `{prefix}/*.parquet` simply finds one file.
 
-A source that is *already* parquet is hardlinked rather than rewritten: downstream
-scans push projection into the parquet reader themselves, so a rewrite would cost a
-full pass to save nothing.
+A source that is *already* parquet is hardlinked when it carries no columns beyond
+what the MESSY config reads, and rewritten with the projection applied otherwise:
+`convert_to_subject_sharded` does not project, so an unpruned column would be copied
+into every downstream intermediate too.
 
 If the user pre-sharded their raw input — for example, supplying
 `patients/shard_a.parquet` and `patients/shard_b.parquet` rather than a single
@@ -379,7 +380,7 @@ strict sequence.
     instead of a clear "you need to run convert_to_subject_sharded first"
     message.
 
-5. **`convert_to_parquet` silently accepts sub-sharded input** via the
-    `{stem}_` disambiguation. This is technically a corner but users with
-    pre-sharded data should probably be told to enter at
-    `split_and_shard_subjects` instead.
+5. **`convert_to_parquet` silently accepts sub-sharded input** (a table
+    supplied as a `{prefix}/` directory of chunk files). This is technically
+    a corner but users with pre-sharded data should probably be told to
+    enter at `split_and_shard_subjects` instead.

--- a/src/MEDS_extract/download/spec.py
+++ b/src/MEDS_extract/download/spec.py
@@ -36,8 +36,9 @@ _SOURCE_TYPES: dict[str, tuple[str, str]] = {
 # interpolatable from bucket entries via ``${sources.dataset_version}`` /
 # ``${sources.dataset_version.<bucket>}``. It is consumed by ``meds-extract-run``
 # for the ``etl_metadata.dataset_version`` stamp (see
-# ``MEDS_extract.config.read_sources_dataset_version``, which owns its shape
-# validation) and must never be treated as a bucket here.
+# ``MessyConfig._sources_dataset_version`` in ``MEDS_extract.config``, which owns
+# its shape validation, and the public accessors ``sources_version`` /
+# ``raw_version_for``) and must never be treated as a bucket here.
 SOURCES_RESERVED_KEYS: frozenset[str] = frozenset({"dataset_version"})
 
 

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -544,9 +544,10 @@ def main(cfg: DictConfig):
     """Extracts any dataset-specific metadata and adds it to any existing code metadata file.
 
     This script can extract arbitrary, code-linked metadata columns from input mappings and add them to the
-    `metadata/codes.parquet` file. The metadata columns are extracted from the raw metadata files using a
-    parsing DSL that is specified in the `MESSY_config_fp` file. See `parser.py` for more details
-    on this DSL.
+    `metadata/codes.parquet` file. The metadata columns are extracted from the raw metadata files using
+    ``_metadata`` blocks in the `MESSY_config_fp` file; see ``MEDS_extract.config`` (``MessyConfig`` and
+    ``compile_metadata_block``) for the block semantics and the dftly documentation for the expression
+    DSL.
 
     Metadata is attached to codes through one join path: each ``_metadata`` entry's key
     columns (the produced columns whose names match the code expression's component


### PR DESCRIPTION
Two docs-accuracy items from the RC review, both verified against the code:

- **Hardlink claim** — `docs/ingestion_pathways.md` and the README performance tip stated parquet sources are *always* hardlinked; `_convert_one` hardlinks only when the file carries no columns beyond what the MESSY config reads, and otherwise rewrites with the projection applied (deliberately — `convert_to_subject_sharded` does not project, so an unpruned column would propagate into every downstream intermediate). The README tip now tells users the actionable version: prune pre-converted parquet to config-read columns to get the free-ingest behavior. Also replaces the stale `{stem}_` disambiguation reference in open question 5 — that mechanism died with `shard_events`.
- **Dead cross-references** — `extract_code_metadata.main()`'s docstring pointed at a nonexistent `parser.py` (pre-0.7 leftover; now points at `MEDS_extract.config` + dftly), and `download/spec.py`'s reserved-keys comment pointed at `read_sources_dataset_version`, which was renamed away during the rewrite (now `MessyConfig._sources_dataset_version` + the public accessors).

Doctests for both touched modules pass; ruff clean.

Closes #243. Closes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)