### PR TITLE
Reject join column-name overlaps that clobber or drop delivered columns

### DIFF
--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -1614,7 +1614,9 @@ class TableConfig:
             # derived column sharing a joined column's name would silently overwrite
             # the joined values. Same-named join keys are exempt: the join coalesces
             # them, and re-deriving a self-contained key is a no-op.
-            coalesced = {lft for lft, r in zip(self.join.left_on, self.join.right_on, strict=False) if lft == r}
+            coalesced = {
+                lft for lft, r in zip(self.join.left_on, self.join.right_on, strict=False) if lft == r
+            }
             clobbered = sorted((set(self.cols) & set(self.join.cols)) - coalesced)
             if clobbered:
                 raise ValueError(

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -577,6 +577,19 @@ class JoinConfig:
             raise ValueError(
                 f"Join config for '{self.input_prefix}' must pull in at least one column via 'cols'."
             )
+        # A right key whose left counterpart has a different name is coalesced into
+        # that counterpart by the left join and delivers no column of its own, so
+        # listing it in ``cols`` promises a column that can never arrive.
+        renamed_keys = {r: lft for lft, r in zip(self.left_on, self.right_on, strict=False) if lft != r}
+        dropped = sorted(c for c in self.cols if c in renamed_keys)
+        if dropped:
+            hints = ", ".join(f"'{c}' arrives as '{renamed_keys[c]}'" for c in dropped)
+            raise ValueError(
+                f"Join config for '{self.input_prefix}': 'cols' lists right key column(s) "
+                f"{dropped}, but a left join coalesces each right key into its left counterpart "
+                f"({hints}) and delivers no column under the right key's name. Reference the "
+                f"left key column instead — the values are identical after the join."
+            )
         # Aggregation validation lives here (not only in ``parse``) so a directly-constructed
         # JoinConfig is held to the same rules — validation-at-construction, per repo convention.
         for col, agg in self.aggregations:
@@ -1596,6 +1609,20 @@ class TableConfig:
                     f"does not already have, referenced without a suffix. Rename the "
                     f"colliding source column upstream, or compute the value in a "
                     f"pre-processing step."
+                )
+            # Derived expressions are applied AFTER the join (except join keys), so a
+            # derived column sharing a joined column's name would silently overwrite
+            # the joined values. Same-named join keys are exempt: the join coalesces
+            # them, and re-deriving a self-contained key is a no-op.
+            coalesced = {lft for lft, r in zip(self.join.left_on, self.join.right_on, strict=False) if lft == r}
+            clobbered = sorted((set(self.cols) & set(self.join.cols)) - coalesced)
+            if clobbered:
+                raise ValueError(
+                    f"Table '{self.input_prefix}': derived column(s) {clobbered} under "
+                    f"'_table.cols' share names with columns delivered by the join. Derived "
+                    f"expressions are applied after the join and would silently overwrite the "
+                    f"joined values. Give the derived column and the joined column distinct "
+                    f"names."
                 )
 
     @classmethod

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -534,3 +534,48 @@ def test_join_collision_with_left_schema_rejected_at_scan(tmp_path):
     left = pl.LazyFrame({"stay_id": [1], "age": [39]})
     with pytest.raises(ValueError, match=r"joined column\(s\) \['age'\] already exist"):
         jc.apply(left, tmp_path)
+
+
+def test_derived_column_clobbering_joined_column_rejected_at_parse():
+    """A '_table.cols' derived column sharing a joined column's name is rejected at
+    parse: derived expressions apply after the join and would silently overwrite the
+    joined values (every event time would come out as the derived constant)."""
+    with pytest.raises(ValueError, match=r"derived column\(s\) \['dischtime'\].*overwrite"):
+        TableConfig.parse(
+            "vitals",
+            {
+                "_defaults": {"subject_id": "$subject_id"},
+                "_table": {
+                    "cols": {"dischtime": "'1970-01-01'"},
+                    "join": {"stays": {"key": "stay_id", "cols": ["dischtime"]}},
+                },
+                "v": {"code": "V", "time": "$dischtime"},
+            },
+        )
+
+
+def test_derived_join_key_listed_in_cols_still_allowed():
+    """The sanctioned filter idiom survives the clobber guard: a derived left key with
+    the same right-key name coalesces in the join, and re-deriving it is a no-op."""
+    tc = TableConfig.parse(
+        "emar",
+        {
+            "_defaults": {"subject_id": "$subject_id"},
+            "_table": {
+                "cols": {"drug_type": "'MAIN'"},
+                "join": {"prescriptions": {"key": ["pharmacy_id", "drug_type"], "cols": ["ndc"]}},
+            },
+            "med": {"code": 'f"MED//{$ndc}"', "time": None},
+        },
+    )
+    assert tc.join is not None
+
+
+def test_right_key_listed_in_cols_rejected_when_left_name_differs():
+    """Listing a right key column in 'cols' when its left counterpart has a different
+    name is rejected at parse: the left join coalesces the right key into the left one
+    and delivers no column under the right key's name, so the promise can never be
+    kept (references crash deep in the events stage; unreferenced, it silently never
+    exists)."""
+    with pytest.raises(ValueError, match=r"right key column\(s\) \['adm_id'\].*coalesces"):
+        JoinConfig.parse({"adm": {"left_on": "hadm_id", "right_on": "adm_id", "cols": ["adm_id", "x"]}})


### PR DESCRIPTION
Closes #287
Closes #288

Two confirmed holes in the join-collision guard family (#285), found in the final release-gate review of dev:

- **#287 (silent data corruption):** a `_table.cols` derived column sharing a joined column's name passed every existing guard (it isn't in the raw left schema, so `JoinConfig.apply`'s check passes), then `prepare()` applied the derived expression after the join and silently overwrote the joined values — reproduced end-to-end with every event time becoming the derived constant. Now rejected at parse. Same-named join keys stay exempt: the join coalesces them and re-deriving a self-contained key is a no-op, so the composite-key filter idiom (`drug_type: "'MAIN'"`) is unaffected (pinned by test).
- **#288 (undeliverable promise):** `join.cols` listing a right key column whose paired left key has a different name — polars coalesces the right key into the left one and delivers no column under the right name, so references crash deep in the events stage and unreferenced entries silently never exist. Now rejected at parse with the arrival-name hint.

Tests: parse-rejection tests for both guards plus a filter-idiom-survives regression. Full suite: 225 passed, 3 deselected; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)