### PR TITLE
Download: never echo credential-bearing values in errors or logs

### DIFF
--- a/src/MEDS_extract/download/backends/http.py
+++ b/src/MEDS_extract/download/backends/http.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 from ..source import RemoteFile, Source
 
@@ -68,6 +68,35 @@ _MAX_RESUME_ATTEMPTS = 3
 # doctests pass an explicit ``retry_wait`` (e.g. ``tenacity.wait_fixed(0)``) so
 # exercising the retry paths costs no real sleep time.
 _RETRY_WAIT = wait_exponential(multiplier=1, min=1, max=30)
+
+
+def _redact_url(url: object) -> str:
+    """Return ``url`` as a string safe to echo in error messages and logs.
+
+    A URL may carry credentials in its userinfo component
+    (``https://user:pass@host/...``), and these messages land on stderr and in the
+    persisted Hydra log — so the userinfo is masked before echoing. Non-string
+    values are described by type only, never echoed.
+
+    Examples:
+        >>> _redact_url("https://example.com/data/x.csv")
+        'https://example.com/data/x.csv'
+        >>> _redact_url("https://alice:hunter2@example.com:8080/x.csv?a=1")
+        'https://***@example.com:8080/x.csv?a=1'
+        >>> _redact_url({"nested": "dict"})
+        '<non-string url of type dict>'
+        >>> _redact_url("https://[broken/")
+        '<unparsable url>'
+    """
+    if not isinstance(url, str):
+        return f"<non-string url of type {type(url).__name__}>"
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return "<unparsable url>"
+    if "@" not in parts.netloc:
+        return url
+    return urlunsplit(parts._replace(netloc="***@" + parts.netloc.rpartition("@")[2]))
 
 
 class HTTPSource(Source):
@@ -451,7 +480,9 @@ class HTTPSource(Source):
             with client.stream("GET", url, headers=headers) as r:
                 # 416 "Range Not Satisfiable" — remote file shrank or changed; restart.
                 if resume_from and r.status_code == 416:
-                    logger.warning(f"Server rejected resume for {url} with 416; restarting from byte 0.")
+                    logger.warning(
+                        f"Server rejected resume for {_redact_url(url)} with 416; restarting from byte 0."
+                    )
                     if target.exists():
                         target.unlink()
                     resume_from = 0
@@ -463,7 +494,9 @@ class HTTPSource(Source):
                         # WARNING for consistency with the 416 and Content-Range
                         # siblings — all three discard the accumulated partial and
                         # re-transfer from byte 0.
-                        logger.warning(f"Server ignored Range for {url}; restarting from byte 0.")
+                        logger.warning(
+                            f"Server ignored Range for {_redact_url(url)}; restarting from byte 0."
+                        )
                         if target.exists():
                             target.unlink()
                         resume_from = 0
@@ -472,7 +505,7 @@ class HTTPSource(Source):
                     # a server returning 206 with a shifted range silently corrupts ``target``.
                     if not HTTPSource._content_range_starts_at(r.headers.get("Content-Range"), resume_from):
                         logger.warning(
-                            f"Server returned mismatched Content-Range for {url} "
+                            f"Server returned mismatched Content-Range for {_redact_url(url)} "
                             f"(got {r.headers.get('Content-Range')!r} for "
                             f"resume_from={resume_from}); restarting from byte 0."
                         )
@@ -490,7 +523,7 @@ class HTTPSource(Source):
         # loop terminate. Surface it loudly rather than looping forever.
         raise RuntimeError(
             f"_resumable_stream exhausted {_MAX_RESUME_ATTEMPTS} restart attempts "
-            f"for {url}; range-resume loop failed to converge. This indicates a bug "
+            f"for {_redact_url(url)}; range-resume loop failed to converge. This indicates a bug "
             "in the restart logic — the expected invariant is that each restart "
             "resets resume_from to 0, which prevents any subsequent restart."
         )
@@ -559,16 +592,24 @@ class HTTPSource(Source):
             >>> r.rel_path, r.unarchive, r.cleanup_archive
             ('AUMCdb.zip', 'zip', True)
 
-            Raises on missing ``url``, unknown keys, malformed digests, or bad type:
+            Raises on missing ``url``, unknown keys, malformed digests, or bad type.
+            The dict-shaped errors echo key names only — entry values may carry
+            resolved credentials (e.g. a mis-indented ``headers:`` block) — and any
+            echoed url has its userinfo masked:
 
             >>> HTTPSource._normalize({"sha256": "ab" * 32})
             Traceback (most recent call last):
                 ...
