### PR TITLE
Download: verify-or-refetch policy for existing files; download_do_overwrite rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ The runner is a shuttle, so each child's own options are forwarded rather than r
 | `stage_runner_fp=`            | `MEDS_transform-pipeline --stage_runner_fp` | **Parallelism.** A top-level `parallelize:` block in that file becomes every stage's default, and it can override `parallelize` or `script` per stage |
 | `do_profile=true`             | `MEDS_transform-pipeline --do_profile`      | Hydra profiling of each stage                                                                                                                         |
 | `overrides=[...]`             | `MEDS_transform-pipeline --overrides`       | Any pipeline-config key the synthesized config doesn't template (`seed`, pipeline-level `do_overwrite`, …)                                            |
+| `download_do_overwrite=`      | `meds-extract-download do_overwrite=`       | Re-fetch every file, even those whose local copy verifies against the manifest                                                                        |
 | `download_concurrency=`       | `meds-extract-download concurrency=`        | Parallel transport streams — close to linear on PhysioNet                                                                                             |
 | `download_continue_on_error=` | `meds-extract-download continue_on_error=`  | Don't let one bad file sink a multi-hour fetch                                                                                                        |
 

--- a/src/MEDS_extract/download/README.md
+++ b/src/MEDS_extract/download/README.md
@@ -24,8 +24,9 @@ deterministic, verifiable local copy. The goals:
     (`Source.download_all`) stage any dataset, regardless of where it's hosted. ETL
     authors compose backends; they don't reimplement transports.
 - **Deterministic, verified retrieval.** SHA-256 verification, atomic writes, and a
-    strict skip/overwrite policy mean a download either produces exactly the manifest's
-    files or fails loudly — no silently-stale local copies leaking into a pipeline run.
+    verify-or-re-fetch policy mean a completed download contains exactly the manifest's
+    files: local copies that verify are skipped, anything that can't be verified is
+    re-fetched — no silently-stale local copies leaking into a pipeline run.
 
 The submodule sits *alongside* the MEDS-transforms stage DAG, not inside it: download
 I/O is network / blob storage rather than sharded parquet, parallelism is per-file
@@ -46,7 +47,7 @@ At the highest level, staging a dataset is four steps:
 A **`Source`** is anywhere raw data comes from. It knows two things: *what files it
 offers* (`_list_files`) and *how to stream one file's bytes to a local path* (`_pull`).
 Everything else — `.part` staging, SHA-256 verification, atomic rename, the
-skip/overwrite/error policy, manifest validation and include/exclude filtering,
+skip/re-fetch policy, manifest validation and include/exclude filtering,
 duplicate-destination detection, sequential-vs-parallel orchestration, error
 aggregation — lives once on the `Source` ABC and is shared by every backend.
 
@@ -173,7 +174,7 @@ def _pull(self, source_path: str, target: Path) -> None: ...  # stream bytes
 
 The base class supplies everything else. `_fetch_one(item, dest_dir, do_overwrite)`
 is the per-file pipeline (orchestrator-facing): resolve dest, apply the
-skip/overwrite/error policy, derive `.part`, call `_pull`, verify SHA-256,
+skip/re-fetch policy, derive `.part`, call `_pull`, verify SHA-256,
 atomic-rename.
 
 The user-facing entry points:
@@ -219,7 +220,7 @@ destination — lives in `Source.files`, and the cross-*source* variant in
 
 `sha256` is the only verifier the orchestrator trusts to skip a re-fetch. A
 `RemoteFile` with no `sha256` can still be downloaded, but on a re-run it can't be
-*skipped* — see the overwrite policy below.
+*skipped* — it is re-fetched; see the skip/re-fetch policy below.
 
 ### The orchestration loop
 
@@ -240,18 +241,24 @@ of fetch *attempts*, and run them through a single error-collection loop.
 4. If any errors were collected, they are raised together as one `ExceptionGroup`;
     otherwise `download_all` returns `None`.
 
-`_fetch_one` is where the per-file **skip / overwrite / error policy** lives:
+`_fetch_one` is where the per-file **skip / re-fetch policy** lives:
 
-| `dest` state                               | `do_overwrite=False`  | `do_overwrite=True` |
-| ------------------------------------------ | --------------------- | ------------------- |
-| doesn't exist                              | fetch                 | fetch               |
-| exists, verifies against manifest `sha256` | **skip**              | clear + refetch     |
-| exists, sha mismatch *or* no manifest sha  | **`FileExistsError`** | clear + refetch     |
+| `dest` state                               | `do_overwrite=False`         | `do_overwrite=True` |
+| ------------------------------------------ | ---------------------------- | ------------------- |
+| doesn't exist                              | fetch                        | fetch               |
+| exists, verifies against manifest `sha256` | **skip**                     | clear + refetch     |
+| exists, sha mismatch                       | **refetch** (with a warning) | clear + refetch     |
+| exists, no manifest sha                    | **refetch**                  | clear + refetch     |
 
