### PR TITLE
Reject colliding join outputs with clean errors

### DIFF
--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -705,6 +705,13 @@ class JoinConfig:
         non-empty, the right-hand side is grouped by ``right_on`` and each
         named column is reduced before the join.
 
+        Every joined column must arrive under a name the left table does not
+        already have: polars would deliver a colliding column under a
+        ``_right``-suffixed name, which MESSY expressions and the source-column
+        plan cannot model, so the collision is rejected here with the offending
+        names instead. (Same-named key columns are exempt — a left join
+        coalesces them into one column.)
+
         Examples:
             End-to-end aggregated join — the admissions side has three rows for
             subject 1 (three admissions) and two rows for subject 2; the join
@@ -732,7 +739,35 @@ class JoinConfig:
             │ 2          ┆ null       │
             │ 3          ┆ null       │
             └────────────┴────────────┘
+
+            A joined column colliding with a left column is rejected:
+
+            >>> with yaml_disk('''
+            ... stays.parquet: {stay_id: [1], age: [40]}
+            ... ''') as d:
+            ...     jc = JoinConfig.parse({"stays": {"key": "stay_id", "cols": ["age"]}})
+            ...     jc.apply(pl.LazyFrame({"stay_id": [1], "age": [39]}), Path(d))
+            Traceback (most recent call last):
+                ...
+            ValueError: Join config for 'stays': joined column(s) ['age'] already exist on the left
+            table. Polars would deliver them under '_right'-suffixed names, which MESSY expressions
+            and the source-column plan cannot model, so plans and references would silently
+            mis-resolve. Joined columns must arrive under names the left table does not already
+            have: rename the column in the source data, or compute the value in a pre-processing
+            step.
         """
+        left_schema = left.collect_schema().names()
+        coalesced_keys = {r for lft, r in zip(self.left_on, self.right_on, strict=False) if lft == r}
+        colliding = [c for c in self.cols if c in left_schema and c not in coalesced_keys]
+        if colliding:
+            raise ValueError(
+                f"Join config for '{self.input_prefix}': joined column(s) {colliding} already "
+                f"exist on the left table. Polars would deliver them under '_right'-suffixed "
+                f"names, which MESSY expressions and the source-column plan cannot model, so "
+                f"plans and references would silently mis-resolve. Joined columns must arrive "
+                f"under names the left table does not already have: rename the column in the "
+                f"source data, or compute the value in a pre-processing step."
+            )
         right = scan_source(resolve_source_files(input_dir, self.input_prefix))
         if self.aggregations:
             right = self._aggregate(right)
@@ -1530,6 +1565,38 @@ class TableConfig:
                             f"columns are applied before the join and must be computable from "
                             f"raw source columns alone."
                         )
+            # A self-join can never deliver its columns: every column of the joined
+            # table exists on the left by construction (same file), so every output
+            # would collide. Rejected at parse so the failure names the pattern
+            # instead of surfacing per-column at scan time.
+            if self.join.input_prefix == self.input_prefix:
+                raise ValueError(
+                    f"Table '{self.input_prefix}' joins to itself. A self-join cannot work: "
+                    f"every joined column already exists on the left side (same file), and "
+                    f"MESSY does not support suffixed join outputs. Compute per-group "
+                    f"reductions of a table's own columns in a pre-processing step instead."
+                )
+            # A reference to '<col>_right' means the config was written against
+            # polars' collision suffix, which MESSY does not support.
+            refs: set[str] = set()
+            if self.subject_id_node is not None:
+                refs.update(self.subject_id_node.referenced_columns)
+            for node in self.cols.values():
+                refs.update(node.referenced_columns)
+            for event in self.events:
+                refs.update(event.referenced_columns)
+            suffixed = sorted(
+                r for r in refs if r.endswith("_right") and r[: -len("_right")] in self.join.cols
+            )
+            if suffixed:
+                raise ValueError(
+                    f"Table '{self.input_prefix}' references column(s) {suffixed}, the "
+                    f"'_right'-suffixed form of joined column(s). Suffixed join outputs are "
+                    f"not supported: joined columns must arrive under names the left table "
+                    f"does not already have, referenced without a suffix. Rename the "
+                    f"colliding source column upstream, or compute the value in a "
+                    f"pre-processing step."
+                )
 
     @classmethod
     def parse(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -448,8 +448,8 @@ def test_messy_save_source_deleted_errors(tmp_path):
 def test_composite_join_key_filters_and_plans(tmp_path):
     """A composite join key with a derived-literal left column restricts the join to matching right rows (no
     fan-out from multi-row-per-id right tables), extracts the right values end-to-end, and plans source
