### PR TITLE
meds-extract-run: split download_key into do_download + dataset_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,8 +458,8 @@ With that in place, the whole ETL is one command:
 
 ```bash
 meds-extract-run spec=MIMIC-IV output_dir=/data/mimic_meds                     # full dataset
-meds-extract-run spec=MIMIC-IV output_dir=/tmp/demo_meds download_key=demo     # demo sources bucket
-meds-extract-run spec=messy.yaml output_dir=... download_key=null input_dir=.. # unpackaged / pre-staged
+meds-extract-run spec=MIMIC-IV output_dir=/tmp/demo_meds dataset_key=demo      # demo sources bucket
+meds-extract-run spec=messy.yaml output_dir=... do_download=false input_dir=.. # unpackaged / pre-staged
 ```
 
 `spec=` resolves down a three-rung ladder: a **registered name** (the entry-point group above), a
@@ -473,8 +473,8 @@ nothing outside `output_dir` — logs and Hydra config snapshots land under
 download), never in a CWD `outputs/` dir. The runner is a thin orchestrator over the
 two public CLIs — it shells out to each in turn (in-module invocation modes may come later, upstream):
 
-1. spawns `meds-extract-download` to stage the selected `sources:` bucket (`download_key=` picks
-    the bucket, `common` is always appended; `download_key=null` skips downloading entirely);
+1. spawns `meds-extract-download` to stage the selected `sources:` bucket (`dataset_key=` picks
+    the bucket, `common` is always appended; `do_download=false` skips downloading entirely);
 2. synthesizes a MEDS-transforms pipeline config — the canonical stage list plus the `etl:` block's
     curated options — with every value **inlined** (no env-var indirection), written to
     `<output_dir>/.meds_extract_run/pipeline.yaml` as self-contained provenance. Its
@@ -489,22 +489,24 @@ two public CLIs — it shells out to each in turn (in-module invocation modes ma
 4. stamps `etl_metadata.dataset_name` and `etl_metadata.dataset_version` automatically (through the
     synthesized config): the name is `etl.dataset_name`, defaulting to the registered pipeline name for
     registry-resolved specs; the version is `{raw version}:{ETL package's installed version}`, where the
-    raw version is the selected bucket's `sources.dataset_version` (or the `etl.raw_dataset_version`
-    fallback) and the package version comes from the entry point's providing distribution — so version
-    provenance needs zero code in the dataset package. For `pkg://`/path specs (no distribution to ask)
-    the stamp is the raw version alone, or pass `dataset_version=` explicitly.
+    raw version is the `dataset_key=` bucket's `sources.dataset_version` (or the
+    `etl.raw_dataset_version` fallback) — the same bucket whether or not the download runs, so a
+    pre-staged demo run stamps the demo version — and the package version comes from the entry
+    point's providing distribution — so version provenance needs zero code in the dataset package.
+    For `pkg://`/path specs (no distribution to ask) the stamp is the raw version alone, or pass
+    `dataset_version=` explicitly.
 
 `output_dir` is where the final MEDS cohort lands (`data/`, `metadata/`). Raw data downloads into
 `download_dest_dir=` (defaulting under `<output_dir>/.meds_extract_run/` — point it somewhere durable
 to reuse raw data across runs) and is also the pipeline's input; download-free runs pass
