### PR TITLE
Model _right-suffixed join outputs in the source-column planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,48 @@ The pipeline logs a warning whenever `min`/`max` aggregates a String column; mak
 the column's text ordering matches its temporal ordering, or use a typed (parquet)
 source. `sum`/`mean` on a String column are rejected outright.
 
+#### Self-joins and colliding column names
+
+An aggregated join may target the *same* table — the natural way to derive per-subject
+facts from a table's own earliest/latest row ("this subject's minimum `age`"). The
+pulled column then necessarily shares a name with a column the table already has, and
+the joined copy arrives with a `_right` suffix: `$age` keeps meaning the row's own
+value, and `$age_right` is the per-subject aggregate. (The same renaming applies to any
+join output whose name collides with a column on the left table.)
+
+```python
+>>> with yaml_disk('''
+... ops.parquet:
+...   subject_id: [1, 1, 2]
+...   age: [41, 40, 30]
+... ''') as raw_dir:
+...     tc = TableConfig.parse("ops", {
+...         "_defaults": {"subject_id": "$subject_id"},
+...         "_table": {
+...             "cols": {"is_first": "$age == $age_right"},
+...             "join": {"ops": {"key": "subject_id", "cols": {"age": "min"}}},
+...         },
+...         "birth": {"code": "MEDS_BIRTH", "time": None, "numeric_value": "$age_right"},
+...     })
+...     df = tc.prepare(tc.scan(raw_dir)).collect()  # scan applies the self-join
+>>> df.sort("subject_id", "age").select("subject_id", "age", "age_right", "is_first")
+shape: (3, 4)
+┌────────────┬─────┬───────────┬──────────┐
+│ subject_id ┆ age ┆ age_right ┆ is_first │
+│ ---        ┆ --- ┆ ---       ┆ ---      │
+│ i64        ┆ i64 ┆ i64       ┆ bool     │
+╞════════════╪═════╪═══════════╪══════════╡
+│ 1          ┆ 40  ┆ 40        ┆ true     │
+│ 1          ┆ 41  ┆ 40        ┆ false    │
+│ 2          ┆ 30  ┆ 30        ┆ true     │
+└────────────┴─────┴───────────┴──────────┘
+
+```
+
+The `birth` event's `numeric_value: $age_right` reads the aggregate, and the derived
+`is_first` column freely mixes the row's own `age` with it — the usual guard for
+"emit this static fact from the first row only", since MESSY has no row filter.
+
 ### Metadata linking, in depth
 
 Datasets usually ship dictionary tables alongside the event data — `d_items.csv`,

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 import random
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass, field
 from functools import cached_property
 from importlib.metadata import entry_points
@@ -391,6 +391,17 @@ class JoinConfig:
       matching stays coherent; for ``sum``/``mean``/``count`` it is synthetic
       and will match nothing in a raw-valued metadata table.
 
+    Collision suffixing: a pulled column keeps its bare name unless the left
+    frame already has a column of that name at join time, in which case
+    ``pl.LazyFrame.join`` delivers it with :attr:`SUFFIX` appended (``age`` →
+    ``age_right``). This is how a *self*-join expresses "this subject's
+    min/max of a column the table already has": the bare name keeps meaning
+    the row's own value, and ``$<col>_right`` means the aggregate. Because
+    config expressions reference the suffixed name, the suffix is part of the
+    MESSY contract — :meth:`apply` pins it explicitly rather than relying on
+    polars' default, and :meth:`delivered_cols` derives planner-visible names
+    from the same constant.
+
     Examples:
         Plain-list ``cols`` — no aggregation. Fields are shown individually
         rather than via the default repr, which would otherwise push the
@@ -481,6 +492,13 @@ class JoinConfig:
     right_on: str
     cols: tuple[str, ...]
     aggregations: tuple[tuple[str, str], ...] = ()
+
+    #: Suffix under which a pulled column lands when its name collides with a column
+    #: already on the left frame. Config expressions reference colliding outputs as
+    #: ``$<col>_right``, so this is contract, not a polars implementation detail — it
+    #: is the single source for both the runtime join (:meth:`apply`) and the
+    #: planner-visible names (:meth:`delivered_cols`), so the two cannot drift.
+    SUFFIX: ClassVar[str] = "_right"
 
     def __post_init__(self):
         if not self.cols:
@@ -592,6 +610,22 @@ class JoinConfig:
             )
         return tuple(cols_raw), ()
 
