### PR TITLE
Confine every Hydra dir to output_dir; delete user_path; explicit-path spec ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,13 @@ meds-extract-run spec=messy.yaml output_dir=... download_key=null input_dir=.. #
 
 `spec=` resolves down a three-rung ladder: a **registered name** (the entry-point group above), a
 **`pkg://` reference** (`pkg://MIMIC_IV_MEDS.configs.event_configs.yaml` — the same syntax
-`MEDS_transform-pipeline` uses), or a **filesystem path**. The runner is a thin orchestrator over the
+`MEDS_transform-pipeline` uses), or an **explicit filesystem path** — absolute, `~`-prefixed, or
+explicitly relative (`./messy.yaml`). A bare name is only ever a registry lookup: `spec=messy.yaml`
+errors with a hint to write `./messy.yaml`, so a typo'd dataset name can never silently resolve to a
+stray local file. Both CLIs keep the invoking CWD untouched (`hydra.job.chdir=false`) and write
+nothing outside `output_dir` — logs and Hydra config snapshots land under
+`<output_dir>/.meds_extract_run/hydra_run` (runner) / `<output_dir>/.hydra_download` (standalone
+download), never in a CWD `outputs/` dir. The runner is a thin orchestrator over the
 two public CLIs — it shells out to each in turn (in-module invocation modes may come later, upstream):
 
 1. spawns `meds-extract-download` to stage the selected `sources:` bucket (`download_key=` picks

--- a/src/MEDS_extract/_cli.py
+++ b/src/MEDS_extract/_cli.py
@@ -1,0 +1,83 @@
+"""Shared console-script plumbing for the two Hydra CLIs.
+
+One job: validate that the required dotlist arguments are present BEFORE Hydra owns
+the process. Both CLIs anchor their Hydra run dir at ``${output_dir}/...``, so Hydra
+cannot even start without ``output_dir`` — and the error it produces for a missing
+interpolation names OmegaConf internals, not the flag the user forgot. Checking
+``sys.argv`` first turns the most common new-user mistake (a bare invocation) into a
+one-line usage message, and guarantees a failed invocation creates no directories
+anywhere.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Flags under which Hydra should run without the required args (help/introspection
+# modes; ``--cfg`` and ``--info`` take their value as a separate token).
+_PASSTHROUGH_FLAGS = frozenset(
+    {"-h", "--help", "--hydra-help", "--cfg", "-c", "--info", "-i", "--shell-completion", "-sc"}
+)
+
+
+def require_dotlist_args(prog: str, required: dict[str, str], *, local_only: tuple[str, ...] = ()) -> None:
+    """Exit 1 with a usage line unless every required ``key=`` argument is present.
+
+    ``local_only`` keys are additionally rejected when their argv value is a URL.
+    This duplicates the authoritative in-config validation (``user_local_path``) for
+    one reason: Hydra's run dir is anchored at ``${output_dir}/...`` and is created
+    BEFORE the task function runs, so a URL-shaped ``output_dir`` would otherwise
+    make Hydra itself materialize a literal ``s3:/...`` directory tree (#213) before
+    any validation could fire.
+
+    Args:
+        prog: Console-script name for the usage message.
+        required: Maps each required dotlist key to the placeholder shown in the
+            usage line (e.g. ``{"spec": "<name|pkg://…|/path|./path>"}``).
+        local_only: Dotlist keys whose values must be local paths, not URLs.
+
+    Examples:
+        >>> import pytest
+        >>> argv = sys.argv
+        >>> sys.argv = ["meds-extract-run"]
+        >>> with pytest.raises(SystemExit) as exc_info:
+        ...     require_dotlist_args("meds-extract-run", {"spec": "<spec>", "output_dir": "<dir>"})
+        >>> exc_info.value.code
+        1
+        >>> sys.argv = ["meds-extract-run", "spec=X", "output_dir=/tmp/o", "download_key=demo"]
+        >>> require_dotlist_args("meds-extract-run", {"spec": "<spec>", "output_dir": "<dir>"})
+        >>> sys.argv = ["meds-extract-run", "spec=X", "output_dir=s3://bucket/raw"]
+        >>> with pytest.raises(SystemExit) as exc_info:
+        ...     require_dotlist_args(
+        ...         "meds-extract-run", {"spec": "<spec>", "output_dir": "<dir>"},
+        ...         local_only=("output_dir",),
+        ...     )
+        >>> exc_info.value.code
+        1
+        >>> sys.argv = ["meds-extract-run", "--help"]
+        >>> require_dotlist_args("meds-extract-run", {"spec": "<spec>", "output_dir": "<dir>"})
+        >>> sys.argv = argv
+    """
+    args = sys.argv[1:]
+    if any(a in _PASSTHROUGH_FLAGS for a in args):
+        return
+    given = dict(a.split("=", 1) for a in args if "=" in a)
+    missing = [k for k in required if k not in given]
+    if missing:
+        usage = " ".join(f"{k}={placeholder}" for k, placeholder in required.items())
+        print(
+            f"{prog}: missing required argument(s): {', '.join(f'{k}=' for k in missing)}\n"
+            f"usage: {prog} {usage} [key=value ...]   (see {prog} --help for all options)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    for k in local_only:
+        if k in given and "://" in given[k]:
+            print(
+                f"{prog}: {k}={given[k]!r} is a URL, but {k} must be a local filesystem path. "
+                "Remote data enters through the download layer (e.g. a `type: fsspec` source in "
+                f"the spec's `sources:` block): fetch to local disk first, then point {k} at the "
+                "local copy.",
+                file=sys.stderr,
+            )
+            sys.exit(1)

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -1651,26 +1651,39 @@ def resolve_config_path(path: str | Path) -> Path:
     return Path(path)
 
 
-def user_path(p: str | Path) -> Path:
-    """Absolutize a user-supplied CLI path against the user's ORIGINAL working directory.
+def user_local_path(p: str | Path, *, field: str = "path") -> Path:
+    """Normalize a user-supplied local path; reject URLs with an actionable error.
 
-    Hydra changes CWD into its run dir by default, so a relative path typed on a CLI
-    would otherwise be resolved against the run dir and "not found". Hydra's
-    ``to_absolute_path`` maps it against the original CWD (and degrades to a plain
-    ``abspath`` outside any Hydra app, so this is safe in tests and library use);
-    ``expanduser``/``resolve`` normalize ``~`` and symlinks. Absolute inputs pass
-    through unchanged (modulo normalization), so this cannot misdirect a
-    fully-specified path.
+    Both CLIs run with ``hydra.job.chdir=false``, so a relative path means exactly
+    what the invoking shell suggests; ``expanduser``/``resolve`` normalize ``~``,
+    ``.``, and symlinks into the unambiguous absolute form the child processes need.
+    URL-shaped values are rejected rather than silently collapsed into a local
+    relative path (``Path("s3://b/x")`` becomes the literal directory ``s3:/b/x``
+    under CWD — see #213): these fields are local-only by design, and the download
+    layer is the one remote-data ingress.
 
     Examples:
-        >>> user_path("/already/absolute")
+        >>> user_local_path("/already/absolute")
         PosixPath('/already/absolute')
-        >>> user_path("relative.yaml").is_absolute()
+        >>> user_local_path("relative_dir").is_absolute()
         True
+        >>> user_local_path("s3://bucket/raw", field="output_dir")
+        Traceback (most recent call last):
+            ...
+        ValueError: output_dir='s3://bucket/raw' is a URL, but output_dir must be a local
+        filesystem path. Remote data enters through the download layer (e.g. a `type: fsspec`
+        source in the spec's `sources:` block): fetch to local disk first, then point
+        output_dir at the local copy.
     """
-    from hydra.utils import to_absolute_path  # deferred: keep hydra off non-CLI import paths
-
-    return Path(to_absolute_path(str(p))).expanduser().resolve()
+    s = str(p)
+    if "://" in s:
+        raise ValueError(
+            f"{field}={s!r} is a URL, but {field} must be a local filesystem path. "
+            "Remote data enters through the download layer (e.g. a `type: fsspec` source "
+            f"in the spec's `sources:` block): fetch to local disk first, then point "
+            f"{field} at the local copy."
+        )
+    return Path(s).expanduser().resolve()
 
 
 # ── EtlConfig: the reserved `etl:` block ─────────────────────────────
@@ -2103,7 +2116,7 @@ class MessyConfig:
         )
 
     @classmethod
-    def load(cls, spec: str | Path, *, path_resolver: Callable[[str], Path] = Path) -> MessyConfig:
+    def load(cls, spec: str | Path) -> MessyConfig:
         """THE loading entry point: resolve a spec reference, read, validate, parse.
 
         Every consumer — the run CLI, the download CLI, and all eight stages (via
@@ -2121,13 +2134,12 @@ class MessyConfig:
            :meth:`dataset_version_for`), and :attr:`spec_ref` becomes the
            equivalent portable ``pkg://`` reference.
         2. **pkg://** — resolved via the shared :func:`resolve_config_path`.
-        3. **Filesystem path** — everything else, mapped through ``path_resolver``
-           (CLIs inject Hydra original-CWD resolution) then checked for existence;
-           a miss errors listing the registered names, so a typo'd dataset name is
-           diagnosable. Registered names win over paths by design: they are dataset
-           display names ("MIMIC-IV") that in practice never name an existing file,
-           and an explicit ``./name`` or absolute path never matches an entry-point
-           name.
+        3. **Explicit filesystem path** — an absolute path, a ``~`` path, or an
+           explicit relative path (``./x.yaml`` / ``../x.yaml``). A bare name that
+           matches no registration is an error naming both remedies (the registered
+           names, and the ``./`` spelling) — it is NOT tried as a relative path, so
+           a typo'd dataset name can never silently resolve to a stray local file,
+           and an explicit path never collides with an entry-point name.
 
         Examples:
             >>> with yaml_disk('''
@@ -2167,13 +2179,26 @@ class MessyConfig:
             ValueError: Entry point 'Missing-Res' points at 'fake_ds_pkg:nope.yaml', but module
             'fake_ds_pkg' has no resource named 'nope.yaml' ...
 
-            A spec matching no rung fails naming the registered pipelines:
+            A bare name matching no registration fails with both remedies — the
+            registered names, and the explicit-path spelling (bare relative paths are
+            deliberately not tried, so ``file.yaml`` errors while ``./file.yaml``
+            loads):
 
             >>> MessyConfig.load("Not-A-Registered-Name")
             Traceback (most recent call last):
                 ...
-            FileNotFoundError: spec='Not-A-Registered-Name' is not a registered pipeline name, a
-            pkg:// reference, or an existing file. Registered pipelines: Bare-Mod, Fake-DS, ...
+            FileNotFoundError: spec='Not-A-Registered-Name' is not a registered pipeline name or a
+            pkg:// reference. Registered pipelines: Bare-Mod, Fake-DS, Missing-Res. To load a MESSY
+            file by path, give an absolute path or an explicit relative path
+            (./Not-A-Registered-Name).
+
+            An explicit path that does not exist says so directly:
+
+            >>> MessyConfig.load("./no-such-file.yaml")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            FileNotFoundError: spec='./no-such-file.yaml' resolved to ...no-such-file.yaml, which
+            does not exist.
         """
         spec = str(spec)
         by_name = {ep.name: ep for ep in entry_points(group=cls.PIPELINES_ENTRY_POINT_GROUP)}
@@ -2202,16 +2227,21 @@ class MessyConfig:
             fp = resolve_config_path(spec)
             if not fp.is_file():
                 raise FileNotFoundError(f"spec={spec!r} resolved to {fp}, which does not exist.")
-        else:
-            fp = path_resolver(spec)
+        elif spec.startswith(("./", "../", "~")) or Path(spec).is_absolute():
+            fp = Path(spec).expanduser().resolve()
             if not fp.is_file():
-                registered = ", ".join(sorted(by_name)) or "(none)"
-                raise FileNotFoundError(
-                    f"spec={spec!r} is not a registered pipeline name, a pkg:// reference, or an "
-                    f"existing file. Registered pipelines: {registered}."
-                )
-            fp = fp.resolve()
+                raise FileNotFoundError(f"spec={spec!r} resolved to {fp}, which does not exist.")
             spec_ref = str(fp)
+        else:
+            # A bare name is ONLY a registry lookup: never fall back to treating it as
+            # a relative path, so a typo'd dataset name cannot silently resolve to a
+            # stray local file (and an explicit path never collides with a name).
+            registered = ", ".join(sorted(by_name)) or "(none)"
+            raise FileNotFoundError(
+                f"spec={spec!r} is not a registered pipeline name or a pkg:// reference. "
+                f"Registered pipelines: {registered}. To load a MESSY file by path, give an "
+                f"absolute path or an explicit relative path (./{spec})."
+            )
 
         logger.info(f"Reading MESSY config from {fp}")
         raw = OmegaConf.load(fp)

--- a/src/MEDS_extract/download/_cli.yaml
+++ b/src/MEDS_extract/download/_cli.yaml
@@ -1,0 +1,15 @@
+# Primary Hydra config for ``meds-extract-download``: the DownloadConfig dataclass
+# schema plus the Hydra behavior the dataclass cannot carry. The run dir defaults
+# under the download destination itself, so logs and the .hydra/ snapshot travel with
+# the fetched data and nothing is written to the invoking CWD (#236); the runner
+# overrides it under its own work dir. ``chdir: false`` keeps relative paths anchored
+# to the user's CWD.
+defaults:
+  - download_defaults
+  - _self_
+
+hydra:
+  run:
+    dir: ${output_dir}/.hydra_download
+  job:
+    chdir: false

--- a/src/MEDS_extract/download/cli.py
+++ b/src/MEDS_extract/download/cli.py
@@ -28,7 +28,8 @@ import hydra
 from MEDS_transforms.configs.utils import hydra_registered_dataclass
 from omegaconf import MISSING, DictConfig
 
-from ..config import MessyConfig, user_path
+from .._cli import require_dotlist_args
+from ..config import MessyConfig, user_local_path
 from .source import validate_unique_destinations
 
 logger = logging.getLogger(__name__)
@@ -61,9 +62,9 @@ class DownloadConfig:
     do_overwrite: bool = False
 
 
-@hydra.main(version_base=None, config_name="download_defaults")
-def main(cfg: DictConfig) -> None:
-    """Entry point for the ``meds-extract-download`` console script.
+@hydra.main(version_base=None, config_path=".", config_name="_cli")
+def _hydra_main(cfg: DictConfig) -> None:
+    """Hydra task function for ``meds-extract-download``; see :func:`main`.
 
     Required args (Hydra dotlist syntax):
 
@@ -91,19 +92,14 @@ def main(cfg: DictConfig) -> None:
     :func:`sys.exit` — Hydra discards the task function's *return* value, so a
     plain ``return 1`` would not reach the process exit code.
     """
-    # ``pkg://`` specs resolve through the shared helper; filesystem specs resolve
-    # against the user's original working directory — Hydra changes CWD by default,
-    # so a relative `spec=` would otherwise be looked up under Hydra's output dir
-    # and silently fail with FileNotFoundError.
-    output_dir = user_path(str(cfg.output_dir))
-
     # One load of the one config object, then everything comes off it. Errors —
-    # spec resolution, document validation, bad bucket key, malformed source
-    # entries, unresolvable interpolations in the selected bucket — are user
-    # config mistakes: log them and exit 1, mirroring the manifest-validation
+    # spec resolution, a URL-shaped output_dir, document validation, bad bucket key,
+    # malformed source entries, unresolvable interpolations in the selected bucket —
+    # are user config mistakes: log them and exit 1, mirroring the manifest-validation
     # handling below, rather than dumping a raw traceback through Hydra.
     try:
-        messy = MessyConfig.load(str(cfg.spec), path_resolver=user_path)
+        output_dir = user_local_path(str(cfg.output_dir), field="output_dir")
+        messy = MessyConfig.load(str(cfg.spec))
         sources = messy.selected_sources(key=cfg.key)
     except (TypeError, ValueError, FileNotFoundError) as e:
         logger.error(f"Could not construct sources from the spec: {e}")
@@ -160,6 +156,22 @@ def main(cfg: DictConfig) -> None:
                     break
         if not all_ok:
             sys.exit(1)
+
+
+def main() -> None:
+    """Console-script entry point for ``meds-extract-download``.
+
+    Validates the required dotlist args before Hydra owns the process: the Hydra run
+    dir is anchored at ``${output_dir}/...``, so without this check a bare invocation
+    would die inside interpolation resolution instead of printing usage — and a failed
+    invocation must create no directories anywhere.
+    """
+    require_dotlist_args(
+        "meds-extract-download",
+        {"spec": "<pkg://...|/path|./path>", "output_dir": "<dir>"},
+        local_only=("output_dir",),
+    )
+    _hydra_main()
 
 
 if __name__ == "__main__":

--- a/src/MEDS_extract/run/_cli.yaml
+++ b/src/MEDS_extract/run/_cli.yaml
@@ -1,0 +1,15 @@
+# Primary Hydra config for ``meds-extract-run``: the RunConfig dataclass schema plus
+# the Hydra behavior the dataclass cannot carry. The run dir lives INSIDE the target
+# output tree — every log and .hydra/ snapshot lands where the run's artifacts live,
+# and nothing is ever written to the invoking CWD (#236). ``chdir: false`` keeps the
+# process in the user's CWD, so relative paths (``output_dir=out``, ``spec=./x.yaml``)
+# mean exactly what the shell suggests they mean.
+defaults:
+  - run_defaults
+  - _self_
+
+hydra:
+  run:
+    dir: ${output_dir}/.meds_extract_run/hydra_run
+  job:
+    chdir: false

--- a/src/MEDS_extract/run/cli.py
+++ b/src/MEDS_extract/run/cli.py
@@ -37,7 +37,8 @@ import hydra
 from MEDS_transforms.configs.utils import hydra_registered_dataclass
 from omegaconf import MISSING, DictConfig, OmegaConf
 
-from ..config import MessyConfig, user_path
+from .._cli import require_dotlist_args
+from ..config import MessyConfig, user_local_path
 
 logger = logging.getLogger(__name__)
 
@@ -118,9 +119,10 @@ class RunConfig:
     dataclass). It validates the plausible combinations — exactly one of "download
     into ``download_dest_dir``" (``download_key`` set) or "read pre-staged
     ``input_dir``" (``download_key=null``) describes where the pipeline's raw
-    input comes from (:attr:`effective_input_dir`) — and absolutizes the directory
-    fields against the user's original working directory, so no path handling is
-    left to the CLI body.
+    input comes from (:attr:`effective_input_dir`) — and normalizes the directory
+    fields to absolute local paths (URL-shaped values are rejected; relative paths
+    resolve against the invoking CWD, which ``hydra.job.chdir=false`` leaves
+    untouched), so no path handling is left to the CLI body.
     """
 
     spec: str = MISSING
@@ -137,11 +139,13 @@ class RunConfig:
     download_continue_on_error: bool = False
 
     def __post_init__(self):
-        # ``stage_runner_fp`` is user-typed like the directory fields, so it takes the
-        # same original-CWD absolutization — Hydra has already changed CWD by now.
+        # The CLI runs with ``hydra.job.chdir=false`` (see ``_cli.yaml``), so relative
+        # paths mean what the shell suggests; they are absolutized here only so the
+        # children (which may manage their own CWDs) see unambiguous paths. URL-shaped
+        # values are rejected outright — these fields are local-only.
         for f in ("output_dir", "download_dest_dir", "input_dir", "stage_runner_fp"):
             if getattr(self, f) not in (None, MISSING):
-                setattr(self, f, str(user_path(getattr(self, f))))
+                setattr(self, f, str(user_local_path(getattr(self, f), field=f)))
         if self.download_key is None and self.input_dir is None:
             raise ValueError(
                 "download_key=null (no download) requires input_dir= pointing at pre-staged raw data."
@@ -234,9 +238,9 @@ class RunConfig:
         return argv
 
 
-@hydra.main(version_base=None, config_name="run_defaults")
-def main(cfg: DictConfig) -> None:
-    """Entry point for the ``meds-extract-run`` console script.
+@hydra.main(version_base=None, config_path=".", config_name="_cli")
+def _hydra_main(cfg: DictConfig) -> None:
+    """Hydra task function for ``meds-extract-run``; see :func:`main`.
 
     Required args (Hydra dotlist syntax): ``spec=...`` and ``output_dir=...``; see
     :class:`RunConfig` for the optional knobs.
@@ -247,7 +251,7 @@ def main(cfg: DictConfig) -> None:
         # combinations and absolutizes the directory fields.
         run: RunConfig = OmegaConf.to_object(cfg)
         # One load of the one config object; everything else comes off it.
-        messy = MessyConfig.load(run.spec, path_resolver=user_path)
+        messy = MessyConfig.load(run.spec)
         _ = messy.event_tables  # the pipeline needs event tables: fail before any work
         # Version stamping follows the selected sources bucket; a download-free run
         # (download_key=null) has no selected bucket and stamps the default
@@ -278,3 +282,19 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Wrote synthesized pipeline config to {pipeline_fp}")
 
     sys.exit(run_command(run.pipeline_argv(pipeline_fp)))
+
+
+def main() -> None:
+    """Console-script entry point for ``meds-extract-run``.
+
+    Validates the required dotlist args before Hydra owns the process: the Hydra run
+    dir is anchored at ``${output_dir}/...``, so without this check a bare invocation
+    would die inside interpolation resolution instead of printing usage — and a failed
+    invocation must create no directories anywhere.
+    """
+    require_dotlist_args(
+        "meds-extract-run",
+        {"spec": "<name|pkg://...|/path|./path>", "output_dir": "<dir>"},
+        local_only=("output_dir", "input_dir", "download_dest_dir"),
+    )
+    _hydra_main()

--- a/tests/test_download_cli.py
+++ b/tests/test_download_cli.py
@@ -519,3 +519,14 @@ spec.yaml: |
     assert "does not name a sources bucket" in combined
     assert "['dataset', 'demo']" in combined
     assert not (tmp_path / "raw_bad").exists()
+
+
+def test_download_cli_bare_invocation_prints_usage_and_writes_nothing(tmp_path):
+    """A bare invocation exits 1 with a one-line usage message before Hydra runs, so no run dir (or anything
+    else) is created anywhere."""
+    result = subprocess.run(
+        ["meds-extract-download"], capture_output=True, text=True, check=False, cwd=tmp_path
+    )
+    assert result.returncode == 1
+    assert "missing required argument" in result.stderr
+    assert not any(tmp_path.iterdir())

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -51,12 +51,18 @@ _TINY_CSV = "patient_id,eye_color\n1,BLUE\n2,BROWN\n3,GREEN\n4,BLUE\n"
 
 
 def _run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess:
-    """Invoke the real ``meds-extract-run`` console script."""
+    """Invoke the real ``meds-extract-run`` console script from ``tmp_path``.
+
+    Deliberately passes no ``hydra.run.dir`` override and runs with ``cwd=tmp_path``:
+    the default run dir (``${output_dir}/.meds_extract_run/hydra_run``) and the
+    no-CWD-litter contract are part of what these tests pin.
+    """
     return subprocess.run(
-        ["meds-extract-run", *args, f"hydra.run.dir={tmp_path / '.hydra'}"],
+        ["meds-extract-run", *args],
         capture_output=True,
         text=True,
         check=False,
+        cwd=tmp_path,
     )
 
 
@@ -88,12 +94,23 @@ def test_run_command_spawns_via_sys_executable_dash_m(monkeypatch):
 def test_run_cli_full_flow(tmp_path):
     """The real console script end-to-end over a tiny local spec: downloads from the
     fsspec mirror into the default destination, synthesizes a fully inlined pipeline
-    config under the work dir, runs the real pipeline, and exits 0."""
+    config under the work dir, runs the real pipeline, and exits 0.
+
+    Invoked with an explicit relative spec (``./spec.yaml``) and a relative
+    ``output_dir`` from ``tmp_path``, pinning that ``hydra.job.chdir=false`` keeps
+    relative paths anchored to the invoking CWD — and that the entire run writes
+    NOTHING outside the output tree (every Hydra run dir included)."""
     spec_fp = _write_tiny_spec(tmp_path)
     out_dir = tmp_path / "meds"
 
-    result = _run_cli(tmp_path, f"spec={spec_fp}", f"output_dir={out_dir}")
+    result = _run_cli(tmp_path, "spec=./spec.yaml", "output_dir=meds")
     assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+    # No CWD litter: the only new entry beside the fixtures is the output tree itself.
+    assert {p.name for p in tmp_path.iterdir()} == {"mirror", "spec.yaml", "meds"}
+    # The CLIs' Hydra run dirs live inside the output tree, not the CWD.
+    assert (out_dir / ".meds_extract_run" / "hydra_run" / "cli.log").exists()
+    assert (out_dir / ".meds_extract_run" / "hydra_download" / ".hydra").is_dir()
 
     # Raw data staged into the documented default destination (under the work dir).
     assert (out_dir / ".meds_extract_run" / "raw_input" / "patients.csv").exists()
@@ -138,7 +155,8 @@ def test_run_cli_download_failure_stops_the_run(tmp_path):
 def test_run_cli_config_errors_exit_one(tmp_path):
     """Bad inputs fail before any work: an unresolvable spec; a path-resolved spec
     omitting dataset_name; an implausible flag combination (input_dir with a
-    download_key)."""
+    download_key). The only thing a failed run may create is its own Hydra run dir
+    (log + config snapshot) inside the target output tree."""
     result = _run_cli(tmp_path, "spec=No-Such-Pipeline", f"output_dir={tmp_path / 'o1'}")
     assert result.returncode == 1
     assert "not a registered pipeline name" in result.stdout + result.stderr
@@ -155,7 +173,30 @@ def test_run_cli_config_errors_exit_one(tmp_path):
     assert "input_dir= is for download-free runs" in result.stdout + result.stderr
 
     for d in ("o1", "o2", "o3"):
-        assert not (tmp_path / d).exists()  # nothing was written
+        # No data, no staging — at most the run's own Hydra log dir under the target.
+        created = {p.name for p in (tmp_path / d).iterdir()} if (tmp_path / d).exists() else set()
+        assert created <= {".meds_extract_run"}, created
+    assert not (tmp_path / "outputs").exists()  # no Hydra litter in the CWD
+
+
+def test_run_cli_bare_and_pathless_invocations(tmp_path):
+    """A bare invocation prints a one-line usage and creates NOTHING; a bare relative
+    spec (no ``./``) is refused with the explicit-path hint; a URL output_dir is
+    rejected before Hydra can materialize a literal ``s3:/`` directory."""
+    result = _run_cli(tmp_path)
+    assert result.returncode == 1
+    assert "missing required argument" in result.stderr
+    assert not any(tmp_path.iterdir())
+
+    _write_tiny_spec(tmp_path)
+    result = _run_cli(tmp_path, "spec=spec.yaml", "output_dir=out")
+    assert result.returncode == 1
+    assert "./spec.yaml" in result.stdout + result.stderr
+
+    result = _run_cli(tmp_path, "spec=./spec.yaml", "output_dir=s3://bucket/raw")
+    assert result.returncode == 1
+    assert "must be a local filesystem path" in result.stderr
+    assert not any(p.name.startswith("s3:") for p in tmp_path.iterdir())
 
 
 def test_run_cli_download_free_run_and_pipeline_failure_propagates(tmp_path):


### PR DESCRIPTION
The usability half of the upstream-0.7 work, per maintainer direction (goals: **no extra dirs anywhere**, and **less dir-mangling code**).

**No extra dirs (#236):** both CLIs now ship a yaml primary config anchoring `hydra.run.dir` *inside* the target output tree (`<output_dir>/.meds_extract_run/hydra_run` for the runner, `<output_dir>/.hydra_download` for standalone download) with `hydra.job.chdir=false`. Verified empirically: a full pipeline run from a clean CWD with relative paths (`spec=./spec.yaml output_dir=out`) creates *only* `out/`, with all ten Hydra dirs (parent, download child, 8 stage children) confined inside it; a bare invocation creates nothing; a config-error run creates only the run's own log dir inside the target tree. Tests pin the litter contract.

**Less mangling (#213):** `user_path` (the `to_absolute_path` original-CWD compensation — the code that turned `s3://bucket` into `./s3:/bucket`) and `MessyConfig.load`'s `path_resolver` injection are deleted. With no chdir, `.` is unambiguous (always the shell's CWD), so what remains is plain normalization — `Path(v).expanduser().resolve()` on fields handed to child processes — plus an actionable URL rejection (`user_local_path`).

**Explicit-path spec ladder:** `spec=` is a registered name, `pkg://`, or an *explicit* path (absolute / `~` / `./` / `../`). A bare name is only ever a registry lookup — `spec=file.yaml` errors with a hint to write `./file.yaml` — so a typo'd dataset name can never silently resolve to a stray local file.

**One new piece** (`_cli.py`, ~30 lines of logic): a pre-Hydra argv check for required args and URL-shaped `output_dir` (#235). It is the structural price of `run.dir=${output_dir}/…`: Hydra resolves that interpolation and mkdirs the run dir *before* the task function runs, so a missing `output_dir` would otherwise die in an omegaconf-internals traceback and `output_dir=s3://…` would make Hydra itself materialize a literal `s3:/` tree before any validation could fire.

Verified: full default suite (228 passed, incl. new litter/usage/URL tests), parallelism lane, config + `_cli` doctests, pre-commit clean.

Closes #236. Closes #213. Closes #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