-            ValueError: HTTPSource url entry is missing 'url': {'sha256': ...
+            ValueError: HTTPSource url entry is missing 'url'; got keys ['sha256']
             >>> HTTPSource._normalize({"url": "https://example.com/foo.csv", "sha_256": "ab" * 32})
             Traceback (most recent call last):
                 ...
             ValueError: HTTPSource url entry has unknown keys ['sha_256'] ...
+            >>> HTTPSource._normalize({"url": "https://u:pw@example.com/foo.csv", "headers": {"a": "b"}})
+            Traceback (most recent call last):
+                ...
+            ValueError: HTTPSource url entry has unknown keys ['headers'] ... for url
+                        https://***@example.com/foo.csv
             >>> HTTPSource._normalize({"url": "https://example.com/foo.csv", "sha256": "abc"})
             Traceback (most recent call last):
                 ...
@@ -581,13 +622,17 @@ class HTTPSource(Source):
         if isinstance(entry, str):
             return RemoteFile(rel_path=HTTPSource._filename_from_url(entry), source_path=entry)
         if isinstance(entry, dict):
+            # Echo key names (plus a userinfo-redacted url) only, never entry values:
+            # a mis-indented ``headers:`` block reaching here would otherwise put its
+            # resolved token on stderr and in the persisted Hydra log.
             if "url" not in entry:
-                raise ValueError(f"HTTPSource url entry is missing 'url': {entry}")
+                raise ValueError(f"HTTPSource url entry is missing 'url'; got keys {sorted(entry)}")
             unknown = sorted(set(entry) - {"url", "rel_path", "sha256", "unarchive", "cleanup_archive"})
             if unknown:
                 raise ValueError(
                     f"HTTPSource url entry has unknown keys {unknown} "
-                    f"(supported: url, rel_path, sha256, unarchive, cleanup_archive): {entry}"
+                    f"(supported: url, rel_path, sha256, unarchive, cleanup_archive) "
+                    f"for url {_redact_url(entry['url'])}"
                 )
             return RemoteFile(
                 rel_path=entry.get("rel_path") or HTTPSource._filename_from_url(entry["url"]),

--- a/src/MEDS_extract/download/spec.py
+++ b/src/MEDS_extract/download/spec.py
@@ -68,12 +68,14 @@ def source_from_config(cfg: dict) -> Source:
             ...
         ValueError: Unknown source type 's3'. Supported: ['fsspec', 'http', 'physionet'].
 
-        Missing ``type:`` is flagged the same way:
+        Missing ``type:`` is flagged the same way. Only the key names are echoed —
+        by the time an entry reaches this function its ``${oc.env:...}`` interpolations
+        are resolved, so echoing values could put live credentials in logs:
 
-        >>> source_from_config({"urls": ["https://example.com/x.csv"]})
+        >>> source_from_config({"urls": ["https://example.com/x.csv"], "password": "hunter2"})
         Traceback (most recent call last):
             ...
-        ValueError: Source config is missing a 'type:' key. Got: {'urls': ['https://example.com/x.csv']}
+        ValueError: Source config is missing a 'type:' key. Got keys: ['password', 'urls']
 
         Backend-specific kwargs pass through verbatim — e.g. ``HTTPSource``'s ``headers:``
         for API-key auth (DataVerse ``X-Dataverse-key``, bearer tokens, ``Accept:``):
@@ -97,7 +99,9 @@ def source_from_config(cfg: dict) -> Source:
     cfg = dict(cfg)
     source_type = cfg.pop("type", None)
     if source_type is None:
-        raise ValueError(f"Source config is missing a 'type:' key. Got: {cfg}")
+        # Echo key names only: values may hold resolved credentials, and this message
+        # lands on stderr and in the persisted Hydra log.
+        raise ValueError(f"Source config is missing a 'type:' key. Got keys: {sorted(cfg)}")
     if source_type not in _SOURCE_TYPES:
         raise ValueError(f"Unknown source type {source_type!r}. Supported: {sorted(_SOURCE_TYPES)}.")
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -32,7 +32,7 @@ from tenacity import wait_fixed
 if TYPE_CHECKING:
     from pathlib import Path
 
-from MEDS_extract.download import ChecksumError, HTTPSource, PhysioNetSource
+from MEDS_extract.download import ChecksumError, HTTPSource, PhysioNetSource, source_from_config
 
 # ``_resumable_stream`` lives on HTTPSource as a staticmethod — alias it for brevity.
 _resumable_stream = HTTPSource._resumable_stream
@@ -983,3 +983,60 @@ def test_physionet_auto_unarchive_mixed_manifest(tmp_path: Path):
     assert (tmp_path / "waveforms" / "w1.csv").read_text() == "t,v\n0,1\n"
     assert not (tmp_path / "bundle.zip").exists()  # AUTO's cleanup default drops the archive
     assert (tmp_path / "data" / "patients.csv.gz").read_bytes() == gz_body  # untouched
+
+
+# By the time a source entry reaches ``source_from_config`` / ``HTTPSource._normalize``,
+# its ``${oc.env:...}`` interpolations are resolved literals, and the CLI logs these
+# error messages to stderr and the persisted Hydra log inside the shared output tree.
+# So the messages must echo key names (and userinfo-redacted urls) only — never values.
+
+
+def test_missing_type_error_echoes_key_names_not_credentials():
+    """A credentialed entry that omits ``type:`` must not leak its values into the error."""
+    sentinel = "XSECRETPASSX"
+    entry = {"base_url": "http://127.0.0.1:9/pn", "username": "XSECRETUSERX", "password": sentinel}
+
+    with pytest.raises(ValueError, match="missing a 'type:' key") as exc_info:
+        source_from_config(entry)
+
+    msg = str(exc_info.value)
+    assert sentinel not in msg
+    assert "XSECRETUSERX" not in msg
+    for key in ("base_url", "username", "password"):
+        assert key in msg
+
+
+def test_normalize_errors_echo_key_names_not_credentials():
+    """A mis-indented ``headers:`` block nested under a url entry must not leak its token."""
+    sentinel = "XSECRETTOKENX"
+    headers = {"Authorization": f"Bearer {sentinel}"}
+
+    # Unknown-keys path: ``headers:`` is a legal sibling of ``urls:`` on the source, so a
+    # one-level indentation slip lands it inside the last url entry.
+    entry = {"url": "http://127.0.0.1:9/hs/extra.csv", "headers": headers}
+    with pytest.raises(ValueError, match="unknown keys") as exc_info:
+        HTTPSource._normalize(entry)
+    msg = str(exc_info.value)
+    assert sentinel not in msg
+    assert "headers" in msg
+    assert entry["url"] in msg  # credential-free url is echoed to identify the entry
+
+    # Missing-url path: same slip when the mis-indented block displaces the url entirely.
+    with pytest.raises(ValueError, match="missing 'url'") as exc_info:
+        HTTPSource._normalize({"headers": headers})
+    msg = str(exc_info.value)
+    assert sentinel not in msg
+    assert "headers" in msg
+
+
+def test_normalize_unknown_keys_error_redacts_url_userinfo():
+    """A url carrying userinfo credentials is masked before being echoed."""
+    entry = {"url": "https://alice:XSECRETPWX@example.com/x.csv", "headers": {"a": "b"}}
+
+    with pytest.raises(ValueError, match="unknown keys") as exc_info:
+        HTTPSource._normalize(entry)
+
+    msg = str(exc_info.value)
+    assert "XSECRETPWX" not in msg
+    assert "alice" not in msg
+    assert "https://***@example.com/x.csv" in msg


### PR DESCRIPTION
Implements #214 and completes it with a sweep. The two reported sites (spec.py missing-`type:`, http.py `_normalize` missing-url/unknown-keys) now echo key names only — a one-token config mistake can no longer print resolved PhysioNet passwords or bearer tokens to stderr and the persisted Hydra log. The sweep confirmed no other whole-dict interpolations exist in download/, but found four `_resumable_stream` messages echoing the raw request URL — whose userinfo can carry credentials (`https://user:pass@host/…`; httpx honors it as basic auth) — all four now route through a new `_redact_url` helper (userinfo → `***@`, host/path/query preserved, robust to non-string and unparsable values, doctested). The scalar-echo TypeError stays per the issue.

Regression tests plant credential sentinels in a typeless entry, a mis-indented `headers:` block, and url userinfo, asserting each is absent from the raised message while key names and the redacted url are present. 61 tests green; pre-commit clean.

Closes #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)