+    def delivered_cols(self, left_columns: Collection[str]) -> set[str]:
+        """Names under which ``cols`` land on the joined frame, given the left frame's columns.
+
+        A pulled column keeps its bare name unless ``left_columns`` already contains
+        it, in which case :meth:`apply`'s join delivers it with :attr:`SUFFIX`
+        appended.
+
+        Examples:
+            >>> jc = JoinConfig.parse({"stays": {"key": "sid", "cols": ["age", "ward"]}})
+            >>> sorted(jc.delivered_cols({"sid"}))
+            ['age', 'ward']
+            >>> sorted(jc.delivered_cols({"sid", "age"}))
+            ['age_right', 'ward']
+        """
+        return {f"{c}{self.SUFFIX}" if c in left_columns else c for c in self.cols}
+
     def apply(self, left: pl.LazyFrame, input_dir: Path | UPath) -> pl.LazyFrame:
         """Scan join-target files under ``input_dir`` and left-join them to ``left``.
 
@@ -628,6 +662,30 @@ class JoinConfig:
             │ 2          ┆ null       │
             │ 3          ┆ null       │
             └────────────┴────────────┘
+
+            When a pulled column's name already exists on the left frame — here a
+            *self*-join deriving each subject's minimum ``age`` from the very table
+            being joined onto — the joined copy arrives with :attr:`SUFFIX`
+            appended, leaving the row's own ``age`` untouched:
+
+            >>> with yaml_disk('''
+            ... ops.parquet:
+            ...   subject_id: [1, 1, 2]
+            ...   age: [41, 40, 30]
+            ... ''') as d:
+            ...     jc = JoinConfig.parse({"ops": {"key": "subject_id", "cols": {"age": "min"}}})
+            ...     ops = pl.scan_parquet(Path(d) / "ops.parquet")
+            ...     jc.apply(ops, Path(d)).sort("subject_id", "age").collect()
+            shape: (3, 3)
+            ┌────────────┬─────┬───────────┐
+            │ subject_id ┆ age ┆ age_right │
+            │ ---        ┆ --- ┆ ---       │
+            │ i64        ┆ i64 ┆ i64       │
+            ╞════════════╪═════╪═══════════╡
+            │ 1          ┆ 40  ┆ 40        │
+            │ 1          ┆ 41  ┆ 40        │
+            │ 2          ┆ 30  ┆ 30        │
+            └────────────┴─────┴───────────┘
         """
         right = scan_source(resolve_source_files(input_dir, self.input_prefix))
         if self.aggregations:
@@ -637,8 +695,16 @@ class JoinConfig:
         # no-op there), but the streaming engine — which convert_to_subject_sharded's
         # sink-based write runs on — reorders nondeterministically without it, and merge's
         # stable sort propagates that order into the final MEDS bytes for same-time events.
+        # ``suffix`` is pinned to :attr:`SUFFIX` rather than left to polars' default:
+        # config expressions reference colliding outputs by the suffixed name, so a
+        # polars default change must not be able to rename config-visible columns.
         return left.join(
-            right, left_on=self.left_on, right_on=self.right_on, how="left", maintain_order="left_right"
+            right,
+            left_on=self.left_on,
+            right_on=self.right_on,
+            how="left",
+            maintain_order="left_right",
+            suffix=self.SUFFIX,
         )
 
     def _aggregate(self, right: pl.LazyFrame) -> pl.LazyFrame:
@@ -1443,15 +1509,35 @@ class TableConfig:
 
     @property
     def joined_columns(self) -> set[str]:
