### PR TITLE
extract_code_metadata: fail loudly on component-less events; order-independent ingestion

### DIFF
--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -4,7 +4,7 @@ import copy
 import logging
 import random
 import time
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
@@ -102,12 +102,14 @@ def normalize_join_key(expr: pl.Expr, dtype: pl.DataType) -> pl.Expr:
 
 
 def validate_event_data_schema(data_schema: pl.Schema) -> bool:
-    """Validate extracted-event input schema for metadata extraction; return whether components exist.
+    """Validate one extracted-event file's schema; return whether that file carries components.
 
     ``code_components`` is only attached by ``EventConfig.extract`` when a code expression
-    references at least one source column — a dataset whose codes are all literals
+    references at least one source column — a file whose codes are all literals
     legitimately has no components (and therefore nothing to join metadata onto), so its
-    absence is allowed and reported as ``False``.
+    absence is allowed and reported as ``False``. This check is applied per event file
+    (see :func:`union_component_fields`): one file's components must never mask another
+    file's malformed pairing.
 
     When components ARE present, ``source_block`` must be too: ``EventConfig.extract``
     stamps both on every row together, so an input carrying one without the other is
@@ -142,6 +144,62 @@ def validate_event_data_schema(data_schema: pl.Schema) -> bool:
             "extracting code metadata."
         )
     return True
+
+
+def union_component_fields(data_schemas: Iterable[pl.Schema]) -> set[str]:
+    """Union the ``code_components`` struct fields across per-file extracted-event schemas.
+
+    Every metadata join in the reducer runs against component columns, so the set of
+    component columns the stage may join on is decided here — as the UNION over every
+    event file's ``code_components`` struct fields. Files are validated individually
+    through :func:`validate_event_data_schema`, so the decision cannot depend on which
+    file a directory enumeration yields first, and a malformed file (components without
+    ``source_block``) raises even when other files are well-formed. An empty set means no
+    file carries components.
+
+    Examples:
+        Struct fields union across heterogeneous files; all-literal files (no
+        ``code_components`` column) contribute nothing:
+
+        >>> sorted(union_component_fields([
+        ...     pl.Schema({
+        ...         "code": pl.String,
+        ...         "code_components": pl.Struct({"itemid": pl.Int64}),
+        ...         "source_block": pl.String,
+        ...     }),
+        ...     pl.Schema({
+        ...         "code": pl.String,
+        ...         "code_components": pl.Struct({"icd_code": pl.String, "icd_version": pl.String}),
+        ...         "source_block": pl.String,
+        ...     }),
+        ...     pl.Schema({"code": pl.String, "source_block": pl.String}),
+        ... ]))
+        ['icd_code', 'icd_version', 'itemid']
+
+        No file carrying components yields the empty set:
+
+        >>> union_component_fields([pl.Schema({"code": pl.String})])
+        set()
+
+        A malformed file raises even when a sibling file is well-formed:
+
+        >>> union_component_fields([
+        ...     pl.Schema({
+        ...         "code": pl.String,
+        ...         "code_components": pl.Struct({"itemid": pl.Int64}),
+        ...         "source_block": pl.String,
+        ...     }),
+        ...     pl.Schema({"code": pl.String, "code_components": pl.Struct({"itemid": pl.Int64})}),
+        ... ])
+        Traceback (most recent call last):
+            ...
+        ValueError: Extracted event data carries 'code_components' but no 'source_block' column. ...
+    """
+    fields: set[str] = set()
+    for schema in data_schemas:
+        if validate_event_data_schema(schema):
+            fields.update(f.name for f in schema["code_components"].fields)
+    return fields
 
 
 def build_code_component_map(all_data: pl.LazyFrame) -> pl.DataFrame:
@@ -611,6 +669,12 @@ def main(cfg: DictConfig):
     When no ``_metadata`` blocks are configured at all, the stage still writes the full
     observed code vocabulary (a codes-only table).
 
