### PR TITLE
Add _self metadata blocks: source code metadata from the event's own rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,74 @@ nothing — vocabulary declared for one event never leaks onto another. (The cod
 still appears — `codes.parquet` always enumerates every observed code, as MEDS
 requires — it just carries no metadata.)
 
+#### Sourcing metadata from the event's own table: `_self`
+
+Sometimes the "dictionary" is not a separate file — the descriptive column sits right in
+the data table (a `long_label` next to every `itemid`). Pointing a `_metadata` block at
+the event's **own** prefix technically works but is an antipattern (it warns): the stage
+would re-scan the full raw table, materialize the mapped frame in memory, and join it
+against every observed code. The `_self` prefix expresses this directly:
+
+```yaml
+chartevents:
+  chart:
+    code: f"CHART//{$itemid}"
+    time: $charttime
+    _metadata:
+      _self:
+        description: $long_label
+```
+
+`_self` expressions are evaluated **during event extraction**, over the event's fully
+prepared frame — post-join, post-`_table.cols` — so they may reference source columns,
+joined columns, and derived columns alike (add whatever you need to the table block and
+`_self` sees it). The evaluated outputs ride alongside `code_components` in a
+`metadata_components` struct, `extract_code_metadata` reads distinct component→metadata
+pairs straight from the extracted event files (no raw re-scan, no join against raw
+data), and the struct is dropped at merge — a metadata-only column never appears in the
+final data output, and its source column is planned automatically.
+
+Unlike an external block, `_self` never restates join keys: every code component pairs
+with the outputs row-wise exactly, so the block lists only outputs (and output names may
+not collide with component names). Everything downstream is identical — scoping,
+broadcasting, `codes.parquet` shape:
+
+```python
+>>> root = yaml_disk('''
+... raw/:
+...   chartevents.csv:
+...     subject_id: [1, 2, 3]
+...     itemid: [220045, 220045, 220179]
+...     long_label: [Heart Rate, Heart Rate, NBP systolic]
+...     ts: ["2024-01-01 09:30", "2024-03-02 14:00", "2024-04-01 08:15"]
+... messy.yaml:
+...   chartevents:
+...     chart:
+...       code: 'f"CHART//{$itemid}"'
+...       time: '$ts::"%Y-%m-%d %H:%M"'
+...       _metadata:
+...         _self:
+...           description: '$long_label'
+... ''', Path(tempfile.mkdtemp()))
+>>> run_extraction(root)
+>>> pl.read_parquet(f"{root}/output/metadata/codes.parquet").select("code", "description").sort("code")
+shape: (2, 2)
+┌───────────────┬──────────────┐
+│ code          ┆ description  │
+│ ---           ┆ ---          │
+│ str           ┆ str          │
+╞═══════════════╪══════════════╡
+│ CHART//220045 ┆ Heart Rate   │
+│ CHART//220179 ┆ NBP systolic │
+└───────────────┴──────────────┘
+
+```
+
+One code should carry one metadata value: if a component key maps to *distinct* `_self`
+values across its occurrences, the stage warns (that is usually data leaking into
+metadata — the varying value belongs in the code or in an event value column) and the
+conflicting values are aggregated per code like any other metadata collision.
+
 #### Raw values, not rendered values
 
 Two things routinely differ between what a code *displays* and what the raw data

--- a/src/MEDS_extract/config.py
+++ b/src/MEDS_extract/config.py
@@ -60,6 +60,18 @@ SOURCE_BLOCK_COL = "source_block"
 # collides with the pipeline-generated output ``code``.
 METADATA_RESERVED_COLS = frozenset({"code", "code_template"})
 
+# Reserved ``_metadata`` prefix naming the event's OWN prepared source frame (post-join,
+# post-``_table.cols``) as the metadata source. ``_self`` expressions are evaluated during
+# event extraction and their outputs carried in the ``METADATA_COMPONENTS_COL`` struct, so
+# ``extract_code_metadata`` reads distinct component→metadata pairs from the already-extracted
+# event files instead of re-scanning (and fully materializing) the raw table.
+SELF_METADATA_PREFIX = "_self"
+
+# Struct column carrying evaluated ``_self`` metadata outputs on extracted event rows.
+# Internal linkage state exactly like ``code_components``: consumed by
+# ``extract_code_metadata``, dropped by ``merge_to_MEDS_cohort``, never in final data.
+METADATA_COMPONENTS_COL = "metadata_components"
+
 
 @dataclass(frozen=True)
 class CompiledMetadataBlock:
@@ -313,6 +325,114 @@ def compile_metadata_block(
 
     return CompiledMetadataBlock(
         exprs=exprs, key_cols=key_cols, output_cols=output_cols, code_template=code_template_str
+    )
+
+
+def compile_self_metadata_block(
+    block: Mapping[str, Any],
+    component_cols: frozenset[str] | set[str],
+    *,
+    code_template_str: str,
+    context: str = "",
+) -> CompiledMetadataBlock:
+    """Compile and validate one ``_self`` metadata block against its declaring event.
+
+    A ``_self`` block maps **output column name → dftly expression**, evaluated over the
+    event's own prepared source frame (post-join, post-``_table.cols``) during event
+    extraction — never over a re-scanned raw table. Join keys are implicit: every code
+    component pairs with the outputs row-wise exactly, so unlike an external
+    :func:`compile_metadata_block` entry, the block never restates key columns —
+    ``key_cols`` is always the full component set, and every produced column is a
+    metadata output.
+
+    Raises:
+        ValueError: On a literal code (no components to attach through), a non-mapping
+            or empty block, a reserved output name, an output name colliding with a
+            component column (keys are implicit — the name is already taken), or an
+            unparsable expression.
+
+    Examples:
+        >>> compiled = compile_self_metadata_block(
+        ...     {"description": "$long_label", "vocab": '"LOCAL"'},
+        ...     {"itemid"},
+        ...     code_template_str='f"CHART//{$itemid}"',
+        ... )
+        >>> compiled.key_cols, compiled.output_cols
+        (('itemid',), ('description', 'vocab'))
+        >>> sorted(compiled.referenced_columns)
+        ['long_label']
+
+        Output names may not collide with the code's components (keys are implicit):
+
+        >>> compile_self_metadata_block(
+        ...     {"itemid": "$other"}, {"itemid"}, code_template_str='f"CHART//{$itemid}"'
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: _self metadata output column name(s) ['itemid'] collide with the code
+        expression's component columns. _self join keys are implicit (every component pairs
+        row-wise); name the outputs differently.
+
+        A literal code has no components for the reducer to attach through:
+
+        >>> compile_self_metadata_block(
+        ...     {"description": "$label"}, set(), code_template_str='"ADMISSION"'
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: The code expression '"ADMISSION"' is a literal: it references no source
+        columns, so a literal code has no components to match metadata on. Add static metadata
+        for literal codes to a pre-existing codes.parquet instead of a _metadata block.
+    """
+    ctx = f" ({context})" if context else ""
+
+    if not isinstance(block, Mapping) or isinstance(block, str):
+        raise ValueError(
+            f"_self metadata entry{ctx} must be a mapping of output column name -> dftly "
+            f"expression, got {type(block).__name__}: {block!r}."
+        )
+    if not block:
+        raise ValueError(
+            f"_self metadata entry{ctx} is empty. Map output column names to dftly expressions "
+            f"over the event's own source frame."
+        )
+    component_cols = frozenset(component_cols)
+    if not component_cols:
+        raise ValueError(
+            f"The code expression {code_template_str!r} is a literal: it references no source "
+            "columns, so a literal code has no components to match metadata on. Add static "
+            "metadata for literal codes to a pre-existing codes.parquet instead of a _metadata "
+            "block."
+        )
+    reserved = sorted(k for k in block if k in METADATA_RESERVED_COLS)
+    if reserved:
+        raise ValueError(
+            f"_self metadata output column name(s) {reserved}{ctx} are reserved: 'code' and "
+            "'code_template' are generated by the pipeline and cannot be overwritten."
+        )
+    colliding = sorted(set(block) & component_cols)
+    if colliding:
+        raise ValueError(
+            f"_self metadata output column name(s) {colliding}{ctx} collide with the code "
+            f"expression's component columns. _self join keys are implicit (every component "
+            f"pairs row-wise); name the outputs differently."
+        )
+
+    parser = Parser()
+    exprs: dict[str, NodeBase] = {}
+    for out_col, raw_expr in block.items():
+        try:
+            exprs[out_col] = raw_expr if isinstance(raw_expr, NodeBase) else parser(raw_expr)
+        except Exception as e:
+            raise ValueError(
+                f"_self metadata column {out_col!r}{ctx} failed to parse as a dftly expression: {e}"
+            ) from e
+
+    return CompiledMetadataBlock(
+        exprs=exprs,
+        key_cols=tuple(sorted(component_cols)),
+        output_cols=tuple(block),
+        code_template=code_template_str,
     )
 
 
@@ -987,7 +1107,10 @@ class EventConfig:
                     f"(or pass raw_code= when constructing EventConfig directly)."
                 )
             for prefix, block in self.metadata.items():