-        """Column names that come from the joined table, not the source file."""
-        return set(self.join.cols) if self.join is not None else set()
+        """Column names the join delivers onto the frame, as they actually arrive.
+
+        A join output keeps its bare name unless the left frame already holds a
+        column of that name at join time, in which case it arrives with
+        :attr:`JoinConfig.SUFFIX` appended (see :meth:`JoinConfig.delivered_cols`).
+        The join runs against the raw source scan — before :meth:`prepare` adds
+        ``_table.cols`` outputs — so only planned raw columns can collide, and only
+        two things force a join output's name into that plan: the join's own left
+        key, and — in a *self*-join — the right side's input columns (group key plus
+        pulled/aggregated columns), which are read from this very table's file.
+        """
+        if self.join is None:
+            return set()
+        left_at_join = {self.join.left_on}
+        if self.join.input_prefix == self.input_prefix:
+            left_at_join |= {self.join.right_on, *self.join.cols}
+        return self.join.delivered_cols(left_at_join)
 
     def source_columns(self) -> set[str]:
         """Columns that must be read from this table's source parquet file.
 
         Aggregates the subject_id source columns, the join left key, derived-column
         inputs, and all event-referenced columns — minus columns produced by
-        ``_table.cols`` (derived) or pulled in by the join (come from elsewhere).
+        ``_table.cols`` (derived) or delivered by the join (come from elsewhere).
+        Join outputs are excluded under the names they actually arrive with (see
+        :attr:`joined_columns`): bare for a non-colliding output, suffixed where the
+        output collides with a left-frame column. In the colliding (self-join) case
+        the bare name keeps meaning the row's own raw column, so it stays planned
+        here when referenced.
 
         Examples:
             >>> tc = TableConfig.parse("labs", {
@@ -1464,6 +1550,21 @@ class TableConfig:
             ... })
             >>> sorted(tc.source_columns())
             ['anchor_age', 'anchor_year', 'patient_id', 'stay_id', 'test']
+
+            A *self*-join pulling an aggregate of a column the table already has:
+            the joined copy arrives as ``age_right``, so the bare ``age`` stays a
+            raw source column and the suffixed name is excluded:
+
+            >>> tc = TableConfig.parse("ops", {
+            ...     "_defaults": {"subject_id": "$subject_id"},
+            ...     "_table": {
+            ...         "cols": {"is_first": "$age == $age_right"},
+            ...         "join": {"ops": {"key": "subject_id", "cols": {"age": "min"}}},
+            ...     },
+            ...     "birth": {"code": "MEDS_BIRTH", "time": None, "numeric_value": "$age_right"},
+            ... })
+            >>> sorted(tc.source_columns())
+            ['age', 'subject_id']
         """
         cols: set[str] = set()
         if self.subject_id_node is not None:
@@ -2657,6 +2758,25 @@ class MessyConfig:
             ... })
             >>> cfg.needed_source_columns()
             {'hosp/patients': ['subject_id'], 'hosp/admissions': ['deathtime', 'subject_id']}
+
+            When a join output *collides* with a column the left frame already has
+            — the aggregated self-join that derives per-subject aggregates of an
+            existing column — the joined copy arrives suffixed (``age_right``
+            below), so only the real raw columns are attributed to the source
+            file; the suffixed name never appears in the plan:
+
+            >>> cfg = MessyConfig.parse({
+            ...     "ops": {
+            ...         "_defaults": {"subject_id": "$subject_id"},
+            ...         "_table": {
+            ...             "cols": {"is_first": "$age == $age_right"},
+            ...             "join": {"ops": {"key": "subject_id", "cols": {"age": "min"}}},
+            ...         },
+            ...         "birth": {"code": "MEDS_BIRTH", "time": None, "numeric_value": "$age_right"},
+            ...     },
+            ... })
+            >>> cfg.needed_source_columns()
+            {'ops': ['age', 'subject_id']}
 
             Transform *outputs* are computed at read time, not read from disk, so they are
             excluded from the plan while their input columns are included.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -396,6 +396,53 @@ def test_aggregated_join_apply_numeric_aggregations(tmp_path, agg, expected):
     assert out["v"].to_list() == expected
 
 
+# ── Join-collision planning: delivered names vs. raw source columns ───────────────────────────────
+
+
+def test_non_colliding_join_plan_unchanged():
+    """A join whose outputs don't collide keeps its bare names and the historical plan."""
+    cfg = MessyConfig.parse(
+        {
+            "labs": {
+                "_defaults": {"subject_id": "$patient_id"},
+                "_table": {"join": {"stays": {"key": "stay_id", "cols": ["dischtime"]}}},
+                "lab": {"code": "$test", "time": "$dischtime"},
+            },
+        }
+    )
+    assert cfg.event_tables[0].joined_columns == {"dischtime"}
+    assert cfg.needed_source_columns() == {
+        "labs": ["patient_id", "stay_id", "test"],
+        "stays": ["dischtime", "stay_id"],
+    }
+
+
+def test_join_output_colliding_with_left_key_plans_suffixed(tmp_path):
+    """A pulled column named like the left join key collides and is planned suffixed.
+
+    With ``left_on != right_on``, the right side's ``stay_id`` is a payload column, so
+    polars delivers it as ``stay_id_right``; the planner must expect that name rather
+    than attributing a phantom ``stay_id_right`` to the raw left table.
+    """
+    tc = TableConfig.parse(
+        "labs",
+        {
+            "_defaults": {"subject_id": "$sid"},
+            "_table": {"join": {"stays": {"left_on": "stay_id", "right_on": "id", "cols": ["stay_id"]}}},
+            "lab": {"code": "$test", "time": None, "text_value": "$stay_id_right"},
+        },
+    )
+    assert tc.joined_columns == {"stay_id_right"}
+    assert sorted(tc.source_columns()) == ["sid", "stay_id", "test"]
+
+    # Runtime agrees: the joined frame carries the suffixed name, next to the left key.
+    pl.DataFrame({"id": [10, 20], "stay_id": [100, 200]}).write_parquet(tmp_path / "stays.parquet")
+    left = pl.LazyFrame({"stay_id": [10, 20], "sid": [1, 2], "test": ["a", "b"]})
+    out = tc.join.apply(left, tmp_path).collect()
+    assert set(out.columns) == {"stay_id", "sid", "test", "stay_id_right"}
+    assert out.sort("sid")["stay_id_right"].to_list() == [100, 200]
+
+
 # ── Config-error paths: exact messages for common misconfiguration shapes ─────────────────────────
 
 