-`download_key=null input_dir=<pre-staged raw data>` instead. Run-internal artifacts (the synthesized
+`do_download=false input_dir=<pre-staged raw data>` instead. Run-internal artifacts (the synthesized
 pipeline config, child logs) live under `<output_dir>/.meds_extract_run/`. Exit code is `0` on success
 and non-zero on any failure (child exit codes propagate). The runnable
 [`example/`](https://github.com/mmcdermott/MEDS_extract/tree/main/example) directory's `messy.yaml`
 carries an `etl:` block, so you can try the runner immediately:
 
 ```bash
-meds-extract-run spec=example/messy.yaml output_dir=/tmp/meds_example_meds download_key=null \
+meds-extract-run spec=example/messy.yaml output_dir=/tmp/meds_example_meds do_download=false \
 	input_dir=example/raw_data
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -77,7 +77,7 @@ meds-extract-run spec=example/messy.yaml output_dir=/tmp/meds_example_meds
 ```
 
 `tests/test_run_example.py` regression-verifies that this route reproduces `expected_output/`
-bit-for-bit (it runs with `download_key=null input_dir=...` against pre-staged raw data, so it stays
+bit-for-bit (it runs with `do_download=false input_dir=...` against pre-staged raw data, so it stays
 offline).
 
 A few notes on the reserved blocks in [`messy.yaml`](messy.yaml):

--- a/src/MEDS_extract/_cli.py
+++ b/src/MEDS_extract/_cli.py
@@ -44,7 +44,7 @@ def require_dotlist_args(prog: str, required: dict[str, str], *, local_only: tup
         ...     require_dotlist_args("meds-extract-run", {"spec": "<spec>", "output_dir": "<dir>"})
         >>> exc_info.value.code
         1
-        >>> sys.argv = ["meds-extract-run", "spec=X", "output_dir=/tmp/o", "download_key=demo"]
+        >>> sys.argv = ["meds-extract-run", "spec=X", "output_dir=/tmp/o", "dataset_key=demo"]
         >>> require_dotlist_args("meds-extract-run", {"spec": "<spec>", "output_dir": "<dir>"})
         >>> sys.argv = ["meds-extract-run", "spec=X", "output_dir=s3://bucket/raw"]
         >>> with pytest.raises(SystemExit) as exc_info:

--- a/src/MEDS_extract/run/cli.py
+++ b/src/MEDS_extract/run/cli.py
@@ -2,9 +2,9 @@
 
 One command runs a whole dataset ETL from its MESSY spec::
 
-    meds-extract-run spec=MIMIC-IV output_dir=/data/mimic_meds download_key=demo
+    meds-extract-run spec=MIMIC-IV output_dir=/data/mimic_meds dataset_key=demo
     meds-extract-run spec=pkg://MIMIC_IV_MEDS.configs.event_configs.yaml output_dir=...
-    meds-extract-run spec=/path/to/messy.yaml output_dir=... download_key=null input_dir=...
+    meds-extract-run spec=/path/to/messy.yaml output_dir=... do_download=false input_dir=...
 
 The CLI itself just shuttles commands: it loads the spec into the one MESSY config
 object (:meth:`~MEDS_extract.config.MessyConfig.load` — resolution ladder,
@@ -68,17 +68,22 @@ class RunConfig:
             child's Hydra run dir) live under the derived :attr:`work_dir`
             (``<output_dir>/.meds_extract_run``), alongside the pipeline's own
             ``.logs``/intermediate stage outputs.
-        download_key: Which ``sources:`` bucket to download (``dataset`` /
-            ``demo`` / ...); ``common`` is always appended, and the per-bucket
-            entry of a mapping-form ``sources.dataset_version`` follows it.
-            ``null`` skips downloading entirely (``input_dir`` is then required;
-            version stamping uses the default ``dataset`` bucket).
-        download_dest_dir: Where to download raw data (only with a
-            ``download_key``); it is then also the pipeline's effective input.
-            Defaults under :attr:`work_dir` — point it somewhere durable to keep
-            raw data across output trees.
+        do_download: Whether to run the download stage at all. ``False`` spawns
+            no download child (``input_dir`` is then required).
+        dataset_key: Which ``sources:`` bucket is in play (``dataset`` /
+            ``demo`` / ...). It selects what the download child fetches
+            (``common`` is always appended) AND which entry of a mapping-form
+            ``sources.dataset_version`` is stamped into the output's
+            ``etl_metadata.dataset_version`` — always, whether or not the
+            download runs, so a pre-staged demo run
+            (``do_download=false dataset_key=demo input_dir=...``) stamps the
+            demo version.
+        download_dest_dir: Where to download raw data (only with
+            ``do_download=true``); it is then also the pipeline's effective
+            input. Defaults under :attr:`work_dir` — point it somewhere durable
+            to keep raw data across output trees.
         input_dir: Where pre-staged raw input data lives (only with
-            ``download_key=null``).
+            ``do_download=false``).
         dataset_version: Explicit override for ``etl_metadata.dataset_version``
             (default: computed — see ``MessyConfig.dataset_version_for``).
 
@@ -119,10 +124,10 @@ class RunConfig:
     ``OmegaConf.to_object`` (Hydra itself always hands the task function a
     ``DictConfig``; ``to_object`` is the idiomatic bridge back to the registered
     dataclass). It validates the plausible combinations — exactly one of "download
-    into ``download_dest_dir``" (``download_key`` set) or "read pre-staged
-    ``input_dir``" (``download_key=null``) describes where the pipeline's raw
+    into ``download_dest_dir``" (``do_download=true``) or "read pre-staged
+    ``input_dir``" (``do_download=false``) describes where the pipeline's raw
     input comes from (:attr:`effective_input_dir`) — rejects non-default
-    ``download_*`` knobs on a download-free run (``download_key=null`` spawns no
+    ``download_*`` knobs on a download-free run (``do_download=false`` spawns no
     download child, so they could only be silently ignored) — and normalizes the
     directory fields to absolute local paths (URL-shaped values are rejected;
     relative paths resolve against the invoking CWD, which
@@ -132,7 +137,8 @@ class RunConfig:
 
     spec: str = MISSING
     output_dir: str = MISSING
-    download_key: str | None = "dataset"
+    do_download: bool = True
+    dataset_key: str = "dataset"
     download_dest_dir: str | None = None
     input_dir: str | None = None
     dataset_version: str | None = None
@@ -151,19 +157,17 @@ class RunConfig:
         for f in ("output_dir", "download_dest_dir", "input_dir", "stage_runner_fp"):
             if getattr(self, f) not in (None, MISSING):
                 setattr(self, f, str(user_local_path(getattr(self, f), field=f)))
-        if self.download_key is None and self.input_dir is None:
+        if not self.do_download and self.input_dir is None:
+            raise ValueError("do_download=false requires input_dir= pointing at pre-staged raw data.")
+        if self.do_download and self.input_dir is not None:
             raise ValueError(
-                "download_key=null (no download) requires input_dir= pointing at pre-staged raw data."
-            )
-        if self.download_key is not None and self.input_dir is not None:
-            raise ValueError(
-                "input_dir= is for download-free runs (download_key=null). With a download_key, "
+                "input_dir= is for download-free runs (do_download=false). With do_download=true, "
                 "data is downloaded into download_dest_dir=, which is also the pipeline's input "
                 "— set one or the other."
             )
-        if self.download_key is None and self.download_dest_dir is not None:
-            raise ValueError("download_dest_dir= has no effect with download_key=null; use input_dir=.")
-        if self.download_key is None:
+        if not self.do_download and self.download_dest_dir is not None:
+            raise ValueError("download_dest_dir= has no effect with do_download=false; use input_dir=.")
+        if not self.do_download:
             # A download-free run spawns no download child, so a download-only knob
             # could only be silently ignored — reject it instead.
             defaults = {f.name: f.default for f in fields(self)}
@@ -171,8 +175,8 @@ class RunConfig:
             set_knobs = [k for k in knobs if getattr(self, k) != defaults[k]]
             if set_knobs:
                 raise ValueError(
-                    f"{', '.join(f'{k}=' for k in set_knobs)} has no effect with download_key=null "
-                    "(no download child runs); remove it or set a download_key."
+                    f"{', '.join(f'{k}=' for k in set_knobs)} has no effect with do_download=false "
+                    "(no download child runs); remove it or set do_download=true."
                 )
 
     @property
@@ -191,7 +195,7 @@ class RunConfig:
         """Build the ``meds-extract-download`` child command line.
 
         Examples:
-            >>> run = RunConfig(spec="Example", output_dir="/data/out", download_key="demo")
+            >>> run = RunConfig(spec="Example", output_dir="/data/out", dataset_key="demo")
             >>> run.download_argv("pkg://ex.messy.yaml")
             ['MEDS_extract.download.cli', 'spec=pkg://ex.messy.yaml',
              'output_dir=/data/out/.meds_extract_run/raw_input', 'key=demo', 'do_overwrite=False',
@@ -212,7 +216,7 @@ class RunConfig:
             "MEDS_extract.download.cli",
             f"spec={spec_ref}",
             f"output_dir={self.effective_input_dir}",
-            f"key={self.download_key}",
+            f"key={self.dataset_key}",
             f"do_overwrite={self.download_do_overwrite}",
             f"concurrency={self.download_concurrency}",
             f"continue_on_error={self.download_continue_on_error}",
@@ -270,14 +274,13 @@ def _hydra_main(cfg: DictConfig) -> None:
         # One load of the one config object; everything else comes off it.
         messy = MessyConfig.load(run.spec)
         _ = messy.event_tables  # the pipeline needs event tables: fail before any work
-        # Version stamping follows the selected sources bucket; a download-free run
-        # (download_key=null) has no selected bucket and stamps the default
-        # ``dataset`` entry (only relevant for mapping-form sources.dataset_version).
-        stamp_key = run.download_key if run.download_key is not None else "dataset"
+        # Version stamping always follows the selected sources bucket (dataset_key),
+        # whether or not the download runs — only relevant for mapping-form
+        # sources.dataset_version, where buckets carry distinct versions.
         pipeline_cfg = messy.pipeline_config(
             input_dir=run.effective_input_dir,
             output_dir=Path(run.output_dir),
-            key=stamp_key,
+            key=run.dataset_key,
             dataset_version=run.dataset_version,
         )
     except (ValueError, FileNotFoundError) as e:
@@ -285,13 +288,13 @@ def _hydra_main(cfg: DictConfig) -> None:
         sys.exit(1)
     logger.info(f"Resolved spec={run.spec!r} to {messy.spec_ref}")
 
-    if run.download_key is not None:
+    if run.do_download:
         rc = run_command(run.download_argv(messy.spec_ref))
         if rc != 0:
             logger.error(f"meds-extract-download failed with exit code {rc}.")
             sys.exit(rc)
     else:
-        logger.info("download_key=null: skipping the download stage.")
+        logger.info("do_download=false: skipping the download stage.")
 
     pipeline_fp = run.work_dir / "pipeline.yaml"
     pipeline_fp.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -12,6 +12,7 @@ contract, which requires patching ``subprocess.run`` to observe.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -155,10 +156,10 @@ def test_run_cli_download_failure_stops_the_run(tmp_path):
 
 def test_run_cli_config_errors_exit_one(tmp_path):
     """Bad inputs fail before any work: an unresolvable spec; a path-resolved spec
-    omitting dataset_name; implausible flag combinations (input_dir with a
-    download_key; a download-only knob on a download-free run). The only thing a
-    failed run may create is its own Hydra run dir (log + config snapshot) inside
-    the target output tree."""
+    omitting dataset_name; implausible flag combinations (input_dir on a downloading
+    run; a download-free run without input_dir; a download-only knob on a
+    download-free run). The only thing a failed run may create is its own Hydra run
+    dir (log + config snapshot) inside the target output tree."""
     result = _run_cli(tmp_path, "spec=No-Such-Pipeline", f"output_dir={tmp_path / 'o1'}")
     assert result.returncode == 1
     assert "not a registered pipeline name" in result.stdout + result.stderr
@@ -178,14 +179,18 @@ def test_run_cli_config_errors_exit_one(tmp_path):
         tmp_path,
         f"spec={spec_fp}",
         f"output_dir={tmp_path / 'o4'}",
-        "download_key=null",
+        "do_download=false",
         f"input_dir={tmp_path}",
         "download_concurrency=8",
     )
     assert result.returncode == 1
-    assert "no effect with download_key=null" in result.stdout + result.stderr
+    assert "no effect with do_download=false" in result.stdout + result.stderr
 
-    for d in ("o1", "o2", "o3", "o4"):
+    result = _run_cli(tmp_path, f"spec={spec_fp}", f"output_dir={tmp_path / 'o5'}", "do_download=false")
+    assert result.returncode == 1
+    assert "do_download=false requires input_dir=" in result.stdout + result.stderr
+
+    for d in ("o1", "o2", "o3", "o4", "o5"):
         # No data, no staging — at most the run's own Hydra log dir under the target.
         created = {p.name for p in (tmp_path / d).iterdir()} if (tmp_path / d).exists() else set()
         assert created <= {".meds_extract_run"}, created
@@ -213,7 +218,7 @@ def test_run_cli_bare_and_pathless_invocations(tmp_path):
 
 
 def test_run_cli_download_free_run_and_pipeline_failure_propagates(tmp_path):
-    """``download_key=null input_dir=...`` skips the download; a pipeline-stage failure (missing raw table
+    """``do_download=false input_dir=...`` skips the download; a pipeline-stage failure (missing raw table
     file) surfaces as a non-zero runner exit."""
     spec_fp = _write_tiny_spec(tmp_path)
     empty_input = tmp_path / "empty_input"
@@ -223,12 +228,43 @@ def test_run_cli_download_free_run_and_pipeline_failure_propagates(tmp_path):
         tmp_path,
         f"spec={spec_fp}",
         f"output_dir={tmp_path / 'meds'}",
-        "download_key=null",
+        "do_download=false",
         f"input_dir={empty_input}",
     )
     assert result.returncode != 0
     combined = result.stdout + result.stderr
     assert "skipping the download stage" in combined
+
+
+def test_run_cli_download_free_run_stamps_the_dataset_key_bucket(tmp_path):
+    """Version stamping follows ``dataset_key=`` even when no download runs: with a mapping-form
+    ``sources.dataset_version``, a pre-staged demo run (``do_download=false dataset_key=demo input_dir=...``)
+    stamps the DEMO bucket's version into the synthesized pipeline config — not the ``dataset`` bucket's."""
+    spec_fp = _write_tiny_spec(tmp_path)
+    spec_fp.write_text(
+        spec_fp.read_text().replace(
+            'dataset_version: "2.0"',
+            'dataset_version:\n    dataset: "9.9"\n    demo: "2.0"',
+        )
+    )
+    staged = tmp_path / "staged"
+    staged.mkdir()
+    shutil.copy(tmp_path / "mirror" / "patients.csv", staged)
+    out_dir = tmp_path / "meds"
+
+    result = _run_cli(
+        tmp_path,
+        f"spec={spec_fp}",
+        f"output_dir={out_dir}",
+        "do_download=false",
+        "dataset_key=demo",
+        f"input_dir={staged}",
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+    cfg = OmegaConf.load(out_dir / ".meds_extract_run" / "pipeline.yaml")
+    assert cfg.etl_metadata.dataset_version == "2.0"  # the demo bucket's entry, not dataset's "9.9"
+    assert (out_dir / "data" / "train" / "0.parquet").exists()
 
 
 def test_run_cli_forwards_child_flags_end_to_end(tmp_path):
@@ -272,12 +308,12 @@ def test_run_cli_forwards_child_flags_end_to_end(tmp_path):
 
 
 def test_run_config_rejects_download_knobs_on_download_free_runs(tmp_path):
-    """``download_key=null`` spawns no download child, so a non-default download-only knob could only be
+    """``do_download=false`` spawns no download child, so a non-default download-only knob could only be
     silently ignored — ``RunConfig`` rejects the combination instead, naming the offending knob."""
     base = {
         "spec": "X",
         "output_dir": str(tmp_path),
-        "download_key": None,
+        "do_download": False,
         "input_dir": str(tmp_path),
     }
     run_cli.RunConfig(**base)  # the download-free shape itself is valid
@@ -287,5 +323,5 @@ def test_run_config_rejects_download_knobs_on_download_free_runs(tmp_path):
         {"download_concurrency": 8},
         {"download_continue_on_error": True},
     ):
-        with pytest.raises(ValueError, match="no effect with download_key=null"):
+        with pytest.raises(ValueError, match="no effect with do_download=false"):
             run_cli.RunConfig(**base, **knob)

--- a/tests/test_run_example.py
+++ b/tests/test_run_example.py
@@ -3,14 +3,14 @@
 The one-command counterpart of ``tests/test_example.py``: where that test invokes
 ``meds-extract-download`` + ``MEDS_transform-pipeline`` separately (the two-command
 walkthrough), this one drives the exact same MESSY file through the generic runner —
-``meds-extract-run spec=example/messy.yaml output_dir=... download_key=null input_dir=...``
+``meds-extract-run spec=example/messy.yaml output_dir=... do_download=false input_dir=...``
 against pre-staged raw data — and regression-compares the final ``data/`` +
 ``metadata/`` outputs against the same committed golden fixtures. A green run proves
 the ``etl:`` block in ``example/messy.yaml`` reproduces ``example/pipeline.yaml``'s
 outputs bit-for-bit, and that the synthesized pipeline config carries fully inlined
 values.
 
-``download_key=null`` (with the bundled CSVs copied into place) keeps this test
+``do_download=false`` (with the bundled CSVs copied into place) keeps this test
 offline: with downloading on, the spec's always-appended ``common`` bucket would pull
 the MIMIC-IV demo from PhysioNet, which ``test_example.py`` already covers. The
 runner's ``meds-extract-download`` subprocess leg is covered offline in
@@ -112,7 +112,7 @@ def test_meds_extract_run_example_end_to_end(with_knobs: bool):
     with tempfile.TemporaryDirectory() as tmpdir:
         root = Path(tmpdir) / "example_meds"
 
-        # Pre-stage the bundled raw CSVs; ``download_key=null input_dir=...`` skips
+        # Pre-stage the bundled raw CSVs; ``do_download=false input_dir=...`` skips
         # the sources stage entirely, keeping the test offline.
         staged = Path(tmpdir) / "raw_input"
         shutil.copytree(RAW_DATA, staged)
@@ -139,7 +139,7 @@ def test_meds_extract_run_example_end_to_end(with_knobs: bool):
             "meds-extract-run",
             f"spec={MESSY_YAML}",
             f"output_dir={root}",
-            "download_key=null",
+            "do_download=false",
             f"input_dir={staged}",
             *extra_args,
             f"hydra.run.dir={Path(tmpdir) / '.hydra'}",


### PR DESCRIPTION
Implements the redesign decided in #237: `download_key: str | None` (where `null` meant skip-download AND silently degraded version stamping to the 'dataset' bucket) becomes two orthogonal knobs — `do_download: bool = True` (whether the download child runs) and `dataset_key: str = "dataset"` (which `sources:` bucket is in play, driving BOTH the download child's `key=` and version stamping, always). The stamping bug this issue reported dies intrinsically: `do_download=false dataset_key=demo input_dir=...` now stamps the demo bucket's version, pinned by a test asserting the synthesized config carries the demo entry from a mapping-form `sources.dataset_version` rather than the dataset one.

Validation reworked in the new vocabulary (`input_dir` required iff `do_download=false`; `download_dest_dir` and the download-only knobs rejected when `do_download=false`); name swept consistently through the module docstring, README usage/knob table, `_cli.py` usage line, and every test — grep-verified zero `download_key` remnants. Builds on #273's rename/rejection groundwork. All runner suites + the parallelism lane green; pre-commit clean.

Closes #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)