### PR TITLE
extract_code_metadata: pin reducer expansion order across engines

### DIFF
--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -745,11 +745,19 @@ def main(cfg: DictConfig):
             # component column sharing a name with a metadata output column would otherwise
             # shadow it in the post-join select. Join keys are normalized to a canonical
             # String rendering on both sides — components keep raw source dtypes while
-            # csv-sourced metadata keys are uniformly String.
-            components = components.select(
-                FULL_CODE_COL,
-                *[normalize_join_key(pl.col(c), component_schema[c]) for c in match_cols],
-            ).unique()
+            # csv-sourced metadata keys are uniformly String. The frame is then sorted into
+            # a canonical total order: as the join's left side it dictates the relative
+            # order of same-code rows expanded through different key combinations, and that
+            # order must be input-determined — not inherited from an engine-defined unique
+            # order — because the downstream aggregations are order-sensitive.
+            components = (
+                components.select(
+                    FULL_CODE_COL,
+                    *[normalize_join_key(pl.col(c), component_schema[c]) for c in match_cols],
+                )
+                .unique()
+                .sort(FULL_CODE_COL, *match_cols)
+            )
             pdf = pdf.with_columns(normalize_join_key(pl.col(c), pdf_schema[c]) for c in match_cols)
 
             # ``nulls_equal=True`` is a deliberate semantic choice: a null join key on the
@@ -757,8 +765,16 @@ def main(cfg: DictConfig):
             # component is null — e.g. a vocabulary row keyed on a null unit attaches to
             # the code that a ``{$valueuom ?? 'UNK'}`` component rendered for unit-less
             # data rows.
+            #
+            # ``maintain_order="left_right"`` is load-bearing for byte-identical output:
+            # within-key row order must be input-determined, never engine-scheduled,
+            # because the downstream aggregations (``unique(maintain_order=True)`` under
+            # an ordered group_by) fold it into description join order and parent_codes
+            # list order.
             expanded = (
-                components.join(pdf, on=match_cols, how="inner", nulls_equal=True)
+                components.join(
+                    pdf, on=match_cols, how="inner", nulls_equal=True, maintain_order="left_right"
+                )
                 .select(pl.col(FULL_CODE_COL).alias("code"), *metadata_cols)
                 .collect()
             )

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -1364,6 +1364,69 @@ def test_reduction_is_deterministic_across_config_orderings(monkeypatch):
     assert by_code["HR"]["vocab"] == ["LOINC", "SNOMED"]
 
 
+def test_reduction_is_deterministic_across_engines():
+    """Regression guard: ``codes.parquet`` is byte-identical regardless of the polars engine.
+
+    The reducer's expansion join feeds order-sensitive aggregations — description strings are
+    separator-joined and ``parent_codes`` lists are deduplicated in first-seen order — so
+    within-key join order must be input-determined, not engine-scheduled. The streaming engine
+    (selected here exactly as ``POLARS_ENGINE_AFFINITY=streaming`` would select it) partitions
+    joins across threads and reorders within-key rows unless the join pins its order — but only
+    probabilistically, so the scenario amplifies the signal: many metadata rows for each of many
+    codes, and two streaming runs, so an unpinned join escapes only if every code coincidentally
+    stays ordered in both. Two default-engine runs and two streaming-engine runs over identical
+    inputs must all produce byte-identical output files.
+    """
+    n_codes, n_per_code = 8, 500
+    codes = [f"C{i}" for i in range(n_codes)]
+    meta_rows = "".join(
+        f"{code},title {j:03d} for {code},PARENT//{code}//{j:03d}\n"
+        for j in range(n_per_code)
+        for code in codes
+    )
+    messy = """\
+data:
+  measurement:
+    code: $lab_code
+    _metadata:
+      lab_meta:
+        lab_code: $lab_code
+        description: $title
+        parent_codes: $parent
+"""
+    events = {"data": _bare_code_events("lab_code", codes, "data/measurement")}
+    raw = {"lab_meta.csv": f"lab_code,title,parent\n{meta_rows}"}
+
+    engines = (None, None, "streaming", "streaming")
+    outputs: list[bytes] = []
+    frames: list[pl.DataFrame] = []
+    for engine_affinity in engines:
+        with tempfile.TemporaryDirectory() as d, pl.Config(engine_affinity=engine_affinity):
+            _run_ecm_scenario(Path(d), messy, events, raw)
+            fp = Path(d) / "metadata_out" / "metadata" / "codes.parquet"
+            outputs.append(fp.read_bytes())
+            frames.append(pl.read_parquet(fp))
+
+    from polars.testing import assert_frame_equal
+
+    # Frame-level identity first (row order, list order, dtypes all strict) for a readable
+    # diff on failure; then full byte identity of the on-disk files.
+    for i, engine_affinity in enumerate(engines[1:], start=1):
+        assert_frame_equal(frames[0], frames[i], check_row_order=True, check_column_order=True)
+        assert outputs[0] == outputs[i], (
+            f"codes.parquet bytes differ between a default-engine run and run {i} "
+            f"(engine affinity {engine_affinity or 'default'})"
+        )
+
+    # The pinned order has teeth: values aggregate in metadata-file row order, per code.
+    by_code = {r["code"]: r for r in frames[0].iter_rows(named=True)}
+    for code in codes:
+        assert by_code[code]["description"] == "\n".join(
+            f"title {j:03d} for {code}" for j in range(n_per_code)
+        )
+        assert by_code[code]["parent_codes"] == [f"PARENT//{code}//{j:03d}" for j in range(n_per_code)]
+
+
 def test_reduced_schema_is_data_independent():
     """Regression guard: extra metadata columns are always ``List(String)``.
 


### PR DESCRIPTION
Implements #225, one step deeper than the issue's one-line suggestion: the expansion join gains `maintain_order="left_right"`, **and** the join's left side (the components frame) gains a canonical sort after its previously engine-ordered `unique()` — under `left_right`, left-side order dictates the relative order of same-code rows expanded through different key combinations (real via null-coalesced components), so pinning the join without pinning its left input would still leak engine order. Verified unnecessary elsewhere: the one-row-per-code paths are already pinned by the final sort, and the concat is in canonical config order. Comments state the contract only.

Regression: `test_reduction_is_deterministic_across_engines` runs the real scenario under default and streaming engines (via `pl.Config(engine_affinity=...)` — a bare env set is not reliably honored by the Rust-side cache; Config snapshots and restores cleanly) and asserts frame equality including list order plus **byte identity** of all four codes.parquet outputs. The scramble is probabilistic, so the test was amplified until it failed 10/10 pre-fix; it passes 10/10 post-fix. 42 stage tests + doctests + 254-test suite green; pre-commit clean.

Closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)