--- a/tests/test_inprocess_pipeline.py
+++ b/tests/test_inprocess_pipeline.py
@@ -11,6 +11,7 @@ functions themselves.
 
 import json
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 import polars as pl
@@ -377,6 +378,161 @@ def test_convert_to_parquet_projects_wide_parquet_sources(tmp_path):
     out_fp = root / "output" / "data" / "labs.parquet"
     assert out_fp.stat().st_ino != src.stat().st_ino, "a wide parquet source must be rewritten"
     assert pl.read_parquet(out_fp).columns == ["subject_id", "test_name"]
+
+
+# ── aggregated self-join: suffixed collision columns through the full ingestion chain ──
+
+
+def test_self_join_collision_end_to_end(tmp_path):
+    """The aggregated self-join pattern runs through the real ingestion stages.
+
+    A table pulling ``min(age)`` / ``min(admission_time)`` from *itself* collides with
+    its own columns, so the joined copies arrive ``_right``-suffixed. The planner must
+    attribute only the real raw columns to the source file (``convert_to_parquet``
+    projects on that plan — this is exactly where the unfixed planner rejected the run
+    with "missing requested column(s) ['admission_time_right', 'age_right']"), and the
+    suffixed columns must then flow through subject-sharding into event extraction.
+    """
+    from MEDS_extract.convert_to_MEDS_events.convert_to_MEDS_events import main as events_stage
+    from MEDS_extract.convert_to_parquet.convert_to_parquet import main as convert_stage
+    from MEDS_extract.convert_to_subject_sharded.convert_to_subject_sharded import main as shard_stage
+    from MEDS_extract.split_and_shard_subjects.split_and_shard_subjects import main as sss_stage
+
+    event_cfg = """\
+ops:
+  _defaults:
+    subject_id: $subject_id
+  _table:
+    cols:
+      age_gap: $age - $age_right
+    join:
+      ops:
+        key: subject_id
+        cols:
+          age: min
+          admission_time: min
+  birth:
+    code: MEDS_BIRTH
+    time: null
+    numeric_value: $age_right
+  first_admit:
+    code: FIRST_ADMIT
+    time: '$admission_time_right::"%Y-%m-%d"'
+  gap:
+    code: AGE_GAP
+    time: null
+    numeric_value: $age_gap
+"""
+
+    root = tmp_path
+    raw_dir = root / "raw"
+    raw_dir.mkdir()
+    pl.DataFrame(
+        {
+            "subject_id": [1, 1, 2],
+            "age": [41, 40, 30],
+            "admission_time": ["2020-02-01", "2020-01-01", "2021-05-05"],
+            "ignored": ["x", "y", "z"],
+        }
+    ).write_parquet(raw_dir / "ops.parquet")
+
+    messy_fp = root / "messy.yaml"
+    messy_fp.write_text(event_cfg)
+    shards_fp = root / "metadata" / ".shards.json"
+
+    parquet_dir = root / "parquet" / "data"
+    subsharded_dir = root / "subsharded"
+    events_dir = root / "events"
+
+    convert_stage.main_fn(
+        _make_cfg(
+            {
+                "stage": "convert_to_parquet",
+                "input_dir": str(raw_dir),
+                "stage_cfg": {
+                    "data_input_dir": str(raw_dir / "data"),
+                    "output_dir": str(parquet_dir),
+                },
+                "MESSY_config_fp": str(messy_fp),
+            }
+        )
+    )
+
+    # The projection follows the corrected plan: the suffixed join outputs are never
+    # attributed to the raw file, while the raw ``age``/``admission_time`` — needed on
+    # both sides of the self-join — are kept and the unread column is pruned.
+    out_fp = parquet_dir / "ops.parquet"
+    assert sorted(pl.read_parquet(out_fp).columns) == ["admission_time", "age", "subject_id"]
+
+    sss_stage.main_fn(
+        _make_cfg(
+            {
+                "stage_cfg": {
+                    "data_input_dir": str(parquet_dir),
+                    "external_splits_json_fp": None,
+                    "split_fracs": {"train": 1.0},
+                    "n_subjects_per_shard": 10,
+                },
+                "MESSY_config_fp": str(messy_fp),
+                "shards_map_fp": str(shards_fp),
+            }
+        )
+    )
+    assert json.loads(shards_fp.read_text()) == {"train/0": [1, 2]}
+
+    shard_stage.main_fn(
+        _make_cfg(
+            {
+                "stage_cfg": {
+                    "data_input_dir": str(parquet_dir),
+                    "output_dir": str(subsharded_dir),
+                },
+                "MESSY_config_fp": str(messy_fp),
+                "shards_map_fp": str(shards_fp),
+            }
+        )
+    )
+
+    # The subject-sharded output carries the joined aggregates under their suffixed names.
+    sharded = pl.read_parquet(subsharded_dir / "train" / "0" / "ops.parquet")
+    assert set(sharded.columns) == {
+        "subject_id",
+        "age",
+        "admission_time",
+        "age_right",
+        "admission_time_right",
+    }
+
+    events_stage.main_fn(
+        _make_cfg(
+            {
+                "stage_cfg": {
+                    "data_input_dir": str(subsharded_dir),
+                    "output_dir": str(events_dir),
+                    "do_dedup_text_and_numeric": False,
+                },
+                "MESSY_config_fp": str(messy_fp),
+                "shards_map_fp": str(shards_fp),
+            }
+        )
+    )
+
+    events = pl.read_parquet(events_dir / "train" / "0" / "ops.parquet")
+
+    # The per-subject minimum age arrives through ``$age_right``.
+    births = events.filter(pl.col("code") == "MEDS_BIRTH")
+    assert set(zip(births["subject_id"], births["numeric_value"], strict=True)) == {(1, 40.0), (2, 30.0)}
+
+    # A time drawn from the aggregated ``$admission_time_right``.
+    first_admits = events.filter(pl.col("code") == "FIRST_ADMIT")
+    assert set(zip(first_admits["subject_id"], first_admits["time"], strict=True)) == {
+        (1, datetime(2020, 1, 1)),
+        (2, datetime(2021, 5, 5)),
+    }
+
+    # A derived column mixing the bare left column and the suffixed join output.
+    gaps = events.filter(pl.col("code") == "AGE_GAP")
+    assert set(zip(gaps["subject_id"], gaps["numeric_value"], strict=True)) == {(1, 0.0), (1, 1.0), (2, 0.0)}
 
 
 # ── split_and_shard_subjects: external splits JSON wiring ──