-The "exists but can't verify → error" rule is intentional: silently overwriting (or
-silently skipping) a file we can't prove matches the manifest is how stale or
-half-flushed local copies leak into a pipeline run. The user has to opt into the
-ambiguity with `do_overwrite=True`.
+The "exists but can't verify → re-fetch" rule is intentional: a file we can't prove
+matches the manifest is never trusted (silently skipping it is how stale or
+half-flushed local copies leak into a pipeline run), and never skipped. It keeps
+re-runs of mixed manifests — sha-verified PhysioNet files alongside checksum-free
+HTTP URLs — cheap and idempotent: verified files skip, everything else re-fetches.
+The re-fetch still stages into `.part` and replaces `dest` only via the atomic
+rename (after the fresh bytes verify, when a sha exists), so a failed re-fetch
+never destroys the existing copy. `do_overwrite=True` forces a clean re-fetch of
+everything, verified or not.
 
 Two `.part`-level refinements: a leftover `.part` that already verifies against the
 manifest sha is promoted to `dest` directly (a prior run died between the last byte
@@ -337,7 +344,7 @@ A Hydra entry point (`DownloadConfig` is a `hydra_registered_dataclass`). It:
 
 - **Doctests** in each module cover the pure logic: spec dispatch, URL normalization,
     `RemoteFile` validation, `SHA256SUMS.txt` parsing, manifest filtering, and the
-    `Source.download_all` skip/overwrite/traversal/dup paths (via stub sources in the
+    `Source.download_all` skip/re-fetch/traversal/dup paths (via stub sources in the
     `source.py` docstrings). This README's Python-usage example is itself a collected
     doctest.
 - **`tests/test_download.py`** covers what doctests can't: `_resumable_stream`'s

--- a/src/MEDS_extract/download/source.py
+++ b/src/MEDS_extract/download/source.py
@@ -8,9 +8,8 @@ inherit from this ABC and implement two methods:
   validating wrapper :attr:`Source.files` is what callers use).
 - :meth:`Source._pull` — stream the bytes at one source address into a target
   path. The base class wraps this in :meth:`Source._fetch_one`, which owns
-  the full per-file pipeline: the skip / overwrite / error policy on any
-  pre-existing dest, ``.part`` staging, SHA-256 verification, and atomic
-  rename.
+  the full per-file pipeline: the skip / re-fetch policy on any pre-existing
+  dest, ``.part`` staging, SHA-256 verification, and atomic rename.
 
 The single public fetch entry point is :meth:`Source.download_all`. By default it
 runs sequentially; pass a :class:`~concurrent.futures.Executor` (typically a
@@ -127,8 +126,9 @@ class RemoteFile:
             one (PhysioNet from ``SHA256SUMS.txt``, fsspec by hashing the source
             file, HTTP from explicit per-URL ``sha256:`` config) should set it —
             it's the only verifier the orchestrator trusts to skip a re-fetch.
-            ``None`` means "no manifest-side hash"; the orchestrator will refuse
-            to silently overwrite an existing dest in that case.
+            ``None`` means "no manifest-side hash"; an existing dest can then
+            never be proven complete, so the orchestrator re-fetches it on every
+            run rather than trusting it.
         unarchive: Optional post-fetch unpack format. ``None`` (default) means no
             unpack. ``"zip"``, ``"tar"``, ``"tar.gz"`` / ``"tgz"`` dispatch to the
             matching :class:`~MEDS_extract.download.unarchive.ArchiveFormat`;
@@ -265,7 +265,7 @@ class Source(ABC):
     Concrete usage examples live on the methods that implement them:
     :meth:`download_all` (the public entry + orchestration policy),
     :attr:`files` (manifest validation + filtering), :meth:`_fetch_one` (the
-    per-file pipeline: skip/overwrite/error policy + staging + verify + rename).
+    per-file pipeline: skip/re-fetch policy + staging + verify + rename).
     """
 
     # Class-level fallbacks so subclasses that define ``__init__`` without calling
@@ -302,17 +302,15 @@ class Source(ABC):
                 propagates. If ``True``, per-file errors are collected and raised
                 as a single :class:`ExceptionGroup` at the end so the caller sees
                 every failure, not just the first.
-            do_overwrite: If ``True``, skip the "verified or error" check and
-                clear ``dest`` / ``.part`` before each fetch — re-fetches
-                everything from scratch.
+            do_overwrite: If ``True``, skip the verified-dest check and clear
+                ``dest`` / ``.part`` before each fetch — re-fetches everything
+                from scratch, even files whose local copy verifies.
 
         Raises:
             Exception: From the transport layer on any per-file failure when
                 ``continue_on_error=False``.
             ExceptionGroup: When ``continue_on_error=True`` and at least one
                 file failed.
-            FileExistsError: When an existing ``dest`` can't be verified against
-                the manifest and ``do_overwrite=False``.
             ValueError: When the manifest contains an unsafe rel_path (raised at
                 :class:`RemoteFile` construction) or duplicate destinations
                 (raised by :attr:`files`).
@@ -401,9 +399,9 @@ class Source(ABC):
             ...     len(pulls)
             1
 
-            An existing ``dest`` that **doesn't** verify (sha mismatch, or no
-            manifest sha at all) is a hard error rather than a silent overwrite.
-            The user has to opt in to overwriting via ``do_overwrite=True``:
+            An existing ``dest`` with **no manifest sha** can never be proven
+            complete, so it is re-fetched rather than trusted — the stale local
+            copy is replaced atomically, and re-runs stay idempotent:
 
             >>> class UnverifiableSource(Source):
             ...     def _list_files(self):
@@ -415,24 +413,26 @@ class Source(ABC):
             ...     d = Path(d)
             ...     _ = (d / "x.txt").write_bytes(b"stale")
             ...     UnverifiableSource().download_all(d)
-            Traceback (most recent call last):
-                ...
-            FileExistsError: Refusing to overwrite ...x.txt: ... do_overwrite=True ...
+            ...     UnverifiableSource().download_all(d)  # re-run: re-fetches again, no error
+            ...     print((d / "x.txt").read_text())
+            fresh
 
-            The refusal leaves the stale local copy untouched, and
-            ``do_overwrite=True`` is the opt-in that clears it and re-fetches:
+            An existing ``dest`` whose content **mismatches** the manifest sha is
+            likewise re-fetched (with a warning naming the file) — and the fresh
+            bytes must still verify before the atomic replace:
 
+            >>> class MismatchRepairSource(Source):
+            ...     def _list_files(self):
+            ...         return [RemoteFile("x.txt", "", sha256=digest)]
+            ...     def _pull(self, source_path, target):
+            ...         target.write_bytes(body)
+            >>>
             >>> with tempfile.TemporaryDirectory() as d:
             ...     d = Path(d)
-            ...     _ = (d / "x.txt").write_bytes(b"stale")
-            ...     try:
-            ...         UnverifiableSource().download_all(d)
-            ...     except FileExistsError:
-            ...         print(f"refused; on disk: {(d / 'x.txt').read_text()}")
-            ...     UnverifiableSource().download_all(d, do_overwrite=True)
-            ...     print(f"after do_overwrite=True: {(d / 'x.txt').read_text()}")
-            refused; on disk: stale
-            after do_overwrite=True: fresh
+            ...     _ = (d / "x.txt").write_bytes(b"corrupt local copy")
+            ...     MismatchRepairSource().download_all(d)
+            ...     print((d / "x.txt").read_bytes() == body)
+            True
 
             Failure policy: by default the first per-file failure propagates and
             later files are not attempted; ``continue_on_error=True`` attempts
@@ -819,8 +819,11 @@ class Source(ABC):
            Otherwise, on a pre-existing ``dest``:
 
            - ``dest`` verifies against ``item.sha256``: skip and return.
-           - otherwise: raise :class:`FileExistsError` — refuse to silently
-             overwrite a file we can't prove matches the manifest.
+           - ``item.sha256`` is set but ``dest`` mismatches: re-fetch (with a
+             warning naming the file) — ``dest`` is replaced only by the atomic
+             rename in step 7, after the fresh bytes verify.
+           - no ``item.sha256``: re-fetch — a file we can't prove matches the
+             manifest is never trusted, and never skipped.
 
         3. If a prior run left a ``.part`` that already verifies against
            ``item.sha256`` (interrupted between the last byte and the rename),
@@ -845,10 +848,10 @@ class Source(ABC):
             summary.
 
         On any exception, no new ``dest`` is created and an existing ``dest``
-        is never modified (the :class:`FileExistsError` path deliberately
-        leaves the unverifiable pre-existing file in place). ``part`` may
-        exist after a partial transport failure (intentional — gives a future
-        run a head start via Range-resume on backends that support it).
+        is never modified — the re-fetch paths replace it only via the atomic
+        rename, after the fresh bytes verify. ``part`` may exist after a
+        partial transport failure (intentional — gives a future run a head
+        start via Range-resume on backends that support it).
 
         Examples:
             Backend's ``_pull`` produces the bytes; this method handles staging,
@@ -942,11 +945,16 @@ class Source(ABC):
             if self._verifies(dest, item):
                 logger.debug(f"Skipping {item.rel_path}: already complete.")
                 return ("skipped", dest.stat().st_size)
-            raise FileExistsError(
-                f"Refusing to overwrite {dest}: existing file does not verify against "
-                f"the manifest (sha mismatch, or no manifest sha provided). Pass "
-                f"do_overwrite=True to force a refetch, or delete the file first."
-            )
+            # An existing dest that can't be proven complete is never trusted and
+            # never skipped: re-fetch it. The stale copy stays in place until the
+            # fresh bytes verify — the atomic rename below is what replaces it.
+            if item.sha256 is None:
+                logger.debug(f"Re-fetching {item.rel_path}: existing file has no manifest sha to verify.")
+            else:
+                logger.warning(
+                    f"Re-fetching {item.rel_path}: existing file at {dest} failed SHA-256 "
+                    "verification against the manifest."
+                )
 
         if item.sha256 is not None:
             # A prior run may have died between writing the last byte and the
@@ -1087,9 +1095,9 @@ def validate_unique_destinations(sources: Iterable[Source]) -> None:
     :attr:`Source.files` already rejects collisions *within* one source, but the
     CLI (and any caller composing sources) stages several sources into one shared
     directory, where two sources legally listing the same ``rel_path`` would race
-    on the same ``.part`` file under concurrent workers — or serially clobber /
-    ``FileExistsError`` on each other. Calling this before any fetch turns that
-    late, confusing failure into an immediate, precise config error.
+    on the same ``.part`` file under concurrent workers — or serially clobber
+    each other. Calling this before any fetch turns that late, confusing failure
+    into an immediate, precise config error.
 
     Accessing each source's :attr:`~Source.files` materializes its manifest
     (cached, so the later ``download_all`` calls reuse it rather than re-listing).

--- a/src/MEDS_extract/download/spec.py
+++ b/src/MEDS_extract/download/spec.py
@@ -168,7 +168,7 @@ def sources_from_spec(spec: dict, key: str = "dataset") -> list[Source]:
     configured = list(sources_block.get(key, []) or [])
     # ``common`` is always appended UNLESS it's already the selected bucket —
     # otherwise ``sources_from_spec(spec, key="common")`` would build every
-    # common backend twice, race two writers on the same dest, and surface as
-    # a ``FileExistsError`` mid-orchestration.
+    # common backend twice and race two writers on the same dest
+    # mid-orchestration.
     common = list(sources_block.get("common", []) or []) if key != "common" else []
     return [source_from_config(c) for c in configured + common]

--- a/src/MEDS_extract/run/cli.py
+++ b/src/MEDS_extract/run/cli.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import logging
 import subprocess
 import sys
-from dataclasses import field
+from dataclasses import field, fields
 from pathlib import Path
 
 import hydra
@@ -81,8 +81,6 @@ class RunConfig:
             ``download_key=null``).
         dataset_version: Explicit override for ``etl_metadata.dataset_version``
             (default: computed — see ``MessyConfig.dataset_version_for``).
-        do_overwrite: If ``True``, the download stage re-fetches files even when
-            the local copy matches.
 
     Passthroughs to the two children. The runner is a shuttle, so these add no
     semantics of their own — each is forwarded verbatim and documented by the child
@@ -108,6 +106,10 @@ class RunConfig:
             element on the command line, since the values themselves contain ``=``::
 
                 meds-extract-run ... "overrides=['seed=2','do_overwrite=True']"
+        download_do_overwrite: If ``True``, the download child re-fetches every file,
+            even when the local copy verifies against the manifest (forwarded as
+            ``do_overwrite=``). Distinct from the pipeline-level ``do_overwrite``,
+            which is an ``overrides=`` key.
         download_concurrency: Max parallel transport streams for the download child.
         download_continue_on_error: If ``True``, per-file download failures don't sink
             the run; every source is still attempted and the child exits non-zero at
@@ -119,10 +121,13 @@ class RunConfig:
     dataclass). It validates the plausible combinations — exactly one of "download
     into ``download_dest_dir``" (``download_key`` set) or "read pre-staged
     ``input_dir``" (``download_key=null``) describes where the pipeline's raw
-    input comes from (:attr:`effective_input_dir`) — and normalizes the directory
-    fields to absolute local paths (URL-shaped values are rejected; relative paths
-    resolve against the invoking CWD, which ``hydra.job.chdir=false`` leaves
-    untouched), so no path handling is left to the CLI body.
+    input comes from (:attr:`effective_input_dir`) — rejects non-default
+    ``download_*`` knobs on a download-free run (``download_key=null`` spawns no
+    download child, so they could only be silently ignored) — and normalizes the
+    directory fields to absolute local paths (URL-shaped values are rejected;
+    relative paths resolve against the invoking CWD, which
+    ``hydra.job.chdir=false`` leaves untouched), so no path handling is left to
+    the CLI body.
     """
 
     spec: str = MISSING
@@ -131,10 +136,10 @@ class RunConfig:
     download_dest_dir: str | None = None
     input_dir: str | None = None
     dataset_version: str | None = None
-    do_overwrite: bool = False
     stage_runner_fp: str | None = None
     do_profile: bool = False
     overrides: list[str] = field(default_factory=list)
+    download_do_overwrite: bool = False
     download_concurrency: int = 4
     download_continue_on_error: bool = False
 
@@ -158,6 +163,17 @@ class RunConfig:
             )
         if self.download_key is None and self.download_dest_dir is not None:
             raise ValueError("download_dest_dir= has no effect with download_key=null; use input_dir=.")