-    columns per table correctly — the derived key is attributed to neither side's raw files, while its
-    inputs and the right-side key columns are."""
+    columns per table correctly — the derived key is attributed to neither side's raw files, while its inputs
+    and the right-side key columns are."""
     import polars as pl
 
     from MEDS_extract.config import MessyConfig
@@ -491,3 +491,46 @@ def test_composite_join_key_filters_and_plans(tmp_path):
     events = table.extract_events(table.scan(tmp_path)).collect().sort("subject_id")
     assert events.height == 2
     assert events["code"].to_list() == ["MED//10", "MED//20"]
+
+
+def test_self_join_rejected_at_parse():
+    """A self-join is rejected at parse: every joined column exists on the left by
+    construction, so every output would collide with a left column."""
+    with pytest.raises(ValueError, match=r"Table 'ops' joins to itself"):
+        TableConfig.parse(
+            "ops",
+            {
+                "_defaults": {"subject_id": "$subject_id"},
+                "_table": {"join": {"ops": {"key": "subject_id", "cols": {"age": "min"}}}},
+                "birth": {"code": "MEDS_BIRTH", "time": None, "numeric_value": "$age"},
+            },
+        )
+
+
+def test_suffixed_join_output_reference_rejected_at_parse():
+    """Referencing a '_right'-suffixed joined column is rejected at parse with a message naming the suffixed
+    references — configs written against polars' collision suffix get a diagnostic instead of a missing-column
+    failure at convert_to_parquet."""
+    with pytest.raises(ValueError, match=r"references column\(s\) \['age_right'\].*not supported"):
+        TableConfig.parse(
+            "ops",
+            {
+                "_defaults": {"subject_id": "$subject_id"},
+                "_table": {
+                    "cols": {"is_first": "$age == $age_right"},
+                    "join": {"other": {"key": "subject_id", "cols": {"age": "min"}}},
+                },
+                "birth": {"code": "MEDS_BIRTH", "time": None, "numeric_value": "$age_right"},
+            },
+        )
+
+
+def test_join_collision_with_left_schema_rejected_at_scan(tmp_path):
+    """A joined column whose name exists on the left file errors cleanly at join time instead of polars
+    silently delivering it as '<col>_right' (leaving bare references resolving to the LEFT column — silent
+    wrong data)."""
+    pl.DataFrame({"stay_id": [1], "age": [40]}).write_parquet(tmp_path / "stays.parquet")
+    jc = JoinConfig.parse({"stays": {"key": "stay_id", "cols": ["age"]}})
+    left = pl.LazyFrame({"stay_id": [1], "age": [39]})
+    with pytest.raises(ValueError, match=r"joined column\(s\) \['age'\] already exist"):
+        jc.apply(left, tmp_path)


### PR DESCRIPTION
Closes #266

## What

When a join's delivered column name collides with a column already on the left table, polars silently suffixes it `_right`. MESSY expressions and the source-column planner cannot model that suffix, so the failure surfaced as a confusing `missing requested column(s) ['age_right']` error at `convert_to_parquet` — or, if the config referenced the bare name, as bare references silently resolving to the *left* column (wrong data, no error).

Per discussion on #279 (closed unmerged), suffixed join outputs are an antipattern we don't want to bless as contract. This PR instead makes every collision a clean, actionable error:

- **Parse time**: a self-join is rejected outright (every joined column exists on the left by construction), and any reference to `$<col>_right` where `<col>` is a join output is rejected as written-against-the-suffix.
- **Join time** (`JoinConfig.apply`): a joined column present on the left schema raises with the offending names and remediation guidance (rename the source column upstream, or use a pre-processing step). Same-named key columns are exempt — a left join coalesces them.

The motivating INSPIRE pattern (aggregated self-join for earliest-row static facts) will be workshopped in the INSPIRE ETL instead; `age` is recorded on every row there, so no first-row selection is actually required.

## Tests

- Doctest on `JoinConfig.apply` for the join-time collision error.
- `tests/test_config.py`: self-join parse rejection (the #266 repro shape), `_right`-reference parse rejection, and the scan-time left-schema collision.

Full suite: 220 passed, 3 deselected; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)