### PR TITLE
Docs: zero-warning strict build + docs CI job

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,38 @@
+# Guards against doc drift (#244): ``mkdocs build --strict`` fails on broken internal
+# links, dead anchors, and warnings from the generated stage/API pages. The install
+# mirrors ReadTheDocs (package + docs extra, no dev group), so a green check here also
+# means the RTD build can resolve its toolchain and render the site.
+
+name: Docs
+
+on:
+  pull_request:
+    branches: [main, "release/*", "dev"]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # git-authors / git-revision-date-localized derive per-page metadata from git
+          # history; a shallow clone would make them warn and mis-report dates.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-suffix: docs
+
+      - name: Install docs toolchain
+        run: uv sync --locked --extra docs --no-dev
+
+      - name: Build the site
+        run: uv run --no-sync mkdocs build --strict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,10 @@ repos:
       - id: end-of-file-fixer
       - id: check-docstring-first
       - id: check-yaml
+        # mkdocs.yml uses the (MkDocs-sanctioned) ``!!python/object/apply:`` tag for its
+        # GitHub-compatible heading slugifier, which PyYAML's safe loader rejects. The
+        # Docs CI workflow validates mkdocs.yml far more thoroughly on every PR anyway.
+        exclude: mkdocs.yml
       - id: debug-statements
       - id: detect-private-key
       - id: check-executables-have-shebangs

