### PR TITLE
test_atomic_write_parquet: stop the watcher with an Event, check every observation

### DIFF
--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -1687,12 +1687,13 @@ def test_atomic_write_parquet_never_exposes_partial_state(tmp_path):
     def writer():
         atomic_write_parquet(pl.DataFrame({"code": list(range(10_000))}), out_fp)
 
+    stop = threading.Event()
+
     def watcher():
         # Sample the destination as fast as Python lets us. If atomic-write is
         # working, every observation where ``out_fp`` exists must be a valid
         # parquet — we never see the path with a non-parquet body.
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline:
+        while not stop.is_set():
             if out_fp.exists():
                 try:
                     pl.scan_parquet(out_fp, glob=False).collect()
@@ -1707,8 +1708,10 @@ def test_atomic_write_parquet_never_exposes_partial_state(tmp_path):
     s.start()
     w.start()
     w.join()
-    # Stop watcher early once writer finishes — no need to keep sampling.
-    s.join(timeout=0.1)
+    # Writer is done, so signal the watcher to stop sampling and wait for it to
+    # exit before asserting — every observation it took gets checked.
+    stop.set()
+    s.join()
 
     assert all(observations), (
         f"atomic_write_parquet exposed a partial-parquet state to a concurrent reader; "


### PR DESCRIPTION
Implements the fix prescribed in #230: the watcher thread now loops on a `threading.Event` and the test does `w.join(); stop.set(); s.join()` — no timeouts — so the watcher is fully stopped before the assertion and every observation actually taken is checked (previously appends after `join(timeout=0.1)` were silently unchecked), and ~1.5s of pointless post-assertion I/O per run disappears (wall ~3.65s → ~2.1s). The stale 'stop watcher early' comment now describes the real mechanism. 5/5 green post-fix; pre-commit clean.

Closes #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)