### PR TITLE
Pass marker_dir to the two direct rwlock_wrap call sites

### DIFF
--- a/src/MEDS_extract/convert_to_MEDS_events/convert_to_MEDS_events.py
+++ b/src/MEDS_extract/convert_to_MEDS_events/convert_to_MEDS_events.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import polars as pl
 from MEDS_transforms.dataframe import write_df
-from MEDS_transforms.mapreduce.rwlock import rwlock_wrap
+from MEDS_transforms.mapreduce.rwlock import run_marker_dir, rwlock_wrap
 from MEDS_transforms.stages import Stage
 from omegaconf import DictConfig
 from upath import UPath
@@ -49,6 +49,11 @@ def main(cfg: DictConfig):
 
     do_dedup = cfg.stage_cfg.get("do_dedup_text_and_numeric", False)
 
+    # Run-scoped do_overwrite (MEDS-transforms 0.7.0): the marker dir is how parallel
+    # workers tell "fresh, written by a sibling this run" from "stale, overwrite it".
+    # map_stage passes this automatically; direct rwlock_wrap callers must too, or
+    # do_overwrite degrades to N-fold recomputation. None (no run_id) is legacy mode.
+    marker_dir = run_marker_dir(cfg)
     for sp, _ in subject_splits:
         for table in messy_cfg.shuffled_tables():
             input_fps = table.source_files(input_dir / sp)
@@ -61,6 +66,7 @@ def main(cfg: DictConfig):
                 write_df,
                 partial(table.extract_events, do_dedup_text_and_numeric=do_dedup),
                 do_overwrite=cfg.do_overwrite,
+                marker_dir=marker_dir,
             )
 
     logger.info("Subsharded into converted events.")

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import polars as pl
 from dftly import Parser
 from meds import CodeMetadataSchema
-from MEDS_transforms.mapreduce.rwlock import is_complete_parquet_file, rwlock_wrap
+from MEDS_transforms.mapreduce.rwlock import is_complete_parquet_file, run_marker_dir, rwlock_wrap
 from MEDS_transforms.stages import Stage
 from omegaconf import DictConfig
 from upath import UPath
@@ -674,6 +674,9 @@ def main(cfg: DictConfig):
                 atomic_write_parquet,
                 partial(extract_metadata, compiled=compiled),
                 do_overwrite=cfg.do_overwrite,
+                # Run-scoped do_overwrite (MT 0.7.0): without the marker dir, parallel
+                # workers treat each other's fresh outputs as stale and redo the work.
+                marker_dir=run_marker_dir(cfg),
             )
             all_out_fps.append(out_fp)
             out_fp_keys[out_fp] = (input_prefix, cfg_idx)


### PR DESCRIPTION
Completes the MEDS-transforms 0.7.0 adoption from #257: run-scoped `do_overwrite` only engages when `rwlock_wrap` receives a `marker_dir` — `map_stage` passes `run_marker_dir(cfg)` automatically, but `convert_to_MEDS_events` and `extract_code_metadata` call `rwlock_wrap` directly and didn't, so multi-worker `do_overwrite` runs of those two stages redid each output N times (correctness preserved by 0.7.0's atomic writes + delete-under-lock; throughput was not). Found by the #254 read/write-atomicity audit. `run_marker_dir` returns `None` without `run_id`/`log_dir`, so tests and legacy invocations are untouched.

Two-line change per site; stage/e2e/inprocess tests green locally.

Refs #257, #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)