### PR TITLE
extract_code_metadata: derive observed codes from the component map

### DIFF
--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -857,10 +857,16 @@ def main(cfg: DictConfig):
     # so seed the reduction with the observed code universe: metadata-matched codes keep
     # their rows, and every other observed code gets one all-null metadata row. The left
     # join is exact, not lossy: every metadata code above came through an inner join
-    # against observed components, so metadata codes are a subset of observed codes. The
-    # scan is column-pruned to ``code`` alone — cheap relative to the component-map
-    # collect.
-    observed_codes = all_data.select("code").drop_nulls().unique().collect()
+    # against observed components, so metadata codes are a subset of observed codes.
+    # When the component map was materialized, it already holds every distinct code in
+    # the data — it is a select/unique over the same concat with no row filtering (rows
+    # whose components are null still carry their code) — so the vocabulary is read off
+    # the map rather than re-scanning the full dataset. Only the map-less path pays a
+    # scan, column-pruned to ``code`` alone.
+    if code_component_map is not None:
+        observed_codes = code_component_map.select(pl.col(FULL_CODE_COL).alias("code")).drop_nulls().unique()
+    else:
+        observed_codes = all_data.select("code").drop_nulls().unique().collect()
     reduced = observed_codes.join(reduced, on="code", how="left")
 
     metadata_input_dir = Path(cfg.stage_cfg.metadata_input_dir)

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -430,6 +430,68 @@ data:
     assert hr_row["description"] == "Heart Rate"
 
 
+def test_observed_vocabulary_exact_across_mixed_component_shapes():
+    """codes.parquet's vocabulary is exactly the distinct non-null codes across all event frames.
+
+    The reducer seeds the output with the observed code universe, and no event shape may
+    fall out of it: component-bearing codes with a metadata match, component-bearing
+    codes with no match, codes from a literal-code event file (no ``code_components``
+    column at all — null-struct rows in the mixed-schema concat), and rows whose
+    components are null while the code is not. Null codes are excluded, as always.
+    """
+    messy = """\
+labs:
+  measurement:
+    code: 'f"LAB//{$lab_code}"'
+    _metadata:
+      lab_meta:
+        lab_code: $lab_code
+        description: $title
+admissions:
+  admit:
+    code: ADMISSION
+    time: null
+"""
+    event_frames = {
+        "labs": pl.DataFrame(
+            {
+                # A metadata match (HR), a no-match (TEMP), a null-component row whose
+                # code survives (UNK), and a null code that must NOT appear.
+                "code": ["LAB//HR", "LAB//TEMP", "LAB//UNK", None],
+                "code_components": [
+                    {"lab_code": "HR"},
+                    {"lab_code": "TEMP"},
+                    {"lab_code": None},
+                    {"lab_code": "X"},
+                ],
+                "source_block": ["labs/measurement"] * 4,
+            }
+        ),
+        # A literal-code event file: no code_components column at all.
+        "admissions": pl.DataFrame({"code": ["ADMISSION"], "source_block": ["admissions/admit"]}),
+    }
+    expected = sorted(
+        {c for frame in event_frames.values() for c in frame["code"].to_list() if c is not None}
+    )
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames=event_frames,
+            raw_files={"lab_meta.csv": "lab_code,title\nHR,Heart Rate\n"},
+        )
+
+    assert codes_df["code"].to_list() == expected, (
+        f"codes.parquet vocabulary must be exactly the distinct non-null observed codes "
+        f"({expected}).\n{codes_df}"
+    )
+    by_code = {r["code"]: r["description"] for r in codes_df.iter_rows(named=True)}
+    assert by_code["LAB//HR"] == "Heart Rate"
+    assert by_code["LAB//TEMP"] is None
+    assert by_code["LAB//UNK"] is None
+    assert by_code["ADMISSION"] is None
+
+
 def test_no_metadata_blocks_still_writes_all_observed_codes():
     """A config with NO ``_metadata`` blocks still yields a codes.parquet of every observed code.
 


### PR DESCRIPTION
Implements #227 under the condition set in the issue thread — no metadata codes can be lost — which the change proves out stronger than the original analysis: `build_code_component_map` applies **no row filter whatsoever** on current dev, so every distinct non-null code in `all_data` appears in the map by construction, and the map is built from the *identical* concat the removed scan read. The reducer's second full-cohort pass over the string `code` column is gone; the map-less path (no components / no `_metadata` blocks) keeps the original scan unchanged.

The no-loss guarantee is pinned by a new test mixing all four risk shapes (matched components, unmatched components, literal-code files with null structs, null-components-non-null-code) plus a null code, asserting the reduced vocabulary equals exactly the distinct non-null codes across all event frames — and verified (via a temporary fault injection during development) to execute the map-derived branch rather than the fallback. 42 tests + doctests green; pre-commit clean.

Closes #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)