### PR TITLE
split_and_shard_subjects: reject external split names colliding with IID splits

### DIFF
--- a/src/MEDS_extract/split_and_shard_subjects/split_and_shard_subjects.py
+++ b/src/MEDS_extract/split_and_shard_subjects/split_and_shard_subjects.py
@@ -52,7 +52,9 @@ def shard_subjects(
         overlap will solely occur between the an external split and another external split.
 
     Raises:
-        ValueError: If the sum of the split fractions in `split_fracs_dict` is not equal to 1.
+        ValueError: If the sum of the split fractions in `split_fracs_dict` is not equal to 1, or if an
+            external split name collides with an IID split name that would be generated from
+            `split_fracs_dict`.
 
     Examples:
         >>> subjects = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=int)
@@ -75,6 +77,18 @@ def shard_subjects(
          'held_out/0': [6],
          'taskA/held_out/0': [8, 9, 10],
          'taskB/held_out/0': [10, 8, 9]}
+
+        An external split may not reuse the name of an IID split that would be generated from
+        `split_fracs_dict`; were the two merged, the IID subjects assigned to that name would
+        silently vanish from the output. Rename the external split or remove the name from the
+        split fractions:
+
+        >>> shard_subjects(subjects, 3, {'held_out': np.array([1, 2], dtype=int)})
+        Traceback (most recent call last):
+            ...
+        ValueError: External split names ['held_out'] collide with the IID split names generated through
+        the split fractions; merging the two would silently drop the IID subjects assigned to those names.
+        Rename the colliding external splits or remove their names from the split fractions.
         >>> shard_subjects(subjects, n_subjects_per_shard=3, split_fracs_dict={'train': 0.5})
         Traceback (most recent call last):
             ...
@@ -138,6 +152,14 @@ def shard_subjects(
 
     rng = np.random.default_rng(seed)
     if n_subjects := len(subject_ids_to_split):
+        colliding_names = sorted(set(split_fracs_dict) & set(external_splits))
+        if colliding_names:
+            raise ValueError(
+                f"External split names {colliding_names} collide with the IID split names generated "
+                "through the split fractions; merging the two would silently drop the IID subjects "
+                "assigned to those names. Rename the colliding external splits or remove their names "
+                "from the split fractions."
+            )
         if not math.isclose(splits_cover, 1):
             raise ValueError(
                 f"The sum of the split fractions must be equal to 1. Got {splits_cover} "

--- a/tests/test_inprocess_pipeline.py
+++ b/tests/test_inprocess_pipeline.py
@@ -426,6 +426,42 @@ def test_split_and_shard_subjects_external_splits(tmp_path):
     assert sorted(iid) == list(range(1, 9))
 
 
+def test_split_and_shard_subjects_external_split_name_collision(tmp_path):
+    """An external split reusing an IID split name errors out instead of silently dropping subjects.
+
+    With the default IID split fractions, an external ``held_out`` split would overwrite the IID
+    ``held_out`` entry on merge, so every subject the IID pass assigned there would vanish from the
+    output shards. The stage must refuse such configs with an error naming the colliding split.
+    """
+    from MEDS_extract.split_and_shard_subjects.split_and_shard_subjects import main as sss_stage
+
+    root = tmp_path
+    input_dir = root / "input"
+    input_dir.mkdir()
+    pl.DataFrame({"subject_id": list(range(1, 11))}).write_parquet(input_dir / "patients.parquet")
+
+    event_cfg_fp = root / "messy.yaml"
+    event_cfg_fp.write_text("patients:\n  e:\n    code: X\n    time: null\n")
+
+    ext_fp = root / "external_splits.json"
+    ext_fp.write_text(json.dumps({"held_out": [9, 10]}))
+
+    cfg = _make_cfg(
+        {
+            "stage_cfg": {
+                "data_input_dir": str(input_dir),
+                "external_splits_json_fp": str(ext_fp),
+                "split_fracs": {"train": 0.8, "tuning": 0.1, "held_out": 0.1},
+                "n_subjects_per_shard": 10,
+            },
+            "MESSY_config_fp": str(event_cfg_fp),
+            "shards_map_fp": str(root / "metadata" / ".shards.json"),
+        }
+    )
+    with pytest.raises(ValueError, match=r"External split names \['held_out'\] collide"):
+        sss_stage.main_fn(cfg)
+
+
 def test_split_and_shard_subjects_external_splits_file_missing(tmp_path):
     """A configured-but-missing external splits JSON raises ``FileNotFoundError`` naming the path."""
     from MEDS_extract.split_and_shard_subjects.split_and_shard_subjects import main as sss_stage


### PR DESCRIPTION
Implements #222: an external split reusing a generated IID split name (the natural "official held_out set + default IID fractions" configuration) previously clobbered the IID entry in the dict merge — every subject the IID pass assigned to that name silently vanished from all shards. Now it raises a ValueError naming the colliding names and both remedies (rename the external split, or remove the name from split_fracs).

One check, placed inside the branch where IID splits are actually generated, which deliberately preserves two existing behaviors: the external-covers-everyone path (default fracs ignored, no IID pass — no collision to check) and null-fraction-disabled names (held_out: None + external held_out correctly doesn't collide, since the check runs on the None-filtered fracs). main() routes both paths through shard_subjects, proven by a main()-level unit test rather than a duplicate check. Error-catalog doctest uses the issue's exact repro. 14 targeted + 15 in-process tests green; pre-commit clean.

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)