-                compile_metadata_block(
+                compile_fn = (
+                    compile_self_metadata_block if prefix == SELF_METADATA_PREFIX else compile_metadata_block
+                )
+                compile_fn(
                     block,
                     self.code_source_columns,
                     code_template_str=self.raw_code,
@@ -1157,18 +1280,41 @@ class EventConfig:
         return frozenset(self.columns["code"].referenced_columns)
 
     @cached_property
+    def self_metadata_exprs(self) -> dict[str, NodeBase]:
+        """Compiled ``_self`` metadata expressions (output column → node), or ``{}``.
+
+        ``_self`` metadata is evaluated over the event's own prepared source frame
+        during :meth:`extract` — the outputs land in the ``METADATA_COMPONENTS_COL``
+        struct rather than re-reading any raw table at metadata-extraction time.
+        """
+        block = self.metadata.get(SELF_METADATA_PREFIX)
+        if not block:
+            return {}
+        compiled = compile_self_metadata_block(
+            block,
+            self.code_source_columns,
+            code_template_str=self.raw_code,
+            context=f"event '{self.name}', metadata prefix '{SELF_METADATA_PREFIX}'",
+        )
+        return compiled.exprs
+
+    @cached_property
     def referenced_columns(self) -> frozenset[str]:
         """All source columns referenced by any output column expression.
 
-        Aggregates across ``code``, ``time``, and all additional value columns.
-        Used by :meth:`TableConfig.source_columns` to determine which columns
-        must be read from the source parquet file.
+        Aggregates across ``code``, ``time``, all additional value columns, and any
+        ``_self`` metadata expressions (which read the same prepared frame — external
+        ``_metadata`` blocks reference metadata-table columns and are excluded). Used
+        by :meth:`TableConfig.source_columns` to determine which columns must be read
+        from the source parquet file.
         """
         cols: set[str] = set()
         for v in self.columns.values():
             if v is None:
                 continue
             cols.update(v.referenced_columns)
+        for node in self.self_metadata_exprs.values():
+            cols.update(node.referenced_columns)
         return frozenset(cols)
 
     def extract(
@@ -1375,6 +1521,13 @@ class EventConfig:
             exprs["code_components"] = pl.struct(
                 **{col: pl.col(col) for col in sorted(self.code_source_columns)}
             )
+        if self.self_metadata_exprs:
+            # Evaluated ``_self`` metadata outputs, paired row-wise with the components
+            # above. ``extract_code_metadata`` reads distinct component→metadata pairs
+            # from these two structs; ``merge_to_MEDS_cohort`` drops both.
+            exprs[METADATA_COMPONENTS_COL] = pl.struct(
+                **{out: node.polars_expr for out, node in self.self_metadata_exprs.items()}
+            )
 
         exprs["time"] = self.polars_exprs["time"]
 
@@ -1561,6 +1714,16 @@ class TableConfig:
                 raise TypeError(
                     f"Table '{self.input_prefix}' derived column '{k}' must be a parsed dftly "
                     f"node, got {type(v).__name__}."
+                )
+        for event in self.events:
+            if self.input_prefix in event.metadata:
+                logger.warning(
+                    f"Table '{self.input_prefix}' event '{event.name}': its _metadata block "
+                    f"targets the event's own source table. extract_code_metadata will re-scan "
+                    f"the raw table, fully materialize the mapped frame, and join it against "
+                    f"every observed code — on a large table this exhausts memory. Use the "
+                    f"'{SELF_METADATA_PREFIX}' prefix instead to source these columns from the "
+                    f"event's own extracted rows."
                 )
         if self.join is not None:
             # A join key may be a ``_table.cols`` derived column (the canonical case: a

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -18,10 +18,24 @@ from omegaconf import DictConfig
 from upath import UPath
 
 from .._stage_example import MEDSExtractStageExample
-from ..config import SOURCE_BLOCK_COL, CompiledMetadataBlock, MessyConfig, compile_metadata_block
+from ..config import (
+    METADATA_COMPONENTS_COL,
+    SELF_METADATA_PREFIX,
+    SOURCE_BLOCK_COL,
+    CompiledMetadataBlock,
+    MessyConfig,
+    compile_metadata_block,
+    compile_self_metadata_block,
+)
 from ..io import _format_family, resolve_source_files, scan_source
 
 logger = logging.getLogger(__name__)
+
+# On-disk size above which an external metadata table draws a WARNING: metadata tables
+# are fully materialized by the mapper and joined against every observed code, so they
+# are sized for vocabularies, not data tables. A larger source is almost always an event
+# table pointed at itself (the ``_self`` prefix is the fix) or a mis-typed prefix.
+METADATA_TABLE_WARN_BYTES = 256 * 2**20
 
 # The MEDS-mandated dtypes of the sentinel code-metadata columns, derived from the
 # authoritative ``meds.CodeMetadataSchema`` (a pyarrow schema) rather than hand-written:
@@ -239,8 +253,11 @@ def build_code_component_map(all_data: pl.LazyFrame) -> pl.DataFrame:
     )
 
 
-def _compile_metadata_entry(event_cfg: Mapping) -> CompiledMetadataBlock:
+def _compile_metadata_entry(event_cfg: Mapping, *, self_block: bool = False) -> CompiledMetadataBlock:
     """Compile one ``{code, _metadata}`` entry: parse the code, compile+validate the block.
+
+    ``self_block=True`` compiles a ``_self`` entry (implicit keys, outputs evaluated at
+    event-extraction time) via ``compile_self_metadata_block``; the shape checks are shared.
 
     The single seam between the entry dicts ``MessyConfig.events_by_metadata_prefix``
     emits and :func:`MEDS_extract.config.compile_metadata_block`. ``main`` compiles
@@ -302,7 +319,8 @@ def _compile_metadata_entry(event_cfg: Mapping) -> CompiledMetadataBlock:
         )
     code_node = Parser()(code_template_str)
 
-    return compile_metadata_block(
+    compile_fn = compile_self_metadata_block if self_block else compile_metadata_block
+    return compile_fn(
         event_cfg["_metadata"],
         frozenset(code_node.referenced_columns),
         code_template_str=code_template_str,
@@ -586,6 +604,91 @@ def extract_metadata(
     return metadata_df.unique(maintain_order=True).select(*match_cols, "code_template", *final_cols)
 
 
+def extract_self_metadata(
+    events_df: pl.LazyFrame, compiled: CompiledMetadataBlock, source_block: str
+) -> pl.DataFrame:
+    """Produce one ``_self`` block's metadata frame from already-extracted event rows.
+
+    The ``_self`` counterpart of :func:`extract_metadata`: the expressions were already
+    evaluated during event extraction and stored in the ``METADATA_COMPONENTS_COL``
+    struct, so this is a pure distinct-pairs projection — component values from
+    ``code_components``, outputs from ``METADATA_COMPONENTS_COL``, scoped to the
+    declaring event's rows — with the same output shape (sorted key columns,
+    ``code_template``, declared outputs) the reducer expects. No raw table is read and
+    nothing is joined; rows whose outputs are all null are dropped, mirroring
+    :func:`extract_metadata`. The result is sorted so partial-file bytes are
+    deterministic regardless of event-file row order, and collected eagerly (it is
+    small — distinct pairs) so conflicting-metadata detection can run here.
+
+    Struct fields are read via ``struct.field`` rather than ``unnest`` so a component
+    name used by one event and a metadata output name used by another can coexist in the
+    diagonally-concatenated input without a duplicate-column collision.
+
+    A component key mapping to multiple distinct metadata rows draws a WARNING: metadata
+    that varies across occurrences of one code is usually data leaking into metadata
+    (the varying value likely belongs in the code or in an event value column).
+
+    Examples:
+        >>> events = pl.LazyFrame({
+        ...     "code": ["CHART//1", "CHART//1", "CHART//2", "OTHER"],
+        ...     "code_components": [{"itemid": 1}, {"itemid": 1}, {"itemid": 2}, {"itemid": None}],
+        ...     "metadata_components": [
+        ...         {"desc": "HR"}, {"desc": "HR"}, {"desc": "RR"}, {"desc": "ignored"},
+        ...     ],
+        ...     "source_block": ["chart/c", "chart/c", "chart/c", "other/o"],
+        ... })
+        >>> compiled = compile_self_metadata_block(
+        ...     {"desc": "$long_label"}, {"itemid"}, code_template_str='f"CHART//{$itemid}"'
+        ... )
+        >>> extract_self_metadata(events, compiled, "chart/c")
+        shape: (2, 3)
+        ┌────────┬─────────────────────┬──────┐
+        │ itemid ┆ code_template       ┆ desc │
+        │ ---    ┆ ---                 ┆ ---  │
+        │ i64    ┆ str                 ┆ str  │
+        ╞════════╪═════════════════════╪══════╡
+        │ 1      ┆ f"CHART//{$itemid}" ┆ HR   │
+        │ 2      ┆ f"CHART//{$itemid}" ┆ RR   │
+        └────────┴─────────────────────┴──────┘
+    """
+    key_exprs = [pl.col("code_components").struct.field(c).alias(c) for c in compiled.key_cols]
+    out_exprs = [pl.col(METADATA_COMPONENTS_COL).struct.field(c).alias(c) for c in compiled.output_cols]
+    out = (
+        events_df.filter(pl.col(SOURCE_BLOCK_COL) == source_block)
+        .select(*key_exprs, pl.lit(compiled.code_template).alias("code_template"), *out_exprs)
+        .filter(~pl.all_horizontal(*(pl.col(c).is_null() for c in compiled.output_cols)))
+        .unique()
+        .sort([*compiled.key_cols, *compiled.output_cols])
+        .collect()
+    )
+
+    # One code, several distinct metadata rows = per-occurrence data leaking into
+    # code-level metadata. The reducer resolves the conflict by aggregating (description
+    # joined, other columns to lists), so this is legal — but it usually means the
+    # varying value belongs in the code itself or in the event data, hence a WARNING
+    # naming an offending key.
+    n_keys = 0 if out.is_empty() else out.select(pl.struct(compiled.key_cols).n_unique()).item()
+    if out.height > n_keys:
+        example = (
+            out.group_by(compiled.key_cols, maintain_order=True)
+            .len()
+            .filter(pl.col("len") > 1)
+            .head(1)
+            .select(compiled.key_cols)
+            .row(0)
+        )
+        logger.warning(
+            f"_self metadata for source block {source_block!r}: {out.height - n_keys} of "
+            f"{out.height} metadata rows are extra distinct rows for an already-seen component "
+            f"key (e.g. {dict(zip(compiled.key_cols, example, strict=False))}). Metadata that varies across "
+            f"occurrences of one code is usually data leaking into metadata — consider making "
+            f"the varying column part of the code or an event value column instead. The "
+            f"conflicting values will be aggregated per code (description joined with the "
+            f"separator; other columns collected into lists)."
+        )
+    return out
+
+
 def atomic_write_parquet(df: pl.LazyFrame | pl.DataFrame, out_fp: Path) -> None:
     """Write ``df`` to ``out_fp`` atomically — write to a sibling ``.tmp`` then rename.
 
@@ -739,7 +842,8 @@ def main(cfg: DictConfig):
     # scan/unique/collect that the N-1 map-only workers never use. The joinable component
     # columns are the union across per-file schemas, so the decision cannot depend on
     # which file an enumeration yields first.
-    component_fields = union_component_fields(df.collect_schema() for df in all_event_dfs)
+    event_schemas = [df.collect_schema() for df in all_event_dfs]
+    component_fields = union_component_fields(event_schemas)
 
     # A `_metadata` block always attaches to a component-bearing code (a literal code
     # with a `_metadata` block is rejected at config compile), so configured blocks over
@@ -771,24 +875,62 @@ def main(cfg: DictConfig):
     for input_prefix, event_metadata_cfgs in event_metadata_configs:
         event_metadata_cfgs = copy.deepcopy(event_metadata_cfgs)
 
-        metadata_fps = resolve_source_files(raw_input_dir, input_prefix)
+        is_self = input_prefix == SELF_METADATA_PREFIX
+        if is_self:
+            # ``_self`` blocks read the already-extracted event files: the expressions
+            # were evaluated during event extraction into METADATA_COMPONENTS_COL, so
+            # the mapper is a distinct-pairs projection — no raw table is scanned.
+            if not any(METADATA_COMPONENTS_COL in s.names() for s in event_schemas):
+                raise ValueError(
+                    f"The MESSY config declares '{SELF_METADATA_PREFIX}' metadata blocks, but no "
+                    f"extracted-event file under {stage_input_dir} carries a "
+                    f"'{METADATA_COMPONENTS_COL}' column. The extracted events predate this "
+                    "configuration; re-run the extraction pipeline before extracting code "
+                    "metadata."
+                )
+            in_fps = event_parquet_files
 
-        # Reader kwargs are chosen per resolved prefix: csv-family sources read with
-        # ``infer_schema=False`` for a uniform all-String schema, while parquet sources
-        # keep their intrinsic types (``infer_schema`` is csv-only and would crash
-        # ``scan_parquet``). Deciding from the first file is sound because
-        # ``scan_source`` enforces format homogeneity across a multi-file source.
-        read_kwargs = {} if _format_family(metadata_fps[0]) == "parquet" else {"infer_schema": False}
+            def read_fn(fps):
+                return pl.concat([pl.scan_parquet(fp, glob=False) for fp in fps], how="diagonal_relaxed")
 
-        def read_fn(fps, read_kwargs=read_kwargs):
-            return scan_source(fps, **read_kwargs)
+        else:
+            in_fps = metadata_fps = resolve_source_files(raw_input_dir, input_prefix)
+
+            # Metadata tables are evaluated over in full and materialized eagerly by the
+            # mapper, then joined against every observed code — sized for vocabulary
+            # tables, not data tables. A large one is almost always an event table
+            # pointed at itself (use ``_self``) or a mis-typed prefix.
+            try:
+                total_bytes = sum(fp.stat().st_size for fp in metadata_fps)
+            except Exception:
+                total_bytes = 0
+            if total_bytes > METADATA_TABLE_WARN_BYTES:
+                logger.warning(
+                    f"Metadata table '{input_prefix}' is "
+                    f"{total_bytes / 2**20:.0f} MiB on disk. Metadata tables are fully "
+                    f"materialized and joined against every observed code; a table this large "
+                    f"will be slow and may exhaust memory. If these columns come from the "
+                    f"event's own source table, use the '{SELF_METADATA_PREFIX}' metadata "
+                    f"prefix instead."
+                )
+
+            # Reader kwargs are chosen per resolved prefix: csv-family sources read with
+            # ``infer_schema=False`` for a uniform all-String schema, while parquet sources
+            # keep their intrinsic types (``infer_schema`` is csv-only and would crash
+            # ``scan_parquet``). Deciding from the first file is sound because
+            # ``scan_source`` enforces format homogeneity across a multi-file source.
+            read_kwargs = {} if _format_family(metadata_fps[0]) == "parquet" else {"infer_schema": False}
+
+            def read_fn(fps, read_kwargs=read_kwargs):
+                return scan_source(fps, **read_kwargs)
 
         # Write one output file per individual event config: entries sharing a metadata
         # prefix can join on different match columns and are scoped to different declaring
         # events.
         for cfg_idx, event_cfg in enumerate(event_metadata_cfgs):
             out_fp = partial_metadata_dir / f"{input_prefix}_{cfg_idx}.parquet"
-            logger.info(f"Extracting metadata from {metadata_fps} and saving to {out_fp}")
+            source_desc = "extracted event files" if is_self else str(metadata_fps)
+            logger.info(f"Extracting metadata from {source_desc} and saving to {out_fp}")
 
             # Always present: ``events_by_metadata_prefix`` stamps every entry (see
             # SOURCE_BLOCK_COL in config.py); a KeyError here means that contract broke.
@@ -801,7 +943,7 @@ def main(cfg: DictConfig):
             # block, a block producing no join-key columns) still surface in every
             # worker even when the output shard already exists and the compute is
             # skipped.
-            compiled = _compile_metadata_entry(event_cfg)
+            compiled = _compile_metadata_entry(event_cfg, self_block=is_self)
             match_cols = list(compiled.key_cols)
 
             # Every join key must name a component column some event file carries, or the
@@ -820,12 +962,17 @@ def main(cfg: DictConfig):
                     "metadata."
                 )
 
