### PR TITLE
extract_code_metadata: explode list-typed mandated metadata columns

### DIFF
--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -446,6 +446,36 @@ def extract_metadata(
         │ C    ┆ 2             ┆ f"FOO//{$code}//{$code_modifie… ┆ C-2-3       ┆ OUT_VAL_for_3/2 │
         │ D    ┆ 3             ┆ f"FOO//{$code}//{$code_modifie… ┆ null        ┆ expanded form   │
         └──────┴───────────────┴─────────────────────────────────┴─────────────┴─────────────────┘
+
+    A metadata source may already carry a scalar-mandated column in its final aggregated
+    ``List`` shape — ``parent_codes`` as ``List(String)``, the shape a MEDS ``codes.parquet``
+    stores when it is itself the metadata source. Such a list is exploded into the mapper's
+    scalar-per-row model: one row per element, with the join-key and sibling output columns
+    replicated onto each. Empty and null lists explode to a single null element, flowing
+    exactly like a null scalar (the reducer re-aggregates and dedups per code):
+
+        >>> raw_metadata = pl.DataFrame({
+        ...     "code": ["A", "B", "C"],
+        ...     "label": ["a", "b", "c"],
+        ...     "parent_codes": [["P/1", "P/2"], [], None],
+        ... })
+        >>> compiled = compile_metadata_block(
+        ...     {"code": "$code", "description": "$label", "parent_codes": "$parent_codes"},
+        ...     {"code"},
+        ...     code_template_str='f"LAB//{$code}"',
+        ... )
+        >>> extract_metadata(raw_metadata, compiled)
+        shape: (4, 4)
+        ┌──────┬─────────────────┬─────────────┬──────────────┐
+        │ code ┆ code_template   ┆ description ┆ parent_codes │
+        │ ---  ┆ ---             ┆ ---         ┆ ---          │
+        │ str  ┆ str             ┆ str         ┆ str          │
+        ╞══════╪═════════════════╪═════════════╪══════════════╡
+        │ A    ┆ f"LAB//{$code}" ┆ a           ┆ P/1          │
+        │ A    ┆ f"LAB//{$code}" ┆ a           ┆ P/2          │
+        │ B    ┆ f"LAB//{$code}" ┆ b           ┆ null         │
+        │ C    ┆ f"LAB//{$code}" ┆ c           ┆ null         │
+        └──────┴─────────────────┴─────────────┴──────────────┘
     """
     df_select_exprs: dict[str, pl.Expr] = {k: node.polars_expr for k, node in compiled.exprs.items()}
 
@@ -470,9 +500,30 @@ def extract_metadata(
         if mandatory_col not in final_cols:
             continue
 
-        if metadata_df.collect_schema()[mandatory_col] != mandatory_type:
-            logger.warning(f"Metadata column '{mandatory_col}' must be of type {mandatory_type}. Casting.")
-            metadata_df = metadata_df.with_columns(pl.col(mandatory_col).cast(mandatory_type, strict=False))
+        actual_type = metadata_df.collect_schema()[mandatory_col]
+        if actual_type == mandatory_type:
+            continue
+
+        if isinstance(actual_type, pl.List) and not isinstance(mandatory_type, pl.List):
+            # A metadata source may already carry a scalar-mandated column in its final
+            # aggregated List shape — e.g. ``parent_codes`` as ``List(String)`` when a MEDS
+            # ``codes.parquet`` is itself the metadata source. The mapper's model is
+            # scalar-per-row, so explode the list into one row per element; the join-key and
+            # sibling output columns replicate onto every emitted row, and the reducer
+            # re-aggregates the scalars per code (deduplicating in the process). Empty and
+            # null lists explode to a single null element, flowing exactly like a null
+            # scalar.
+            logger.warning(
+                f"Metadata column '{mandatory_col}' is {actual_type} but the mapper mandates the "
+                f"scalar {mandatory_type}. Exploding to one row per element."
+            )
+            metadata_df = metadata_df.explode(mandatory_col)
+            actual_type = metadata_df.collect_schema()[mandatory_col]
+            if actual_type == mandatory_type:
+                continue
+
+        logger.warning(f"Metadata column '{mandatory_col}' must be of type {mandatory_type}. Casting.")
+        metadata_df = metadata_df.with_columns(pl.col(mandatory_col).cast(mandatory_type, strict=False))
 
     return metadata_df.unique(maintain_order=True).select(*match_cols, "code_template", *final_cols)
 

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -843,6 +843,68 @@ diagnoses:
     assert codes_df.filter(pl.col("description").is_not_null()).height == 3
 
 
+def test_list_typed_parent_codes_from_parquet_source():
+    """A parquet metadata source storing ``parent_codes`` as ``List(String)`` — the codes.parquet shape.
+
+    The mapper mandates a scalar String ``parent_codes`` per metadata row, so a list-typed
+    source column is exploded into one row per element (sibling columns replicating
+    alongside) before the reducer unions the scalars back into the canonical per-code
+    ``List(String)``. An element delivered by two source rows appears once — the union
+    dedups — and empty or null source lists behave like null scalars: the code's
+    aggregated ``parent_codes`` is null, never ``[]``.
+    """
+    messy = """\
+data:
+  lab:
+    code: 'f"LAB//{$code}"'
+    _metadata:
+      codes:
+        code: $code
+        description: $description
+        parent_codes: $parent_codes
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "data": pl.DataFrame(
+                    {
+                        "code": ["LAB//A", "LAB//B", "LAB//C"],
+                        "code_components": [{"code": "A"}, {"code": "B"}, {"code": "C"}],
+                        "source_block": ["data/lab"] * 3,
+                    }
+                )
+            },
+            raw_files={
+                "codes.parquet": pl.DataFrame(
+                    {
+                        "code": ["A", "A", "B", "C"],
+                        "description": ["Alpha", "Alpha", "Beta", "Gamma"],
+                        "parent_codes": [["ICD9CM/1", "ICD9CM/2"], ["ICD9CM/2", "ICD9CM/3"], [], None],
+                    },
+                    schema={
+                        "code": pl.String,
+                        "description": pl.String,
+                        "parent_codes": pl.List(pl.String),
+                    },
+                )
+            },
+        )
+
+    assert codes_df.schema["parent_codes"] == pl.List(pl.String)
+    by_code = {r["code"]: r for r in codes_df.iter_rows(named=True)}
+    # Union of both source rows' lists, with the shared "ICD9CM/2" element appearing once.
+    assert sorted(by_code["LAB//A"]["parent_codes"]) == ["ICD9CM/1", "ICD9CM/2", "ICD9CM/3"]
+    # An empty source list and a null source list both aggregate to null.
+    assert by_code["LAB//B"]["parent_codes"] is None
+    assert by_code["LAB//C"]["parent_codes"] is None
+    # Sibling columns replicated through the explode: descriptions attach once per code.
+    assert by_code["LAB//A"]["description"] == "Alpha"
+    assert by_code["LAB//B"]["description"] == "Beta"
+    assert by_code["LAB//C"]["description"] == "Gamma"
+
+
 def test_mixed_full_and_partial_match_from_same_metadata_prefix():
     """Regression guard: configs with different match-column sets sharing a metadata prefix.
 


### PR DESCRIPTION
Implements the mechanism chosen in #226: when a `_metadata` block expression yields a List-typed column for a scalar-mandated slot (the natural case being a parquet source already storing `parent_codes` as `List(String)` — the MEDS codes.parquet shape), the mapper now `.explode()`s it into the scalar-per-row model before the existing cast — only for the mandated columns, only when list-typed. Join keys and sibling columns replicate verbatim onto each emitted row, the reducer re-unions per code, and the resulting dedup across rows/sources is the desired behavior per the issue thread. Empty and null lists explode to a null element and flow exactly like null scalars (aggregate to null, never `[]`).

Pinned by an end-to-end test through a `List(String)` parquet source: multi-element lists from two rows union with the shared element deduped, empty/null lists aggregate to null, sibling `description` replication asserted. Full suite 254 green; pre-commit clean.

Closes #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)