+    When ``_metadata`` blocks ARE configured, the stage's data input must be the
+    component-bearing ``convert_to_MEDS_events`` output: every block's join keys must
+    name component columns some event file carries, and an input with no
+    ``code_components`` anywhere (e.g. merged data — ``merge_to_MEDS_cohort`` drops that
+    column) is an error, never a silent codes-only degrade.
+
     Note that there are two sentinel columns in the output metadata that have certain mandates for MEDS
     compliance: The `description` column and the `parent_codes` column. The `description` column must be a
     string, and if there are multiple matches in the extracted metadata for a code, in this script they will
@@ -660,16 +724,35 @@ def main(cfg: DictConfig):
     random.shuffle(event_metadata_configs)
 
     # Load the extracted event data, handling heterogeneous schemas (files whose codes
-    # reference source columns carry code_components; all-literal files don't).
-    event_parquet_files = list(Path(stage_input_dir).rglob("*.parquet"))
+    # reference source columns carry code_components; all-literal files don't). The file
+    # list is sorted so ingestion order never depends on directory enumeration order.
+    event_parquet_files = sorted(Path(stage_input_dir).rglob("*.parquet"))
     all_event_dfs = [pl.scan_parquet(fp, glob=False) for fp in event_parquet_files]
     all_data = pl.concat(all_event_dfs, how="diagonal_relaxed")
 
     # Schema validation runs in EVERY worker (it's a cheap metadata-only check) so a
     # malformed events layout fails loudly everywhere — but the component map itself is
     # only materialized by the reducer (worker 0) below: it is a full-dataset
-    # scan/unique/collect that the N-1 map-only workers never use.
-    has_code_components = validate_event_data_schema(all_data.collect_schema())
+    # scan/unique/collect that the N-1 map-only workers never use. The joinable component
+    # columns are the union across per-file schemas, so the decision cannot depend on
+    # which file an enumeration yields first.
+    component_fields = union_component_fields(df.collect_schema() for df in all_event_dfs)
+
+    # A `_metadata` block always attaches to a component-bearing code (a literal code
+    # with a `_metadata` block is rejected at config compile), so configured blocks over
+    # an input with no components ANYWHERE can never be a valid convert_to_MEDS_events
+    # output. Degrading to a codes-only table here would silently discard every extracted
+    # metadata column, so this is an error, not a warning.
+    if events_and_metadata_by_metadata_fp and not component_fields:
+        raise ValueError(
+            "The MESSY config declares _metadata blocks, but no extracted-event file under "
+            f"{stage_input_dir} carries a 'code_components' column, so no metadata could ever "
+            "be joined onto the codes. A _metadata block always attaches to a component-bearing "
+            "code, so a convert_to_MEDS_events output cannot lack components entirely — this "
+            "input is most likely merged data (merge_to_MEDS_cohort drops 'code_components'). "
+            "Run extract_code_metadata on the convert_to_MEDS_events output: order it before "
+            "merge_to_MEDS_cohort in the pipeline's stages list."
+        )
 
     all_out_fps = []
     # Deterministic reduction order: partial files are produced in each worker's
@@ -718,6 +801,22 @@ def main(cfg: DictConfig):
             compiled = _compile_metadata_entry(event_cfg)
             match_cols = list(compiled.key_cols)
 