+            compute_fn = (
+                partial(extract_self_metadata, compiled=compiled, source_block=source_block)
+                if is_self
+                else partial(extract_metadata, compiled=compiled)
+            )
             rwlock_wrap(
-                metadata_fps,
+                in_fps,
                 out_fp,
                 read_fn,
                 atomic_write_parquet,
-                partial(extract_metadata, compiled=compiled),
+                compute_fn,
                 do_overwrite=cfg.do_overwrite,
                 # Run-scoped do_overwrite (MT 0.7.0): without the marker dir, parallel
                 # workers treat each other's fresh outputs as stale and redo the work.

--- a/src/MEDS_extract/merge_to_MEDS_cohort/merge_to_MEDS_cohort.py
+++ b/src/MEDS_extract/merge_to_MEDS_cohort/merge_to_MEDS_cohort.py
@@ -210,14 +210,16 @@ def merge_subdirs_and_sort(
         │ 3          ┆ 8    ┆ E    ┆ null          │
         └────────────┴──────┴──────┴───────────────┘
 
-        The internal ``code_components`` struct is dropped at merge (#254) — including when only *some*
-        tables carry it (a table whose codes are all literals legitimately has none):
+        The internal ``code_components`` and ``metadata_components`` structs are dropped at merge
+        (#254) — including when only *some* tables carry them (a table whose codes are all literals
+        legitimately has no components; only ``_self``-metadata events carry metadata components):
 
         >>> df4 = pl.DataFrame({
         ...     "subject_id": [1],
         ...     "time": [5],
         ...     "code": ["F//X"],
         ...     "code_components": [{"f": "X"}],
+        ...     "metadata_components": [{"description": "an F"}],
         ... })
         >>> with TemporaryDirectory() as tmpdir:
         ...     sp_dir = Path(tmpdir)
@@ -312,11 +314,15 @@ def merge_subdirs_and_sort(
     file_strs = "\n".join(f"  - {fp.resolve()!s}" for fp in files_to_read)
     logger.info(f"Reading {len(files_to_read)} files:\n{file_strs}")
 
-    # Drop the internal ``code_components`` struct per scan, *before* the concat, so the field-union
-    # superstruct never forms and projection pushdown never reads the column (#254; see the module and
-    # docstring notes above for the memory numbers). ``strict=False`` because a table whose codes are
-    # all literals legitimately has no components column.
-    dfs = [pl.scan_parquet(fp, glob=False).drop("code_components", strict=False) for fp in files_to_read]
+    # Drop the internal ``code_components`` / ``metadata_components`` structs per scan, *before* the
+    # concat, so the field-union superstruct never forms and projection pushdown never reads the
+    # columns (#254; see the module and docstring notes above for the memory numbers).
+    # ``strict=False`` because a table whose codes are all literals legitimately has no components
+    # column, and only ``_self``-metadata events carry metadata components.
+    dfs = [
+        pl.scan_parquet(fp, glob=False).drop("code_components", "metadata_components", strict=False)
+        for fp in files_to_read
+    ]
     df = pl.concat(dfs, how="diagonal_relaxed")
 
     df_columns = set(df.collect_schema().names())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -579,3 +579,73 @@ def test_right_key_listed_in_cols_rejected_when_left_name_differs():
     exists)."""
     with pytest.raises(ValueError, match=r"right key column\(s\) \['adm_id'\].*coalesces"):
         JoinConfig.parse({"adm": {"left_on": "hadm_id", "right_on": "adm_id", "cols": ["adm_id", "x"]}})
+
+
+def test_self_metadata_extraction_and_planning():
+    """A '_self' metadata block evaluates during event extraction into the 'metadata_components' struct — its
+    source columns are planned (read from source) without ever appearing as top-level output columns."""
+    tc = TableConfig.parse(
+        "chartevents",
+        {
+            "_defaults": {"subject_id": "$subject_id"},
+            "chart": {
+                "code": 'f"CHART//{$itemid}"',
+                "time": None,
+                "_metadata": {"_self": {"description": "$long_label"}},
+            },
+        },
+    )
+    assert "long_label" in tc.source_columns()
+
+    raw = pl.DataFrame({"subject_id": [1, 2], "itemid": [10, 20], "long_label": ["Heart Rate", "Resp Rate"]})
+    out = tc.extract_events(raw.lazy()).collect()
+    assert "metadata_components" in out.columns
+    assert "long_label" not in out.columns
+    assert out["metadata_components"].to_list() == [
+        {"description": "Heart Rate"},
+        {"description": "Resp Rate"},
+    ]
+
+
+def test_self_metadata_sees_joined_and_derived_columns(tmp_path):
+    """'_self' expressions evaluate over the fully prepared frame: they may reference joined columns, so
+    metadata can be sourced from either side of a table join."""
+    pl.DataFrame({"itemid": [10, 20], "label": ["HR", "RR"]}).write_parquet(tmp_path / "d_items.parquet")
+    tc = TableConfig.parse(
+        "chartevents",
+        {
+            "_defaults": {"subject_id": "$subject_id"},
+            "_table": {"join": {"d_items": {"key": "itemid", "cols": ["label"]}}},
+            "chart": {
+                "code": 'f"CHART//{$itemid}"',
+                "time": None,
+                "_metadata": {"_self": {"description": "$label"}},
+            },
+        },
+    )
+    raw = pl.DataFrame({"subject_id": [1, 2], "itemid": [10, 20]})
+    prepared = tc.apply_join(raw.lazy(), tmp_path)
+    out = tc.extract_events(prepared).collect().sort("code")
+    assert out["metadata_components"].to_list() == [{"description": "HR"}, {"description": "RR"}]
+    # The joined column is attributed to the join table, not the left source file.
+    assert "label" not in tc.source_columns()
+
+
+def test_metadata_prefix_naming_own_table_warns(caplog):
+    """A _metadata block pointing back at the event's own source table warns with a '_self' remedy:
+
+    extract_code_metadata would re-scan and materialize the raw table.
+    """
+    with caplog.at_level(logging.WARNING):
+        TableConfig.parse(
+            "labs",
+            {
+                "_defaults": {"subject_id": "$sid"},
+                "lab": {
+                    "code": 'f"LAB//{$test}"',
+                    "time": None,
+                    "_metadata": {"labs": {"test": "$test", "description": "$name"}},
+                },
+            },
+        )
+    assert any("_self" in r.message and "own source table" in r.message for r in caplog.records)

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -2086,3 +2086,88 @@ data:
         codes_df = _run_ecm_scenario(Path(d), messy, worker=0, **scenario_kwargs)
     assert calls == [1], f"Worker 0 should build the map exactly once; got {len(calls)} calls."
     assert codes_df.filter(pl.col("code") == "HR")["description"].to_list() == ["Heart Rate"]
+
+
+def test_self_metadata_end_to_end(tmp_path):
+    """A '_self' block attaches metadata sourced from the event's own extracted rows — no raw metadata table
+    exists at all, so nothing raw is scanned or joined."""
+    messy_yaml = """\
+chartevents:
+  _defaults:
+    subject_id: "$subject_id"
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    time: null
+    _metadata:
+      _self:
+        description: "$long_label"
+"""
+    events = pl.DataFrame(
+        {
+            "code": ["CHART//10", "CHART//10", "CHART//20"],
+            "code_components": [{"itemid": 10}, {"itemid": 10}, {"itemid": 20}],
+            "metadata_components": [
+                {"description": "Heart Rate"},
+                {"description": "Heart Rate"},
+                {"description": "Resp Rate"},
+            ],
+            "source_block": ["chartevents/chart"] * 3,
+        }
+    )
+    codes = _run_ecm_scenario(tmp_path, messy_yaml, {"chartevents": events}, raw_files={})
+    got = {r["code"]: r["description"] for r in codes.iter_rows(named=True)}
+    assert got == {"CHART//10": "Heart Rate", "CHART//20": "Resp Rate"}
+
+
+def test_self_metadata_conflicting_values_warn_and_aggregate(tmp_path, caplog):
+    """One component key carrying distinct '_self' metadata values warns (data leaking into metadata) and the
+    reducer aggregates the conflict (description joined)."""
+    messy_yaml = """\
+chartevents:
+  _defaults:
+    subject_id: "$subject_id"
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    time: null
+    _metadata:
+      _self:
+        description: "$long_label"
+"""
+    events = pl.DataFrame(
+        {
+            "code": ["CHART//10", "CHART//10"],
+            "code_components": [{"itemid": 10}, {"itemid": 10}],
+            "metadata_components": [{"description": "HR"}, {"description": "Pulse"}],
+            "source_block": ["chartevents/chart"] * 2,
+        }
+    )
+    with caplog.at_level("WARNING"):
+        codes = _run_ecm_scenario(tmp_path, messy_yaml, {"chartevents": events}, raw_files={})
+    assert any("data leaking into metadata" in r.message for r in caplog.records)
+    (desc,) = codes.filter(pl.col("code") == "CHART//10")["description"].to_list()
+    assert sorted(desc.split("\n")) == ["HR", "Pulse"]
+
+
+def test_self_metadata_without_components_column_errors(tmp_path):
+    """'_self' blocks over event files lacking 'metadata_components' (a stale extraction) error with a re-run
+    remedy instead of a cryptic struct-field failure."""
+    messy_yaml = """\
+chartevents:
+  _defaults:
+    subject_id: "$subject_id"
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    time: null
+    _metadata:
+      _self:
+        description: "$long_label"
+"""
+    events = pl.DataFrame(
+        {
+            "code": ["CHART//10"],
+            "code_components": [{"itemid": 10}],
+            "source_block": ["chartevents/chart"],
+        }
+    )
+    with pytest.raises(ValueError, match="metadata_components"):
+        _run_ecm_scenario(tmp_path, messy_yaml, {"chartevents": events}, raw_files={})


### PR DESCRIPTION
Closes #292

## What

The reserved `_self` prefix inside `_metadata` sources metadata columns from the event's **own** rows instead of a separate raw table:

```yaml
chartevents:
  chart:
    code: 'f"CHART//{$itemid}"'
    time: '$charttime'
    _metadata:
      _self:
        description: '$long_label'
```

Previously the only way to express this was pointing the `_metadata` block back at the event's own prefix — which re-scans the full raw table, **materializes the mapped frame eagerly** (`atomic_write_parquet` collects lazy inputs), and joins it against every observed code: all memory for a per-row column grab.

## How it works

- `_self` expressions evaluate **during event extraction**, over the fully prepared frame (post-join, post-`_table.cols`) — they can reference source, joined, and derived columns alike.
- Outputs ride in a `metadata_components` struct beside `code_components`; `extract_code_metadata` reads **distinct component→metadata pairs** from the extracted event files (no raw re-scan, no join against raw data) and feeds them through the existing reducer untouched (same scoping, broadcasting, aggregation, determinism).
- The struct is dropped at merge alongside `code_components` — metadata-only columns never reach final data — and the planner picks up `_self` source columns automatically.
- Join keys are **implicit** (every code component pairs row-wise), so blocks list outputs only; output names may not collide with components or reserved names; literal-code events are rejected as with external blocks.

## Guardrails

- Parse-time WARNING when a `_metadata` prefix names the event's own source table, with the `_self` remedy.
- Runtime WARNING when an external metadata table exceeds 256 MiB on disk (vocabulary tables shouldn't be that big).
- Runtime WARNING when one component key carries **distinct** `_self` metadata values — data leaking into metadata; the values still aggregate per code as any metadata collision does.
- Clear error when `_self` blocks run over event files lacking `metadata_components` (stale extraction).

## Design decisions for review (see PR discussion)

Explicit `_self` over same-prefix auto-detection; evaluate-at-extract with a **separate** struct (not widening `code_components`, whose fields drive external-block matching); implicit keys; drop-at-merge parity with `code_components`.

## Tests

- Doctests: `compile_self_metadata_block` (validation catalog), `extract_self_metadata` (distinct-pairs projection), merge drop.
- Stage-level: `_self` end-to-end through the real `extract_code_metadata` stage (no raw metadata file at all), conflicting-values warning + aggregation, stale-extraction error.
- Config-level: struct emission + planner attribution, joined/derived column visibility, own-table warning.
- README: new executable `_self` worked example runs the **full real pipeline** in CI.

Full suite: 234 passed, 3 deselected; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)