### PR TITLE
Source-file enumeration skips hidden files

### DIFF
--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -660,8 +660,11 @@ def main(cfg: DictConfig):
     random.shuffle(event_metadata_configs)
 
     # Load the extracted event data, handling heterogeneous schemas (files whose codes
-    # reference source columns carry code_components; all-literal files don't).
-    event_parquet_files = list(Path(stage_input_dir).rglob("*.parquet"))
+    # reference source columns carry code_components; all-literal files don't). Hidden
+    # files are never source data, so they are excluded from the scan.
+    event_parquet_files = [
+        fp for fp in Path(stage_input_dir).rglob("*.parquet") if not fp.name.startswith(".")
+    ]
     all_event_dfs = [pl.scan_parquet(fp, glob=False) for fp in event_parquet_files]
     all_data = pl.concat(all_event_dfs, how="diagonal_relaxed")
 

--- a/src/MEDS_extract/io.py
+++ b/src/MEDS_extract/io.py
@@ -208,9 +208,10 @@ def resolve_source_files(dir: Path | UPath, prefix: str) -> list[Path | UPath]:
         ['labs.csv']
 
         **Sub-sharded directory layout** — many chunks per prefix, typical
-        layout of a pre-sharded source table. All files under ``{prefix}/`` are
-        returned sorted by name; the chunks must share one format family
-        (csv-family or parquet-family — ``scan_source`` rejects a mix):
+        layout of a pre-sharded source table. All non-hidden files under
+        ``{prefix}/`` are returned sorted by name; the chunks must share one
+        format family (csv-family or parquet-family — ``scan_source`` rejects
+        a mix):
 
         >>> with yaml_disk('''
         ... vitals/[0-2).parquet:
@@ -221,6 +222,17 @@ def resolve_source_files(dir: Path | UPath, prefix: str) -> list[Path | UPath]:
         ...     resolved = resolve_source_files(Path(d), "vitals")
         ...     [fp.name for fp in resolved]
         ['[0-2).parquet', '[2-4).parquet']
+
+        Hidden files are never source data, so dotfile debris in a sub-sharded
+        directory (e.g. a stranded writer intermediate) is ignored:
+
+        >>> with yaml_disk('''
+        ... vitals/chunk_0.parquet:
+        ...   hr: [80, 85]
+        ... ''') as d:
+        ...     (Path(d) / "vitals" / ".x.parquet.strings.tmp.parquet").touch()
+        ...     [fp.name for fp in resolve_source_files(Path(d), "vitals")]
+        ['chunk_0.parquet']
 
         **Nested prefixes** like ``hosp/patients`` are handled naturally as
         path components — no recursive walking happens, so a nested prefix
@@ -283,7 +295,9 @@ def resolve_source_files(dir: Path | UPath, prefix: str) -> list[Path | UPath]:
     if is_dir:
         dir_fps: list[Path | UPath] = []
         for ext in SOURCE_FILE_EXTS:
-            dir_fps.extend(sub_dir.glob(f"*{ext}"))
+            # Hidden files are never source data (e.g. in-progress writer intermediates),
+            # and pathlib globs would otherwise match them.
+            dir_fps.extend(fp for fp in sub_dir.glob(f"*{ext}") if not fp.name.startswith("."))
         if dir_fps:
             matches.append((f"sub-sharded directory '{prefix}/'", sorted(dir_fps)))
 


### PR DESCRIPTION
The trivial half of #201, per maintainer direction: hidden files are never source data. Two data-enumeration sites gain the filter — `resolve_source_files`' sub-sharded glob and `extract_code_metadata`'s event-parquet rglob (found by a full src/ glob audit) — so a crash-stranded `.{name}.strings.tmp.parquet` intermediate can never be consumed as a data chunk on resume (previously: a permanently-crashing resume naming the wrong file, or silent row duplication). Deliberately untouched, with reasons recorded: the fsspec download-manifest rglob (dotfiles in a source distribution are legitimately downloadable; inclusion is governed by the user's include/exclude), the stage-example comparison walks (filtering could mask bugs), and merge's explicitly-constructed paths.

Doctest plants a stranded intermediate beside a real chunk and asserts only the chunk resolves. 46 + 48 tests green; pre-commit clean.

The stage-start garbage collection of stale intermediates remains tracked on #201. Refs #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)