+        if self.download_key is None:
+            # A download-free run spawns no download child, so a download-only knob
+            # could only be silently ignored — reject it instead.
+            defaults = {f.name: f.default for f in fields(self)}
+            knobs = ("download_do_overwrite", "download_concurrency", "download_continue_on_error")
+            set_knobs = [k for k in knobs if getattr(self, k) != defaults[k]]
+            if set_knobs:
+                raise ValueError(
+                    f"{', '.join(f'{k}=' for k in set_knobs)} has no effect with download_key=null "
+                    "(no download child runs); remove it or set a download_key."
+                )
 
     @property
     def work_dir(self) -> Path:
@@ -182,21 +198,22 @@ class RunConfig:
              'concurrency=4', 'continue_on_error=False',
              'hydra.run.dir=/data/out/.meds_extract_run/hydra_download']
 
-            The two transfer knobs are forwarded verbatim:
+            The download knobs are forwarded verbatim (``download_do_overwrite``
+            as the child's ``do_overwrite=``):
 
             >>> run = RunConfig(
-            ...     spec="Example", output_dir="/data/out",
+            ...     spec="Example", output_dir="/data/out", download_do_overwrite=True,
             ...     download_concurrency=8, download_continue_on_error=True,
             ... )
-            >>> [a for a in run.download_argv("s") if a.startswith(("concurrency", "continue"))]
-            ['concurrency=8', 'continue_on_error=True']
+            >>> [a for a in run.download_argv("s") if a.startswith(("do_over", "concurrency", "continue"))]
+            ['do_overwrite=True', 'concurrency=8', 'continue_on_error=True']
         """
         return [
             "MEDS_extract.download.cli",
             f"spec={spec_ref}",
             f"output_dir={self.effective_input_dir}",
             f"key={self.download_key}",
-            f"do_overwrite={self.do_overwrite}",
+            f"do_overwrite={self.download_do_overwrite}",
             f"concurrency={self.download_concurrency}",
             f"continue_on_error={self.download_continue_on_error}",
             # Keep the child's Hydra run dir out of the user's CWD.

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -4,7 +4,7 @@ Doctests throughout the module cover most pure-Python machinery — spec dispatc
 normalization, hash helpers, ``RemoteFile`` validation, SHA256SUMS parsing, manifest
 filtering, client lifecycle (``HTTPSource.close``), and the whole
 :meth:`Source._fetch_one` / :meth:`Source.download_all` policy surface
-(skip / overwrite / ``.part`` staging + promotion / checksum / failure-collection /
+(skip / re-fetch / ``.part`` staging + promotion / checksum / failure-collection /
 path-traversal / duplicate-dest) via the doctests in ``source.py``. This file covers
 what doctests can't express cleanly: the ``_resumable_stream`` HTTP primitive's
 wire-level behavior (Range resume, 416/206 mismatch handling, gzip-vs-identity

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -170,6 +170,35 @@ def test_http_source_fetches_multiple_urls(tmp_path: Path):
     assert (tmp_path / "b.csv").read_bytes() == bodies["https://example.com/b.csv"]
 
 
+def test_rerun_mixed_manifest_refetches_only_unverifiable(tmp_path: Path):
+    """A manifest mixing sha-verified entries with checksum-free URLs must be
+    re-runnable end-to-end: the second ``download_all`` skips the verified file
+    (its local copy proves complete) and re-fetches the checksum-free one (which
+    never can) — no refusal, no error, correct bytes after both passes."""
+    v_url = "https://example.com/verified.csv"
+    plain_url = "https://example.com/no_sha.csv"
+    bodies = {v_url: b"stable, verifiable bytes", plain_url: b"bytes with no manifest sha"}
+    served: list[str] = []
+
+    def handler(request):
+        served.append(str(request.url))
+        return httpx.Response(200, content=bodies[str(request.url)])
+
+    for _ in range(2):
+        src = HTTPSource(
+            urls=[{"url": v_url, "sha256": _sha(bodies[v_url])}, plain_url],
+            client=_mock_client(handler),
+        )
+        src.download_all(tmp_path)
+        assert (tmp_path / "verified.csv").read_bytes() == bodies[v_url]
+        assert (tmp_path / "no_sha.csv").read_bytes() == bodies[plain_url]
+
+    # First run fetches both; the re-run skips the verified file and re-fetches
+    # only the unverifiable one.
+    assert served.count(v_url) == 1
+    assert served.count(plain_url) == 2
+
+
 def test_http_source_checksum_mismatch_fails(tmp_path: Path):
     body = b"contents"
     wrong_sha = "0" * 64

--- a/tests/test_download_cli.py
+++ b/tests/test_download_cli.py
@@ -3,7 +3,7 @@
 Every test here drives the real console script as a subprocess — exactly how users
 invoke it — and asserts CLI-level contracts: exit codes, bucket-``key=`` semantics,
 selective interpolation resolution, spec resolution (``pkg://``), reserved
-``sources:`` keys, and overwrite/fail-fast policy. Local ``fsspec`` mirrors are used
+``sources:`` keys, and re-fetch/fail-fast policy. Local ``fsspec`` mirrors are used
 as the transport vehicle purely because they need no network and no extras;
 fsspec-*source*-specific behavior lives in ``test_download_fsspec.py``, and
 HTTP-backed wire behavior in ``test_download.py`` (skipped without the ``download``
@@ -207,14 +207,14 @@ def test_cli_failure_exits_nonzero(tmp_path: Path):
     (mirror / "a.csv").write_text("upstream content\n")
     raw = tmp_path / "raw"
     raw.mkdir()
-    (raw / "a.csv").write_text("conflicting local content\n")  # sha mismatch → FileExistsError
+    (raw / "a.csv").mkdir()  # a directory where the fetch needs a file → the fetch fails
 
     result, _ = _run_cli(tmp_path, f"sources:\n  dataset:\n    - type: fsspec\n      root: {mirror}\n")
     assert result.returncode != 0, f"expected failure exit:\n{result.stdout}\n{result.stderr}"
     # Pin the failure to the intended cause so an unrelated CLI crash can't
     # satisfy this test vacuously.
-    assert "Refusing to overwrite" in result.stdout + result.stderr
-    assert (raw / "a.csv").read_text() == "conflicting local content\n"  # untouched
+    assert "download_all failed" in result.stdout + result.stderr
+    assert (raw / "a.csv").is_dir()  # untouched
 
 
 def test_cli_unknown_key_exits_nonzero(tmp_path: Path):
@@ -354,8 +354,8 @@ def test_cli_selected_bucket_interpolation_failure_is_clear(tmp_path: Path):
 
 
 def test_cli_cross_source_collision_exits_before_any_fetch(tmp_path: Path):
-    """Two sources listing the same rel_path into one shared dest_dir is a config error caught up-front — not
-    a mid-download race/FileExistsError."""
+    """Two sources listing the same rel_path into one shared dest_dir is a config error caught up-front —
+    not a mid-download race."""
     m1 = tmp_path / "m1"
     m2 = tmp_path / "m2"
     for m in (m1, m2):
@@ -378,8 +378,8 @@ def test_cli_cross_source_collision_exits_before_any_fetch(tmp_path: Path):
 
 
 def test_cli_fail_fast_skips_remaining_sources(tmp_path: Path):
-    """With the default ``continue_on_error=false``, a failing source stops the whole run — later sources are
-    not attempted.
+    """With the default ``continue_on_error=false``, a failing source stops the whole run — later sources
+    are not attempted.
 
     With ``continue_on_error=true``, they are.
     """
@@ -396,14 +396,14 @@ def test_cli_fail_fast_skips_remaining_sources(tmp_path: Path):
     - type: fsspec
       root: {m2}
 """
-    # Sabotage source 1: a conflicting pre-existing dest for a.csv.
+    # Sabotage source 1: a directory where a.csv's fetch needs a file.
     raw = tmp_path / "raw"
     raw.mkdir()
-    (raw / "a.csv").write_text("conflicting\n")
+    (raw / "a.csv").mkdir()
 
     result, _ = _run_cli(tmp_path, spec)
     assert result.returncode != 0
-    assert "Refusing to overwrite" in result.stdout + result.stderr  # the intended failure
+    assert "download_all failed" in result.stdout + result.stderr  # the intended failure
     assert not (raw / "b.csv").exists(), "fail-fast must not proceed to source 2"
 
     result, _ = _run_cli(tmp_path, spec, "continue_on_error=true", hydra_dir=".hydra2")

--- a/tests/test_download_cli.py
+++ b/tests/test_download_cli.py
@@ -217,6 +217,29 @@ def test_cli_failure_exits_nonzero(tmp_path: Path):
     assert (raw / "a.csv").is_dir()  # untouched
 
 
+def test_cli_rerun_replaces_unverified_dest_and_stays_idempotent(tmp_path: Path):
+    """A pre-existing dest that fails manifest verification is re-fetched (with a warning naming the file)
+    rather than refused, so a stale or partially-staged output dir is healed by simply re-running; the healed
+    tree then verifies and a further re-run skips it — both runs exit 0."""
+    mirror = tmp_path / "mirror"
+    mirror.mkdir()
+    (mirror / "a.csv").write_text("upstream content\n")
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    (raw / "a.csv").write_text("stale local copy\n")  # fails sha verification
+
+    spec = f"sources:\n  dataset:\n    - type: fsspec\n      root: {mirror}\n"
+    result, _ = _run_cli(tmp_path, spec)
+    assert result.returncode == 0, f"expected success:\n{result.stdout}\n{result.stderr}"
+    assert "failed SHA-256 verification" in result.stdout + result.stderr
+    assert (raw / "a.csv").read_text() == "upstream content\n"
+
+    mtime_after_heal = (raw / "a.csv").stat().st_mtime
+    result, _ = _run_cli(tmp_path, spec, hydra_dir=".hydra2")
+    assert result.returncode == 0, f"expected success:\n{result.stdout}\n{result.stderr}"
+    assert (raw / "a.csv").stat().st_mtime == mtime_after_heal, "healed file must now be skipped"
+
+
 def test_cli_unknown_key_exits_nonzero(tmp_path: Path):
     """A typo'd ``key=`` must be an error listing the available buckets — not a silent no-op success
     (``common`` is always appended, so a bad key would otherwise quietly fetch the wrong subset)."""

--- a/tests/test_download_fsspec.py
+++ b/tests/test_download_fsspec.py
@@ -45,6 +45,56 @@ def test_fetch_refuses_symlink_escape(tmp_path: Path):
     assert list(outside.iterdir()) == [], "nothing may be written outside dest_dir"
 
 
+def test_existing_dest_policy_skips_verified_and_refetches_unverified(tmp_path: Path, caplog):
+    """The default (``do_overwrite=False``) existing-dest policy, all three rows at once:
+
+    a dest that verifies against the manifest sha is skipped (``_pull`` never runs);
+    a dest that MISMATCHES the sha is re-fetched, with a warning naming the file; a
+    dest with no manifest sha is unverifiable and re-fetched silently (debug-level,
+    not a warning). A second pass stays idempotent: the healed mismatch now
+    verifies and skips, while the unverifiable file re-fetches again.
+    """
+    import hashlib
+    import logging
+
+    from MEDS_extract.download import RemoteFile, Source
+
+    good = b"verified body"
+    fresh = b"fresh body"
+    pulls: list[str] = []
+
+    class StubSource(Source):
+        def _list_files(self):
+            return [
+                RemoteFile("verified.txt", "", sha256=hashlib.sha256(good).hexdigest()),
+                RemoteFile("mismatch.txt", "", sha256=hashlib.sha256(fresh).hexdigest()),
+                RemoteFile("no_sha.txt", ""),
+            ]
+
+        def _pull(self, source_path, target):
+            pulls.append(target.name)
+            target.write_bytes(fresh)
+
+    (tmp_path / "verified.txt").write_bytes(good)
+    (tmp_path / "mismatch.txt").write_bytes(b"corrupt local copy")
+    (tmp_path / "no_sha.txt").write_bytes(b"stale local copy")
+
+    with caplog.at_level(logging.WARNING, logger="MEDS_extract.download.source"):
+        StubSource().download_all(tmp_path)
+
+    assert pulls == ["mismatch.txt.part", "no_sha.txt.part"], "the verified dest must not be re-fetched"
+    assert (tmp_path / "verified.txt").read_bytes() == good
+    assert (tmp_path / "mismatch.txt").read_bytes() == fresh
+    assert (tmp_path / "no_sha.txt").read_bytes() == fresh
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("mismatch.txt" in m and "failed SHA-256 verification" in m for m in warnings)
+    assert not any("no_sha.txt" in m for m in warnings), "an unverifiable re-fetch is not a warning"
+
+    pulls.clear()
+    StubSource().download_all(tmp_path)
+    assert pulls == ["no_sha.txt.part"], "re-run: healed mismatch skips; unverifiable re-fetches again"
+
+
 def test_fsspec_include_filters_before_hashing(tmp_path: Path, monkeypatch):
     """``include=`` on FsspecSource must filter *before* hashing — the documented cost mitigation for cloud
     mirrors is that excluded bytes are never read.

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from typing import TYPE_CHECKING
 
+import pytest
 from omegaconf import OmegaConf
 
 from MEDS_extract.config import EtlConfig
@@ -154,9 +155,10 @@ def test_run_cli_download_failure_stops_the_run(tmp_path):
 
 def test_run_cli_config_errors_exit_one(tmp_path):
     """Bad inputs fail before any work: an unresolvable spec; a path-resolved spec
-    omitting dataset_name; an implausible flag combination (input_dir with a
-    download_key). The only thing a failed run may create is its own Hydra run dir
-    (log + config snapshot) inside the target output tree."""
+    omitting dataset_name; implausible flag combinations (input_dir with a
+    download_key; a download-only knob on a download-free run). The only thing a
+    failed run may create is its own Hydra run dir (log + config snapshot) inside
+    the target output tree."""
     result = _run_cli(tmp_path, "spec=No-Such-Pipeline", f"output_dir={tmp_path / 'o1'}")
     assert result.returncode == 1
     assert "not a registered pipeline name" in result.stdout + result.stderr
@@ -172,7 +174,18 @@ def test_run_cli_config_errors_exit_one(tmp_path):
     assert result.returncode == 1
     assert "input_dir= is for download-free runs" in result.stdout + result.stderr
 
-    for d in ("o1", "o2", "o3"):
+    result = _run_cli(
+        tmp_path,
+        f"spec={spec_fp}",
+        f"output_dir={tmp_path / 'o4'}",
+        "download_key=null",
+        f"input_dir={tmp_path}",
+        "download_concurrency=8",
+    )
+    assert result.returncode == 1
+    assert "no effect with download_key=null" in result.stdout + result.stderr
+
+    for d in ("o1", "o2", "o3", "o4"):
         # No data, no staging — at most the run's own Hydra log dir under the target.
         created = {p.name for p in (tmp_path / d).iterdir()} if (tmp_path / d).exists() else set()
         assert created <= {".meds_extract_run"}, created
@@ -228,7 +241,8 @@ def test_run_cli_forwards_child_flags_end_to_end(tmp_path):
     successful run is the assertion.
 
     ``stage_runner_fp`` carries a real ``parallelize`` block (the flag's whole point),
-    and ``overrides`` carries ``seed``, which is a genuine pipeline-config key.
+    ``download_do_overwrite`` routes to the download child as ``do_overwrite=``, and
+    ``overrides`` carries ``seed``, which is a genuine pipeline-config key.
     """
     spec_fp = _write_tiny_spec(tmp_path)
     out_dir = tmp_path / "meds"
@@ -241,6 +255,7 @@ def test_run_cli_forwards_child_flags_end_to_end(tmp_path):
         f"spec={spec_fp}",
         f"output_dir={out_dir}",
         f"stage_runner_fp={stage_runner_fp}",
+        "download_do_overwrite=True",
         "download_concurrency=2",
         "download_continue_on_error=True",
         "overrides=['seed=2']",
@@ -251,5 +266,26 @@ def test_run_cli_forwards_child_flags_end_to_end(tmp_path):
     # The flags reached the children rather than being silently dropped.
     combined = result.stdout + result.stderr
     assert "--stage_runner_fp" in combined
+    assert "do_overwrite=True" in combined
     assert "concurrency=2" in combined
     assert "seed=2" in combined
+
+
+def test_run_config_rejects_download_knobs_on_download_free_runs(tmp_path):
+    """``download_key=null`` spawns no download child, so a non-default download-only knob could only be
+    silently ignored — ``RunConfig`` rejects the combination instead, naming the offending knob."""
+    base = {
+        "spec": "X",
+        "output_dir": str(tmp_path),
+        "download_key": None,
+        "input_dir": str(tmp_path),
+    }
+    run_cli.RunConfig(**base)  # the download-free shape itself is valid
+
+    for knob in (
+        {"download_do_overwrite": True},
+        {"download_concurrency": 8},
+        {"download_continue_on_error": True},
+    ):
+        with pytest.raises(ValueError, match="no effect with download_key=null"):
+            run_cli.RunConfig(**base, **knob)

--- a/tests/test_run_example.py
+++ b/tests/test_run_example.py
@@ -102,8 +102,9 @@ def test_meds_extract_run_example_end_to_end(with_knobs: bool):
       would produce the same output. Together they catch a wrong flag spelling here AND
       a parallelism regression in MEDS-transforms.
     - ``overrides`` carries ``do_overwrite=True``, a genuine pipeline-config key
-      (distinct from ``RunConfig.do_overwrite``, which routes only to the download
-      child), forcing every stage to recompute rather than reuse cached output.
+      (distinct from ``RunConfig.download_do_overwrite``, which routes only to the
+      download child), forcing every stage to recompute rather than reuse cached
+      output.
 
     ``do_profile`` is deliberately excluded: it needs ``hydra_profiler`` installed, so
     exercising it here would test the plugin's availability rather than the passthrough.


### PR DESCRIPTION
Implements the policy decided in #264 exactly: on re-runs, existing destinations are **skipped only when they verify** against the manifest sha; sha-mismatched files re-fetch with a warning naming the file; checksum-free files re-fetch quietly — the `FileExistsError` refusal is gone, so mixed specs (PhysioNet bucket + checksum-free http URLs) re-run and resume cleanly. Re-fetches keep the atomic staging (`.part` + sha-verify + replace), so a failed re-fetch never destroys the existing copy. `do_overwrite=True` remains fetch-everything.

Rides along per #232: the runner's bare `do_overwrite` field becomes `download_do_overwrite` (grouped with its passthrough siblings; README knob table updated), and `__post_init__` now rejects any non-default download-only knob on download-free runs, with defaults compared via `dataclasses.fields` rather than hardcoded.

Every doc site pinning the old refusal is updated (module/class/function docstrings, both READMEs, the spec.py comment). Tests: the refusal-pinning tests now pin the new policy; added MockTransport + CLI coverage that mixed manifests re-fetch only the unverifiable files across two idempotent exit-0 runs, mismatch-repair with the warning, verified-skip pull-counting, the renamed knob reaching the child argv, and the download-free rejection. 60 targeted + 91 wider tests green; pre-commit clean.

Closes #264. Closes #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)