### PR TITLE
convert_to_parquet: pass marker_dir to its direct rwlock_wrap call

### DIFF
--- a/src/MEDS_extract/convert_to_parquet/convert_to_parquet.py
+++ b/src/MEDS_extract/convert_to_parquet/convert_to_parquet.py
@@ -46,7 +46,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import polars as pl
-from MEDS_transforms.mapreduce.rwlock import rwlock_wrap
+from MEDS_transforms.mapreduce.rwlock import run_marker_dir, rwlock_wrap
 from MEDS_transforms.stages import Stage
 from upath import UPath
 
@@ -199,6 +199,9 @@ def main(cfg: DictConfig):
             write_fn=partial(_convert_one, prefix=prefix, columns=prefix_to_columns[prefix] or None),
             compute_fn=lambda src: src,
             do_overwrite=cfg.do_overwrite,
+            # Run-scoped do_overwrite (MT 0.7.0): without the marker dir, parallel
+            # workers treat each other's fresh outputs as stale and redo the work.
+            marker_dir=run_marker_dir(cfg),
         )
 
     logger.info(f"Raw-table conversion completed in {datetime.now(tz=UTC) - start}")

--- a/tests/test_run_example.py
+++ b/tests/test_run_example.py
@@ -193,11 +193,16 @@ def test_meds_extract_run_example_end_to_end(with_knobs: bool):
             pipeline_log = (root / ".logs" / "pipeline.log").read_text(encoding="utf-8")
             for want in ("--multirun", 'worker="range(0,2)"', "hydra/launcher=joblib"):
                 assert want in pipeline_log, f"stage_runner_fp not honored: {want!r} absent\n{debug}"
-            # Each stage really ran as two workers: one log dir per worker index.
-            worker_dirs = sorted(
-                p.name for p in (root / "convert_to_parquet" / ".logs").iterdir() if p.is_dir()
-            )
+            # Each stage really ran as two workers: one log dir per worker index. The
+            # do_overwrite=True override also means MT 0.7.0's run-scoping must engage —
+            # its .run_markers dir under log_dir is the witness that workers shared work
+            # instead of re-deleting each other's fresh outputs.
+            log_entries = {p.name for p in (root / "convert_to_parquet" / ".logs").iterdir() if p.is_dir()}
+            worker_dirs = sorted(n for n in log_entries if not n.startswith("."))
             assert worker_dirs == ["0", "1"], f"expected 2 worker log dirs, got {worker_dirs}\n{debug}"
+            assert ".run_markers" in log_entries, (
+                f"run-scoped do_overwrite never engaged (no .run_markers under .logs)\n{debug}"
+            )
 
         # ``dataset.json``: name from ``etl.dataset_name``; version stamped by the
         # runner — path-mode resolution has no providing distribution, so the stamp is


### PR DESCRIPTION
Completes the #259 sweep: `convert_to_parquet` also calls `rwlock_wrap` directly and was missed, so MT 0.7.0's run-scoped `do_overwrite` never engaged for it (parallel workers redo each other's fresh outputs; correctness unaffected thanks to 0.7.0's atomic writes). Same two-line shape as #259. `convert_to_subject_sharded`'s equivalent fix rides the #262 branch, which is already rewriting that call site.

Stage-example + in-process tests green locally.

Refs #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)