### PR TITLE
meds-extract-run: Hydra-quote the path-valued download-child overrides

### DIFF
--- a/src/MEDS_extract/run/cli.py
+++ b/src/MEDS_extract/run/cli.py
@@ -34,6 +34,7 @@ from dataclasses import field
 from pathlib import Path
 
 import hydra
+from hydra.core.override_parser.types import Quote, QuotedString
 from MEDS_transforms.configs.utils import hydra_registered_dataclass
 from omegaconf import MISSING, DictConfig, OmegaConf
 
@@ -41,6 +42,29 @@ from .._cli import require_dotlist_args
 from ..config import MessyConfig, user_local_path
 
 logger = logging.getLogger(__name__)
+
+
+def _hydra_quote(value: str) -> str:
+    r"""Render ``value`` as a single-quoted string literal in Hydra's override grammar.
+
+    Hydra's override grammar gives bare ``,`` and ``=`` structural meaning (a choice
+    sweep and the key/value separator), so a filesystem path interpolated verbatim
+    into a dotlist override breaks the parse. Inside the grammar's single-quoted
+    form every character is literal except the quote itself: an embedded ``'`` is
+    escaped as ``\'``, and a run of backslashes immediately before a quote is
+    doubled (backslashes elsewhere stay literal). Hydra's own
+    :class:`~hydra.core.override_parser.types.QuotedString` implements exactly
+    those rules, so quoting here always matches what the child's parser accepts.
+
+    Examples:
+        >>> _hydra_quote("/data/comma,dir/spec.yaml")
+        "'/data/comma,dir/spec.yaml'"
+        >>> _hydra_quote("/data/eq=dir/out")
+        "'/data/eq=dir/out'"
+        >>> _hydra_quote("/data/it's here")
+        "'/data/it\\'s here'"
+    """
+    return QuotedString(text=value, quote=Quote.single).with_quotes()
 
 
 def run_command(argv: list[str]) -> int:
@@ -174,13 +198,31 @@ class RunConfig:
     def download_argv(self, spec_ref: str) -> list[str]:
         """Build the ``meds-extract-download`` child command line.
 
+        The path-valued overrides (``spec``, ``output_dir``, ``hydra.run.dir``) are
+        wrapped via :func:`_hydra_quote` so paths containing override-grammar
+        metacharacters survive the child's parse. Quoting stays confined to those
+        three: the child is always spawned single-run, so no legitimate value ever
+        carries sweep/range syntax that quoting would suppress, while the remaining
+        overrides render from typed dataclass fields (``bool``/``int``, plus a
+        ``key`` constrained to sources-bucket names) whose bare forms are what the
+        grammar types natively.
+
         Examples:
             >>> run = RunConfig(spec="Example", output_dir="/data/out", download_key="demo")
             >>> run.download_argv("pkg://ex.messy.yaml")
-            ['MEDS_extract.download.cli', 'spec=pkg://ex.messy.yaml',
-             'output_dir=/data/out/.meds_extract_run/raw_input', 'key=demo', 'do_overwrite=False',
+            ['MEDS_extract.download.cli', "spec='pkg://ex.messy.yaml'",
+             "output_dir='/data/out/.meds_extract_run/raw_input'", 'key=demo', 'do_overwrite=False',
              'concurrency=4', 'continue_on_error=False',
-             'hydra.run.dir=/data/out/.meds_extract_run/hydra_download']
+             "hydra.run.dir='/data/out/.meds_extract_run/hydra_download'"]
+
+            Quoting keeps paths with override-grammar metacharacters (a bare ``,``
+            starts a choice sweep; a bare ``=`` splits the override) intact:
+
+            >>> run = RunConfig(spec="Example", output_dir="/data/comma,dir/eq=dir/out")
+            >>> [a for a in run.download_argv("/data/comma,dir/s.yaml") if a.startswith("spec")]
+            ["spec='/data/comma,dir/s.yaml'"]
+            >>> [a for a in run.download_argv("s") if a.startswith("output_dir")]
+            ["output_dir='/data/comma,dir/eq=dir/out/.meds_extract_run/raw_input'"]
 
             The two transfer knobs are forwarded verbatim:
 
@@ -193,14 +235,14 @@ class RunConfig:
         """
         return [
             "MEDS_extract.download.cli",
-            f"spec={spec_ref}",
-            f"output_dir={self.effective_input_dir}",
+            f"spec={_hydra_quote(spec_ref)}",
+            f"output_dir={_hydra_quote(str(self.effective_input_dir))}",
             f"key={self.download_key}",
             f"do_overwrite={self.do_overwrite}",
             f"concurrency={self.download_concurrency}",
             f"continue_on_error={self.download_continue_on_error}",
             # Keep the child's Hydra run dir out of the user's CWD.
-            f"hydra.run.dir={self.work_dir / 'hydra_download'}",
+            f"hydra.run.dir={_hydra_quote(str(self.work_dir / 'hydra_download'))}",
         ]
 
     def pipeline_argv(self, pipeline_fp: Path) -> list[str]:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from typing import TYPE_CHECKING
 