--- a/README.md
+++ b/README.md
@@ -1474,7 +1474,8 @@ We welcome contributions! Please see our [Contributing Guide](https://github.com
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the
+[LICENSE](https://github.com/mmcdermott/MEDS_extract/blob/main/LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,5 +1,6 @@
 """Generate the code reference pages."""
 
+import re
 from pathlib import Path
 
 import mkdocs_gen_files
@@ -8,6 +9,41 @@ nav = mkdocs_gen_files.Nav()
 
 root = Path(__file__).parent.parent
 src = root / "src"
+
+GITHUB_URL = "https://github.com/mmcdermott/MEDS_extract"
+
+# Matches the target of an inline Markdown link/image whose target is relative (skips
+# absolute URLs, in-page anchors, and mailto:). Group 1 is the ``[text](`` prefix,
+# group 2 the target (with any ``#fragment``), group 3 the closing paren.
+_RELATIVE_LINK_RE = re.compile(r"(\[[^\]]*\]\()(?!(?:[a-z][a-z0-9+.-]*:|#))([^)\s]+)(\))")
+
+
+def absolutize_relative_links(text: str, base_dir: Path) -> str:
+    """Rewrite ``text``'s relative Markdown links as absolute GitHub URLs.
+
+    Package READMEs are written to be read in-repo, where relative links to source
+    files (``[cli.py](cli.py)``) work. When a README is embedded in a generated API
+    page, those targets do not exist among the documentation files, so ``--strict``
+    builds flag every one of them (#244). Rewriting them to ``blob``/``tree`` URLs on
+    the default branch keeps both renderings working without touching the README.
+
+    Targets that do not resolve to an existing repo path are left alone so that
+    MkDocs' link validation still reports them as drift.
+    """
+
+    def _rewrite(match: re.Match) -> str:
+        target, _, fragment = match.group(2).partition("#")
+        resolved = (base_dir / target).resolve()
+        if not resolved.is_relative_to(root) or not resolved.exists():
+            return match.group(0)
+        kind = "tree" if resolved.is_dir() else "blob"
+        url = f"{GITHUB_URL}/{kind}/main/{resolved.relative_to(root).as_posix()}"
+        if fragment:
+            url = f"{url}#{fragment}"
+        return f"{match.group(1)}{url}{match.group(3)}"
+
+    return _RELATIVE_LINK_RE.sub(_rewrite, text)
+
 
 for path in sorted(src.rglob("*.py")):
     module_path = path.relative_to(src).with_suffix("")
@@ -23,9 +59,10 @@ for path in sorted(src.rglob("*.py")):
         doc_path = doc_path.with_name("index.md")
         full_doc_path = full_doc_path.with_name("index.md")
 
-        readme_path = Path("/".join((*parts, "README.md")))
-        if (src / readme_path).exists():
-            md_file_lines.append(f'--8<-- "src/{readme_path!s}"')
+        readme_path = src / Path(*parts) / "README.md"
+        if readme_path.exists():
+            readme_text = readme_path.read_text(encoding="utf-8")
+            md_file_lines.append(absolutize_relative_links(readme_text, readme_path.parent))
     elif parts[-1] == "__main__":
         continue
 

--- a/docs/gen_static_assets.py
+++ b/docs/gen_static_assets.py
@@ -1,0 +1,22 @@
+"""Mirror the repository's root ``static/`` assets into the built site.
+
+``docs/index.md`` snippet-includes the root ``README.md``, whose logo ``<picture>``
+block points at ``static/logo_*.svg`` via repo-root-relative paths. Those resolve on
+GitHub (the files live next to the README) but MkDocs only ships files found under
+``docs_dir``, so on the built site the logo 404s (#244). Rather than duplicating the
+assets or symlinking (fragile on Windows checkouts), copy them into the virtual docs
+tree at build time so the home page — rendered at the site root — sees ``static/...``
+at the same relative location as on GitHub.
+"""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+root = Path(__file__).parent.parent
+
+for path in sorted((root / "static").rglob("*")):
+    if not path.is_file():
+        continue
+    with mkdocs_gen_files.open(path.relative_to(root).as_posix(), "wb") as fd:
+        fd.write(path.read_bytes())

--- a/docs/hooks/silence_griffe_missing_type_warnings.py
+++ b/docs/hooks/silence_griffe_missing_type_warnings.py
@@ -1,0 +1,43 @@
+"""MkDocs hook: drop griffe's "No type or annotation" docstring warnings.
+
+The codebase's Google-style docstrings put types in signatures, not prose, and
+document Hydra config keys as pseudo-parameters (``cfg.stage_cfg.split_fracs``) and
+grouped pass-through kwargs (``include, exclude:``) that have no single signature
+annotation. griffe warns "No type or annotation for parameter ..." on every one,
+which would fail ``mkdocs build --strict`` (#244) despite being deliberate style.
+
+griffe has a first-class ``warn_missing_types: false`` docstring option for exactly
+this, but it only became configurable through mkdocstrings-python in 1.17, which
+requires mkdocstrings >= 1.0 — a major bump from the 0.28.2 this repo pins. Until
+those pins move, filter the message class at the logging layer instead. Delete this
+hook (and set ``warn_missing_types: false`` next to ``warn_unknown_params`` in
+mkdocs.yml) once the docs toolchain is bumped.
+
+Failure mode is safe: if griffe's message wording or logger routing changes, the
+filter stops matching and the warnings resurface as strict-build failures rather
+than being silently swallowed.
+"""
+
+import logging
+
+# mkdocstrings-python patches griffe's logger to emit under the mkdocs plugin
+# namespace (so mkdocs' --strict counter sees it), prefixing messages with
+# "griffe: ". Filtering on the emitting logger drops the record before it
+# propagates to mkdocs' warning counter.
+_GRIFFE_LOGGER_NAME = "mkdocs.plugins.griffe"
+_SILENCED_MARKER = "No type or annotation for"
+
+
+class _MissingTypeWarningFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not (record.levelno == logging.WARNING and _SILENCED_MARKER in record.getMessage())
+
+
+_FILTER = _MissingTypeWarningFilter()
+
+
+def on_startup(command: str, dirty: bool) -> None:
+    """Install the filter once per mkdocs process (idempotent across rebuilds)."""
+    logger = logging.getLogger(_GRIFFE_LOGGER_NAME)
+    if _FILTER not in logger.filters:
+        logger.addFilter(_FILTER)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,8 +14,30 @@ theme:
   name: material
   locale: en
 
+# Build machinery living under docs/ (gen-files scripts, hooks) is loaded by path via the
+# ``hooks:`` / ``gen-files`` config below, not as documentation — keep it out of the site.
+exclude_docs: |
+  *.py
+
+# Fail loudly on doc drift (#244): broken internal links, links to pages outside the nav,
+# and dead anchors are all warnings, so ``mkdocs build --strict`` catches them. (MkDocs
+# defaults ``anchors`` / ``unrecognized_links`` to ``info``, which strict mode ignores.)
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
 markdown_extensions:
   - smarty
+  - toc:
+      # GitHub-compatible heading slugs. GitHub turns ``## 🚀 Quick Start`` into the
+      # anchor ``#-quick-start`` (emoji stripped, separator kept); Python-Markdown's
+      # default slugifier produces ``#quick-start`` instead, silently breaking the
+      # README's intra-page links when it is reused as the docs home page (#244).
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.highlight:
@@ -31,15 +53,40 @@ extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
+hooks:
+  - docs/hooks/silence_griffe_missing_type_warnings.py
+
 plugins:
   - search
   - gen-files:
       scripts:
         - docs/gen_ref_pages.py
         - docs/gen_stage_docs.py
+        - docs/gen_static_assets.py
   - literate-nav:
       nav_file: SUMMARY.md
   - section-index
-  - mkdocstrings
-  - git-authors
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_options:
+              # The codebase's Google-style docstrings deliberately (a) document
+              # Hydra config keys as pseudo-parameters (``cfg.stage_cfg.split_fracs``)
+              # and (b) group pass-through kwargs on one line (``include, exclude:``).
+              # Types live in the signatures, not repeated in prose. griffe flags all
+              # of that ("does not appear in the function signature" / "no type or
+              # annotation"), which is noise for this style — silence just those two
+              # docstring checks; link/nav validation above is unaffected (#244).
+              # The missing-type half lives in hooks/ (see below): griffe's matching
+              # ``warn_missing_types`` option is only configurable here from
+              # mkdocstrings-python >= 1.17, which needs mkdocstrings >= 1.0.
+              warn_unknown_params: false
+  - git-authors:
+      # api/ and stages/ are generated at build time by the gen-files scripts above,
+      # so they have no git history; without this the plugin emits a "has not been
+      # committed yet" warning per generated page, failing ``--strict`` (#244).
+      exclude:
+        - api/*
+        - stages/*
   - git-revision-date-localized


### PR DESCRIPTION
Completes #244 (the RTD-install half landed in #250). `uv run --extra docs mkdocs build --strict` is now **green with zero warnings**, and a new fast (~9s build) `docs.yaml` CI job keeps it that way.

By mechanism: `static/` mirrored into the docs tree via a gen-files script (logo fixed, README untouched); GitHub-exact heading slugs via `pymdownx.slugs` so the emoji anchors work on both renderers (README untouched); embedded package READMEs inlined with relative links rewritten to GitHub blob URLs at gen time (unresolvable targets left for strict validation to catch); the one README edit is the LICENSE link going absolute (the only form both renderers resolve); griffe param-style warnings turned off via the supported mkdocstrings option plus an interim, fail-safe logging filter for the missing-types class (delete when the mkdocstrings pins bump ≥1.0 — both files carry comments); generated trees excluded from the git-authors plugin. Validation is *stronger* than before: `anchors`/`unrecognized_links`/`omitted_files`/`absolute_links` all raised to warn, and the gen scripts no longer ship into the published site.

Trade-offs recorded in the review notes: `check-yaml` no longer parses mkdocs.yml (the sanctioned slugify tag is not safe-loadable; the docs CI job validates it far more thoroughly), and the LICENSE link now always points at main's copy.

Verified also in an RTD-parity env (`--locked --extra docs --no-dev`). `tests/test_pipeline.py` green; pre-commit clean.

Closes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