### PR DESCRIPTION
Implements #266, unblocking the aggregated self-join pattern (INSPIRE's earliest-row-derived static facts). `JoinConfig` gains a single source of truth for the suffix (`SUFFIX = "_right"`, passed explicitly to the join so planner and runtime cannot drift) and a `delivered_cols()` deriving the names outputs actually arrive under. The collision rule was traced precisely: the join applies to the raw scan before `_table.cols` outputs exist, so exactly two things force suffixing — the join's own left key, and (in a self-join) the right side's input columns scanned from the same file. Colliding outputs are excluded from the raw plan under their suffixed names while their bare names stay planned when referenced; non-colliding joins keep the historical plan verbatim (pinned by regression).

The issue's repro now plans `{'ops': ['age', 'subject_id']}` (verified failing before), and an end-to-end test drives the full INSPIRE shape — self-join pulling min(age)/min(admission_time), a derived column mixing `$age` with `$age_right`, `MEDS_BIRTH` from `$age_right`, event time from `$admission_time_right` — through all four real stages with value assertions. README gains a documented self-join subsection with an executable doctest, since `_right` is now contract. 81 targeted + 258 full-suite tests green; pre-commit clean.

One pre-existing latent hazard found during the trace (cross-table projection widening inducing an unmodeled collision) is filed separately rather than scope-crept.

Closes #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)