### PR TITLE
finalize_MEDS_metadata: idempotent under resume

### DIFF
--- a/src/MEDS_extract/finalize_MEDS_metadata/finalize_MEDS_metadata.py
+++ b/src/MEDS_extract/finalize_MEDS_metadata/finalize_MEDS_metadata.py
@@ -48,6 +48,11 @@ def main(cfg: DictConfig):
 
     This stage *_should almost always be the last metadata stage in an extraction pipeline._*
 
+    The stage is deterministic and cheap, so it is idempotent under resume: any pre-existing
+    output files (e.g., left behind when a prior run was killed after writing its outputs but
+    before the pipeline runner recorded the stage as complete) are removed and rewritten
+    unconditionally. Skipping a completed stage is the runner's job, not this stage's.
+
     Args:
         etl_metadata.dataset_name: The name of the dataset being extracted.
         etl_metadata.dataset_version: The version of the dataset being extracted.
@@ -69,10 +74,7 @@ def main(cfg: DictConfig):
 
     for out_fp in [output_code_metadata_fp, dataset_metadata_fp, subject_splits_fp]:
         out_fp.parent.mkdir(parents=True, exist_ok=True)
-        if out_fp.exists() and cfg.do_overwrite:
-            out_fp.unlink()
-        elif out_fp.exists() and not cfg.do_overwrite:
-            raise FileExistsError(f"Output file already exists at {out_fp.resolve()!s}")
+        out_fp.unlink(missing_ok=True)
 
     # Code metadata validation
     logger.info("Validating code metadata")

--- a/tests/test_inprocess_pipeline.py
+++ b/tests/test_inprocess_pipeline.py
@@ -3,7 +3,7 @@
 With coverage.py's subprocess patch enabled, the subprocess tests cover the main code paths.
 These tests target specific edge cases in individual stage ``main_fn``s: subject_id_expr,
 transforms, and new-style config syntax in ``convert_to_MEDS_events``; file skipping in
-``shard_events``; and output-dir validation plus overwrite handling in
+``shard_events``; and output-dir validation plus rerun/resume handling in
 ``finalize_MEDS_metadata``. Stage-level ``extract_code_metadata`` scenarios live in
 ``tests/test_extract_code_metadata.py``; single-function behavior is doctested on the
 functions themselves.
@@ -454,7 +454,7 @@ def test_split_and_shard_subjects_external_splits_file_missing(tmp_path):
         sss_stage.main_fn(cfg)
 
 
-# ── finalize_MEDS_metadata: output-dir validation and overwrite handling ──
+# ── finalize_MEDS_metadata: output-dir validation and rerun/resume handling ──
 
 
 def test_finalize_MEDS_metadata_output_dir_validation():
@@ -483,8 +483,12 @@ def test_finalize_MEDS_metadata_output_dir_validation():
             fmm_stage.main_fn(cfg)
 
 
-def test_finalize_MEDS_metadata_overwrite_error():
-    """Existing output files raise FileExistsError when do_overwrite is False."""
+def test_finalize_MEDS_metadata_rerun_over_existing_outputs():
+    """Rerunning over the stage's own prior outputs succeeds without do_overwrite.
+
+    An interrupted pipeline can leave all three outputs on disk without the runner's stage completion marker;
+    the resumed run must rewrite them rather than raise.
+    """
     from MEDS_extract.finalize_MEDS_metadata.finalize_MEDS_metadata import main as fmm_stage
 
     with tempfile.TemporaryDirectory() as d:
@@ -493,11 +497,9 @@ def test_finalize_MEDS_metadata_overwrite_error():
         metadata_in.mkdir(parents=True)
         shards_fp = root / "metadata" / ".shards.json"
         shards_fp.parent.mkdir(parents=True)
-        shards_fp.write_text(json.dumps({"train/0": [1]}))
+        shards_fp.write_text(json.dumps({"train/0": [1, 2], "held_out/0": [3]}))
 
         out_dir = root / "output" / "metadata"
-        out_dir.mkdir(parents=True)
-        (out_dir / "codes.parquet").write_bytes(b"dummy")
 
         cfg = _make_cfg(
             {
@@ -507,12 +509,27 @@ def test_finalize_MEDS_metadata_overwrite_error():
             }
         )
 
-        with pytest.raises(FileExistsError):
-            fmm_stage.main_fn(cfg)
+        fmm_stage.main_fn(cfg)
+        first_codes = (out_dir / "codes.parquet").read_bytes()
+        first_splits = (out_dir / "subject_splits.parquet").read_bytes()
+        first_meta = json.loads((out_dir / "dataset.json").read_text())
+
+        # Simulate crash resume: outputs exist, no completion marker, do_overwrite unset.
+        fmm_stage.main_fn(cfg)
+
+        assert (out_dir / "codes.parquet").read_bytes() == first_codes
+        assert (out_dir / "subject_splits.parquet").read_bytes() == first_splits
+        second_meta = json.loads((out_dir / "dataset.json").read_text())
+        first_meta.pop("created_at")
+        second_meta.pop("created_at")  # Rewritten with the rerun's timestamp.
+        assert second_meta == first_meta
+
+        splits = pl.read_parquet(out_dir / "subject_splits.parquet")
+        assert sorted(splits["subject_id"].to_list()) == [1, 2, 3]
 
 
-def test_finalize_MEDS_metadata_overwrite_succeeds():
-    """With do_overwrite=True, existing output files are deleted and rewritten."""
+def test_finalize_MEDS_metadata_replaces_preexisting_outputs():
+    """Pre-existing (even invalid) output files are unconditionally replaced with valid outputs."""
     from MEDS_extract.finalize_MEDS_metadata.finalize_MEDS_metadata import main as fmm_stage
 
     with tempfile.TemporaryDirectory() as d:
@@ -528,14 +545,14 @@ def test_finalize_MEDS_metadata_overwrite_succeeds():
         out_dir = root / "output" / "metadata"
         out_dir.mkdir(parents=True)
 
-        # Pre-create output files
+        # Pre-create output files, e.g. partial leftovers from an interrupted run.
         (out_dir / "codes.parquet").write_bytes(b"dummy")
         (out_dir / "dataset.json").write_text("{}")
         (out_dir / "subject_splits.parquet").write_bytes(b"dummy")
 
         cfg = _make_cfg(
             {
-                "do_overwrite": True,
+                "do_overwrite": False,
                 "stage_cfg": {"metadata_input_dir": str(metadata_in), "reducer_output_dir": str(out_dir)},
                 "shards_map_fp": str(shards_fp),
             }


### PR DESCRIPTION
Implements #221: the exists→raise guard is replaced with unconditional `unlink(missing_ok=True)` before each write, so a kill between the first metadata write and the runner's .done touch no longer bricks every subsequent rerun with FileExistsError. Due diligence per the issue: the old guard had no articulated intent anywhere (docstring described only output schemas; no clobber-protection rationale in src/ or docs/), so nothing needed preserving — the docstring now states the resume contract explicitly (outputs removed and rewritten unconditionally; skipping completed stages is the runner's .done gate's job, matching every other stage).

Tests: the FileExistsError-pinning test becomes a rerun-over-existing-outputs test asserting the second run succeeds with byte-identical parquets (dataset.json modulo created_at), and the overwrite test flips to do_overwrite=False proving invalid partial leftovers are replaced without any flag. 5 + 24 tests green; pre-commit clean.

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)