+import pytest
 from omegaconf import OmegaConf
 
 from MEDS_extract.config import EtlConfig
@@ -134,6 +135,30 @@ def test_run_cli_full_flow(tmp_path):
     assert stages[0] == "convert_to_parquet"
     assert stages[1]["split_and_shard_subjects"]["n_subjects_per_shard"] == 7
     assert [s if isinstance(s, str) else next(iter(s)) for s in stages] == list(EtlConfig.DEFAULT_PIPELINE)
+
+
+@pytest.mark.parametrize("dirname", ["comma,dir", "eq=dir"])
+def test_run_cli_paths_with_hydra_metacharacters(tmp_path, dirname):
+    """The full flow succeeds when every path (spec, output tree) lives under a
+    directory whose name contains a Hydra override-grammar metacharacter: a bare
+    ``,`` parses as a choice sweep and a bare ``=`` splits the override, so the
+    runner must quote the path-valued overrides it synthesizes for the download
+    child. The *parent's* args are quoted here the way a user would quote them —
+    Hydra's single-quote syntax — which fixes only the parent's own parse; what
+    this pins is that the child spawn survives too."""
+    base = tmp_path / dirname
+    base.mkdir()
+    spec_fp = _write_tiny_spec(base)
+    out_dir = base / "meds"
+
+    result = _run_cli(base, f"spec='{spec_fp}'", f"output_dir='{out_dir}'")
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+    # The download child received the metacharacter paths intact and staged the data.
+    assert (out_dir / ".meds_extract_run" / "raw_input" / "patients.csv").exists()
+    # The pipeline ran to completion over them as well.
+    assert (out_dir / "data" / "train" / "0.parquet").exists()
+    assert (out_dir / "metadata" / "codes.parquet").exists()
 
 
 def test_run_cli_download_failure_stops_the_run(tmp_path):


### PR DESCRIPTION
`RunConfig.download_argv` built the download child's dotlist overrides by raw f-string interpolation, so a path containing `,` parsed as a Hydra ChoiceSweep and one containing `=` was an override parse error — unrecoverable by the user, since shell quoting fixes only the parent's parse.

Per the caution in the issue thread, both conditions were confirmed before implementing: **(1)** the child is always spawned single-run (plain `subprocess.run`, never `--multirun`), and each interpolated value is either an arbitrary path (`spec`, `output_dir`, `hydra.run.dir`) or a runner-constructed primitive (`key`, `do_overwrite`, `concurrency`, `continue_on_error`) — so no accepted override ever legitimately needs unquoted sweep/range syntax, and the user-facing `overrides=[...]` passthrough targets the argparse pipeline child and is untouched. **(2)** The natural escaping mechanism is Hydra's own `QuotedString.with_quotes()` (escape embedded `'`, double backslash-runs before a quote, everything else literal), verified by round-tripping nine adversarial values through Hydra's `OverridesParser`.

Only the three path-valued overrides are quoted — the parser types quoted primitives as `str` (OmegaConf coercion would restore them, but bare is the native form and those values cannot contain metacharacters). Regression: end-to-end runs with the entire tree under `comma,dir` and `eq=dir`, verified failing pre-fix with the exact reported errors. Full suite 256 green; pre-commit clean.

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)