+            # Every join key must name a component column some event file carries, or the
+            # block could never attach and its extracted metadata would be discarded
+            # wholesale. Checked here — before rwlock_wrap, in every worker — so
+            # config-vs-data drift fails fast rather than surfacing as a reducer-side
+            # degrade after the map compute.
+            missing = [c for c in match_cols if c not in component_fields]
+            if missing:
+                raise ValueError(
+                    f"_metadata block for code {compiled.code_template!r} (source block "
+                    f"{source_block!r}) joins on component column(s) {missing} that no "
+                    f"extracted-event file carries. Available component columns: "
+                    f"{sorted(component_fields)}. The extracted events do not match this "
+                    "configuration; re-run the extraction pipeline before extracting code "
+                    "metadata."
+                )
+
             rwlock_wrap(
                 metadata_fps,
                 out_fp,
@@ -744,10 +843,11 @@ def main(cfg: DictConfig):
     # Build the code_components map every metadata join runs against: full code (under
     # the reserved collision-proof alias), unnested component columns, and the declaring
     # source_block so each join attaches only to its own event's codes. Reducer-only:
-    # this is the one full-dataset collect in the stage. Also skipped when there are no
+    # this is the one full-dataset collect in the stage. Skipped when there are no
     # partial metadata files (no ``_metadata`` blocks configured) — nothing would join
-    # against it, and the reducer then only writes the observed code vocabulary.
-    code_component_map = build_code_component_map(all_data) if all_out_fps and has_code_components else None
+    # against it, and the reducer then only writes the observed code vocabulary. With
+    # blocks configured, components are guaranteed present (validated above).
+    code_component_map = build_code_component_map(all_data) if all_out_fps else None
 
     wait_for_complete_parquets(all_out_fps, polling_time=cfg.polling_time)
 
@@ -763,29 +863,13 @@ def main(cfg: DictConfig):
     # already-written partial files — the mappers' per-worker random.shuffle above is
     # untouched, so map-phase lock contention and runtime spreading are unaffected.
     expanded_dfs = []
-    if code_component_map is None:
-        # Warn only when partial metadata files exist but could not be joined; with no
-        # ``_metadata`` blocks configured there is nothing missing and nothing to warn about.
-        if all_out_fps:
-            logger.warning(
-                "Extracted metadata found but the event data carries no code_components; "
-                "there is nothing to join metadata onto. Writing a codes-only metadata table."
-            )
-    else:
+    if code_component_map is not None:
         component_schema = code_component_map.schema
         for fp in sorted(all_out_fps, key=out_fp_keys.__getitem__):
             pdf = pl.scan_parquet(fp, glob=False)
             match_cols, source_block = join_info[fp]
             pdf_schema = pdf.collect_schema()
             metadata_cols = [c for c in pdf_schema.names() if c not in match_cols]
-
-            missing = [c for c in match_cols if c not in component_schema]
-            if missing:
-                logger.warning(
-                    f"Metadata from {fp} (source block {source_block!r}) requires component "
-                    f"columns {missing} that are absent from the extracted data. Skipping."
-                )
-                continue
 
             # Scope the join to the event config that declared this _metadata block —
             # other events may reference same-named component columns with colliding

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -967,6 +967,133 @@ data:
     assert by_code["LAB//C"]["description"] == "Gamma"
 
 
+def test_reduced_column_set_for_aggregated_union_parent_codes_block():
+    """The reduced ``codes.parquet`` COLUMN SET survives an aggregated-union metadata block.
+
+    The eICU shape: one ``_metadata`` block whose only output is ``parent_codes``, with
+    several metadata rows sharing a join key so the reducer unions them into one
+    ``List(String)`` per code — alongside a literal-code event file with no
+    ``code_components`` column. The assertion is on the exact column set, not row count:
+    losing every metadata column preserves the row count (the output always enumerates
+    the observed vocabulary), so a cardinality check alone stays green through total
+    metadata loss.
+    """
+    messy = """\
+diagnosis:
+  dx:
+    code: f"DIAGNOSIS//{$diagnosisstring}"
+    _metadata:
+      dx_icd_map:
+        diagnosisstring: $diagnosisstring
+        parent_codes: >-
+          f"ICD9CM/{$icd_code}" if $icd_version == "9"
+          else f"ICD10CM/{$icd_code}" if $icd_version == "10"
+vitalPeriodic:
+  hr:
+    code: '"VITALS//PERIODIC//HEARTRATE"'
+    time: null
+"""
+    with tempfile.TemporaryDirectory() as d:
+        codes_df = _run_ecm_scenario(
+            Path(d),
+            messy,
+            event_frames={
+                "diagnosis": pl.DataFrame(
+                    {
+                        "code": ["DIAGNOSIS//a|b", "DIAGNOSIS//c|d"],
+                        "code_components": [{"diagnosisstring": "a|b"}, {"diagnosisstring": "c|d"}],
+                        "source_block": ["diagnosis/dx"] * 2,
+                    }
+                ),
+                # Literal-code table: no code_components column at all.
+                "vitalPeriodic": pl.DataFrame(
+                    {"code": ["VITALS//PERIODIC//HEARTRATE"], "source_block": ["vitalPeriodic/hr"]}
+                ),
+            },
+            # Two metadata rows share the "a|b" join key: the reducer must union both
+            # parents into one list for that code.
+            raw_files={
+                "dx_icd_map.csv": (
+                    "diagnosisstring,icd_code,icd_version\n"
+                    "a|b,250.00,9\n"
+                    "a|b,E11.9,10\n"
+                    "c|d,401.9,9\n"
+                )
+            },
+        )
+
+    assert set(codes_df.columns) == {"code", "code_template", "parent_codes"}, (
+        f"The aggregated-union metadata block's columns must survive reduction.\n{codes_df}"
+    )
+    assert codes_df.schema["parent_codes"] == pl.List(pl.String)
+    by_code = {r["code"]: r["parent_codes"] for r in codes_df.iter_rows(named=True)}
+    assert sorted(by_code["DIAGNOSIS//a|b"]) == ["ICD10CM/E11.9", "ICD9CM/250.00"]
+    assert by_code["DIAGNOSIS//c|d"] == ["ICD9CM/401.9"]
+    # The literal code appears in the vocabulary with null metadata.
+    assert by_code["VITALS//PERIODIC//HEARTRATE"] is None
+
+
+def test_reduced_output_invariant_to_event_file_discovery_order(monkeypatch):
+    """Event-file discovery order cannot change the reduced output.
+
+    Per-table event files have heterogeneous schemas (a literal-code table carries no
+    ``code_components`` column), and ``Path.rglob`` enumerates in filesystem order — which
+    varies across machines and directory histories. Two runs over identical mixed-schema
+    inputs are forced through opposite enumeration orders and must produce identical,
+    correct output frames.
+    """
+    from polars.testing import assert_frame_equal
+
+    messy = """\
+labs:
+  measurement:
+    code: 'f"{$test_name}//{$units}"'
+    _metadata:
+      lab_meta:
+        test_name: $test_name
+        units: $units
+        description: $title
+admissions:
+  admit:
+    code: ADMISSION
+    time: null
+"""
+    event_frames = {
+        "labs": pl.DataFrame(
+            {
+                "code": ["Glucose//mg/dL", "BUN//mg/dL"],
+                "code_components": [
+                    {"test_name": "Glucose", "units": "mg/dL"},
+                    {"test_name": "BUN", "units": "mg/dL"},
+                ],
+                "source_block": ["labs/measurement"] * 2,
+            }
+        ),
+        # Literal-code table (no code_components) — under the wrong enumeration handling
+        # this file coming first is what degraded the run to a codes-only output.
+        "admissions": pl.DataFrame({"code": ["ADMISSION"], "source_block": ["admissions/admit"]}),
+    }
+    raw_files = {"lab_meta.csv": "test_name,units,title\nGlucose,mg/dL,Blood Glucose\n"}
+
+    real_rglob = Path.rglob
+    frames: list[pl.DataFrame] = []
+    for reorder in (lambda fps: fps, lambda fps: list(reversed(fps))):
+
+        def forced_order_rglob(self, pattern, _reorder=reorder):
+            return iter(_reorder(sorted(real_rglob(self, pattern))))
+
+        monkeypatch.setattr(Path, "rglob", forced_order_rglob)
+        with tempfile.TemporaryDirectory() as d:
+            frames.append(_run_ecm_scenario(Path(d), messy, event_frames, raw_files))
+    monkeypatch.undo()
+
+    assert_frame_equal(frames[0], frames[1], check_row_order=True, check_column_order=True)
+    assert set(frames[0].columns) == {"code", "code_template", "description"}
+    by_code = {r["code"]: r["description"] for r in frames[0].iter_rows(named=True)}
+    assert by_code["Glucose//mg/dL"] == "Blood Glucose"
+    assert by_code["ADMISSION"] is None
+
+
 def test_mixed_full_and_partial_match_from_same_metadata_prefix():
     """Regression guard: configs with different match-column sets sharing a metadata prefix.
 

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -554,12 +554,16 @@ data:
     assert by_code == {"EXISTING_CODE": "An existing code", "HR": None}
 
 
-def test_metadata_without_code_components_in_events(caplog):
-    """Metadata with no code_components in the event data yields a codes-only output.
+def test_metadata_blocks_over_componentless_events_error():
+    """Configured ``_metadata`` blocks over events with no ``code_components`` anywhere error.
 
-    Covers the warning path: the stage completes without error, warns that there is
-    nothing to join metadata onto, and writes a codes-only table that still enumerates
-    every observed code (no metadata columns attach).
+    A ``_metadata`` block always attaches to a component-bearing code, so an input with no
+    components in ANY event file cannot be a ``convert_to_MEDS_events`` output — in
+    practice it is merged data (``merge_to_MEDS_cohort`` drops ``code_components``),
+    i.e. ``extract_code_metadata`` ordered after the merge stage. The old behavior wrote a
+    codes-only table with a buried warning: every metadata column silently lost while the
+    per-source partials stayed correct, the row count matched the observed vocabulary, and
+    the run exited 0. That degrade must be a loud error naming the likely cause.
     """
     messy = """\
 data:
@@ -570,19 +574,17 @@ data:
         lab_code: $lab_code
         description: $title
 """
-    with tempfile.TemporaryDirectory() as d, caplog.at_level("WARNING"):
-        codes_df = _run_ecm_scenario(
+    with (
+        tempfile.TemporaryDirectory() as d,
+        pytest.raises(ValueError, match="most likely merged data"),
+    ):
+        _run_ecm_scenario(
             Path(d),
             messy,
-            # Event file WITHOUT code_components (pre-component extraction shape).
+            # Post-merge shape: source_block survives, code_components is dropped.
             event_frames={"data": pl.DataFrame({"code": ["HR"], "source_block": ["data/measurement"]})},
             raw_files={"lab_meta.csv": "lab_code,title\nHR,Heart Rate\n"},
         )
-    assert "nothing to join metadata onto" in caplog.text
-    # The observed code still appears (MEDS requires every observed code), but no
-    # metadata columns could be joined on.
-    assert codes_df["code"].to_list() == ["HR"]
-    assert codes_df.columns == ["code"]
 
 
 def test_extract_code_metadata_no_matching_codes(caplog):
@@ -1014,10 +1016,7 @@ vitalPeriodic:
             # parents into one list for that code.
             raw_files={
                 "dx_icd_map.csv": (
-                    "diagnosisstring,icd_code,icd_version\n"
-                    "a|b,250.00,9\n"
-                    "a|b,E11.9,10\n"
-                    "c|d,401.9,9\n"
+                    "diagnosisstring,icd_code,icd_version\na|b,250.00,9\na|b,E11.9,10\nc|d,401.9,9\n"
                 )
             },
         )
@@ -1475,15 +1474,15 @@ def test_metadata_reserved_output_column_names_error(metadata_block, expected):
         compile_metadata_block(metadata_block, {"icd"}, code_template_str='f"ICD//{$icd}"')
 
 
-def test_reducer_skips_metadata_requiring_absent_component_columns(caplog):
-    """A metadata shard whose match columns aren't all present in the extracted components is skipped with a
-    WARNING, not crashed on or silently joined wrong.
+def test_metadata_requiring_absent_component_columns_errors():
+    """A ``_metadata`` block joining on component columns no event file carries errors.
 
     The code expression references ``$a`` and ``$b`` (match columns ``[a, b]``), but the
-    event data's ``code_components`` struct only carries ``a`` — the shape of event
-    parquets produced before a config gained a component. The reducer must name the
-    absent column(s) and the declaring source block, skip that shard, and still write a
-    (here: codes-only) codes.parquet enumerating the observed codes.
+    event data's ``code_components`` struct only carries ``a`` — the events were produced
+    by an older configuration. Such a block can never attach, so its extracted metadata
+    would be discarded wholesale; the stage must fail fast (before the map compute, in
+    every worker) naming the block, the missing column(s), and the columns that exist,
+    rather than degrade to a codes-only output behind a warning.
     """
     messy = """\
 data:
@@ -1495,8 +1494,11 @@ data:
         b: $b
         description: $title
 """
-    with tempfile.TemporaryDirectory() as d, caplog.at_level("WARNING"):
-        codes_df = _run_ecm_scenario(
+    with (
+        tempfile.TemporaryDirectory() as d,
+        pytest.raises(ValueError, match=r"component column\(s\) \['b'\] that no extracted-event file"),
+    ):
+        _run_ecm_scenario(
             Path(d),
             messy,
             event_frames={
@@ -1508,16 +1510,10 @@ data:
                     }
                 )
             },
-            # The raw metadata itself has both match columns, so the map phase succeeds;
-            # only the reducer-side component join is impossible.
+            # The raw metadata itself has both match columns; only the component join
+            # side is impossible, and that alone must already fail the stage.
             raw_files={"m.csv": "a,b,title\nX,Y,Some title\n"},
         )
-    assert "requires component columns ['b'] that are absent" in caplog.text
-    assert "'data/event'" in caplog.text
-    assert "Skipping" in caplog.text
-    # The observed code survives as a codes-only row; the unjoinable metadata is skipped.
-    assert codes_df["code"].to_list() == ["X//Y"]
-    assert codes_df.columns == ["code"]
 
 
 def test_partial_match_zero_matches_warns(caplog):


### PR DESCRIPTION
Fixes #270. The confirmed mechanism (deterministic, not the bisected merge): eICU_MEDS's own ETL.yaml keeps the legacy stage order (merge → extract), so its extract stage scanned *merged* data — which the code_components drop made component-less — and the reducer's legitimate all-literal path silently degraded the run to a codes-only vocabulary with preserved row count, a warning only in a per-worker log, and exit 0. Our canonical pipeline was reordered in the same PR, so our suite stayed green. The reporter's bisect was contaminated (eICU defaults do_overwrite: False, so reused output dirs carried prior commits' results); the true first-bad commit lies outside the bisected range entirely. The filesystem-order hypothesis from the issue thread was tested and refuted (five forced enumeration orders × polars 1.39.3/1.43.2 — all correct), though sorted ingestion and a per-file union-schema components decision land anyway to make order-independence structural.

The new contract: every configured `_metadata` block either joins (its columns appear in the reduced output) or the stage **fails loudly before the map** — component-less events with metadata blocks error naming the likely cause (merged input) and the remedy (order extract before merge); blocks whose join keys exist in no event file error naming block/missing/available; the zero-match join stays a warning (all-null columns appear; empty intersections are data-legitimate). The partials-correct/reduced-codes-only asymmetry is structurally impossible.

Tests: the reporter-prescribed column-set regression (eICU-shaped parent_codes-union block over mixed schemas), a discovery-order invariance test under forced opposite orders, and the two error contracts — regression pins committed first and passing on pre-fix code where applicable. Full suite 262 green; stage tests also green under polars 1.43.2; pre-commit clean.

Downstream action (filed on eICU_MEDS): its ETL.yaml stages list needs extract before merge — with this fix the run fails fast with that exact message instead of silently losing metadata.

Closes #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)