### PR TITLE
Bring the _self mapper to parity with the external metadata path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,6 +1247,15 @@ values across its occurrences, the stage warns (that is usually data leaking int
 metadata — the varying value belongs in the code or in an event value column) and the
 conflicting values are aggregated per code like any other metadata collision.
 
+One subtlety of the row-wise pairing: event de-duplication considers the metadata
+values too, so two raw rows identical in every *data* output but differing in a
+column only `_self` reads stay two rows in the extracted events (both values must
+survive for the conflict warning above to see them). The merge stage's default
+`unique_by: "*"` collapses them after the struct is dropped, so final data is
+unaffected under the default pipeline — but with `unique_by: null` the duplicate
+reaches the final output. If you run a non-default `unique_by`, don't reference
+per-occurrence-varying columns from `_self`.
+
 #### Raw values, not rendered values
 
 Two things routinely differ between what a code *displays* and what the raw data

--- a/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
+++ b/src/MEDS_extract/extract_code_metadata/extract_code_metadata.py
@@ -572,6 +572,21 @@ def extract_metadata(
 
     metadata_df = metadata_df.filter(~pl.all_horizontal(*[pl.col(c).is_null() for c in final_cols]))
 
+    metadata_df = _apply_mapper_mandatory_types(metadata_df, final_cols)
+
+    return metadata_df.unique(maintain_order=True).select(*match_cols, "code_template", *final_cols)
+
+
+def _apply_mapper_mandatory_types(
+    metadata_df: pl.LazyFrame | pl.DataFrame, final_cols: list[str]
+) -> pl.LazyFrame | pl.DataFrame:
+    """Coerce MEDS-sentinel output columns to the mapper's mandated dtypes.
+
+    Shared by :func:`extract_metadata` and :func:`extract_self_metadata` so both mapper
+    paths emit identical shapes for the reducer — a ``description`` must be String and a
+    ``parent_codes`` a scalar String regardless of which path produced it (the reducer's
+    ``list.join`` / list aggregation assume these dtypes).
+    """
     for mandatory_col, mandatory_type in _MAPPER_MANDATORY_TYPES.items():
         if mandatory_col not in final_cols:
             continue
@@ -601,7 +616,7 @@ def extract_metadata(
         logger.warning(f"Metadata column '{mandatory_col}' must be of type {mandatory_type}. Casting.")
         metadata_df = metadata_df.with_columns(pl.col(mandatory_col).cast(mandatory_type, strict=False))
 
-    return metadata_df.unique(maintain_order=True).select(*match_cols, "code_template", *final_cols)
+    return metadata_df
 
 
 def extract_self_metadata(
@@ -653,13 +668,33 @@ def extract_self_metadata(
     """
     key_exprs = [pl.col("code_components").struct.field(c).alias(c) for c in compiled.key_cols]
     out_exprs = [pl.col(METADATA_COMPONENTS_COL).struct.field(c).alias(c) for c in compiled.output_cols]
+    scoped = events_df.filter(pl.col(SOURCE_BLOCK_COL) == source_block)
+
+    # A null METADATA_COMPONENTS_COL struct on a row of this block can only come from the
+    # diagonal concat null-filling a file that predates the ``_self`` config — extraction
+    # always emits a non-null struct on a ``_self`` event's rows. Without this check,
+    # stale shards' rows would flow through as all-null outputs and be silently dropped,
+    # so metadata would just be missing for their codes.
+    n_total, n_null = (
+        scoped.select(pl.len(), pl.col(METADATA_COMPONENTS_COL).is_null().sum()).collect().row(0)
+    )
+    if n_null:
+        raise ValueError(
+            f"{n_null} of {n_total} extracted event rows for source block {source_block!r} carry "
+            f"no '{METADATA_COMPONENTS_COL}' values. Those event files predate this "
+            f"'{SELF_METADATA_PREFIX}' configuration; re-run the extraction pipeline before "
+            "extracting code metadata."
+        )
+
     out = (
-        events_df.filter(pl.col(SOURCE_BLOCK_COL) == source_block)
-        .select(*key_exprs, pl.lit(compiled.code_template).alias("code_template"), *out_exprs)
+        scoped.select(*key_exprs, pl.lit(compiled.code_template).alias("code_template"), *out_exprs)
         .filter(~pl.all_horizontal(*(pl.col(c).is_null() for c in compiled.output_cols)))
         .unique()
         .sort([*compiled.key_cols, *compiled.output_cols])
         .collect()
+    )
+    out = _apply_mapper_mandatory_types(out, list(compiled.output_cols)).select(
+        *compiled.key_cols, "code_template", *compiled.output_cols
     )
 
     # One code, several distinct metadata rows = per-occurrence data leaking into
@@ -845,6 +880,14 @@ def main(cfg: DictConfig):
     event_schemas = [df.collect_schema() for df in all_event_dfs]
     component_fields = union_component_fields(event_schemas)
 
+    # The union of ``_self`` metadata output fields across event files — the analogue of
+    # ``component_fields`` for METADATA_COMPONENTS_COL, used to fail fast (per block, in
+    # every worker) when the extracted events predate the ``_self`` configuration.
+    metadata_fields: set[str] = set()
+    for s in event_schemas:
+        if METADATA_COMPONENTS_COL in s.names():
+            metadata_fields.update(f.name for f in s[METADATA_COMPONENTS_COL].fields)
+
     # A `_metadata` block always attaches to a component-bearing code (a literal code
     # with a `_metadata` block is rejected at config compile), so configured blocks over
     # an input with no components ANYWHERE can never be a valid convert_to_MEDS_events
@@ -880,14 +923,6 @@ def main(cfg: DictConfig):
             # ``_self`` blocks read the already-extracted event files: the expressions
             # were evaluated during event extraction into METADATA_COMPONENTS_COL, so
             # the mapper is a distinct-pairs projection — no raw table is scanned.
-            if not any(METADATA_COMPONENTS_COL in s.names() for s in event_schemas):
-                raise ValueError(
-                    f"The MESSY config declares '{SELF_METADATA_PREFIX}' metadata blocks, but no "
-                    f"extracted-event file under {stage_input_dir} carries a "
-                    f"'{METADATA_COMPONENTS_COL}' column. The extracted events predate this "
-                    "configuration; re-run the extraction pipeline before extracting code "
-                    "metadata."
-                )
             in_fps = event_parquet_files
 
             def read_fn(fps):
@@ -961,6 +996,22 @@ def main(cfg: DictConfig):
                     "configuration; re-run the extraction pipeline before extracting code "
                     "metadata."
                 )
+            # The ``_self`` analogue: every output must exist as a metadata field in some
+            # event file, or the extracted events predate this block's configuration.
+            # (Per-block staleness of a SUBSET of files is caught at compute time in
+            # ``extract_self_metadata`` via its null-struct check.)
+            if is_self:
+                missing_out = [c for c in compiled.output_cols if c not in metadata_fields]
+                if missing_out:
+                    raise ValueError(
+                        f"'{SELF_METADATA_PREFIX}' metadata block for code "
+                        f"{compiled.code_template!r} (source block {source_block!r}) produces "
+                        f"column(s) {missing_out} that no extracted-event file carries in "
+                        f"'{METADATA_COMPONENTS_COL}'. Available metadata fields: "
+                        f"{sorted(metadata_fields)}. The extracted events predate this "
+                        "configuration; re-run the extraction pipeline before extracting "
+                        "code metadata."
+                    )
 
             compute_fn = (
                 partial(extract_self_metadata, compiled=compiled, source_block=source_block)

--- a/tests/test_extract_code_metadata.py
+++ b/tests/test_extract_code_metadata.py
@@ -2171,3 +2171,83 @@ chartevents:
     )
     with pytest.raises(ValueError, match="metadata_components"):
         _run_ecm_scenario(tmp_path, messy_yaml, {"chartevents": events}, raw_files={})
+
+
+def test_self_metadata_sentinel_dtypes_match_external_path(tmp_path):
+    """'_self' sentinel outputs get the same mandatory-type coercions as external
+    blocks: a non-String 'description' is cast to String and a scalar 'parent_codes'
+    lands as the mandated List(String) — instead of crashing the reducer's list.join
+    or emitting a MEDS-noncompliant dtype."""
+    messy_yaml = """\
+chartevents:
+  _defaults:
+    subject_id: "$subject_id"
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    time: null
+    _metadata:
+      _self:
+        description: "$int_label"
+        parent_codes: "$parent_id"
+"""
+    events = pl.DataFrame(
+        {
+            "code": ["CHART//10", "CHART//20"],
+            "code_components": [{"itemid": 10}, {"itemid": 20}],
+            "metadata_components": [
+                {"description": 111, "parent_codes": 999},
+                {"description": 222, "parent_codes": 888},
+            ],
+            "source_block": ["chartevents/chart"] * 2,
+        }
+    )
+    codes = _run_ecm_scenario(tmp_path, messy_yaml, {"chartevents": events}, raw_files={})
+    assert codes.schema["description"] == pl.String
+    assert codes.schema["parent_codes"] == pl.List(pl.String)
+    got = {r["code"]: (r["description"], r["parent_codes"]) for r in codes.iter_rows(named=True)}
+    assert got == {"CHART//10": ("111", ["999"]), "CHART//20": ("222", ["888"])}
+
+
+def test_self_metadata_partially_stale_events_error(tmp_path):
+    """A '_self' block whose declaring table's files predate the config errors with a re-run remedy even when
+    ANOTHER table's fresh files carry a same-named metadata field — instead of silently emitting null metadata
+    for the stale table's codes."""
+    messy_yaml = """\
+labs:
+  _defaults:
+    subject_id: "$subject_id"
+  lab:
+    code: 'f"LAB//{$test}"'
+    time: null
+    _metadata:
+      _self:
+        description: "$name"
+chartevents:
+  _defaults:
+    subject_id: "$subject_id"
+  chart:
+    code: 'f"CHART//{$itemid}"'
+    time: null
+    _metadata:
+      _self:
+        description: "$long_label"
+"""
+    stale_labs = pl.DataFrame(
+        {
+            "code": ["LAB//1"],
+            "code_components": [{"test": "1"}],
+            "source_block": ["labs/lab"],
+        }
+    )
+    fresh_charts = pl.DataFrame(
+        {
+            "code": ["CHART//10"],
+            "code_components": [{"itemid": 10}],
+            "metadata_components": [{"description": "HR"}],
+            "source_block": ["chartevents/chart"],
+        }
+    )
+    with pytest.raises(ValueError, match=r"labs/lab.*carry\s+no 'metadata_components'"):
+        _run_ecm_scenario(
+            tmp_path, messy_yaml, {"labs": stale_labs, "chartevents": fresh_charts}, raw_files={}
+        )


### PR DESCRIPTION
Refs #292

An adversarial audit of the merged `_self` feature (#293) found three real gaps, all in the ECM-side mapper; this fixes them so the memory-restructure work (#294) can build on a sound base.

1. **Sentinel dtype parity (crash + schema violation):** `_self` outputs kept their natural dtypes — a non-String `description` crashed the reducer's `list.join` (`InvalidOperationError: attempted list join with non-string dtype`), and a scalar `parent_codes` produced a MEDS-noncompliant `List(Int64)` in codes.parquet. The mandatory-type coercion loop is factored out of `extract_metadata` into `_apply_mapper_mandatory_types` and applied on the `_self` path, so both mappers emit identical shapes for the reducer.
2. **Mixed-staleness detection (silent null metadata / cryptic crash):** the old guard fired only when *no* event file carried `metadata_components`. With one table's files predating the config and another's fresh (reachable via resume — rwlock reuses outputs without input-freshness checks), a same-named field silently emitted null metadata, and a differently-named one crashed with a bare `StructFieldNotFoundError`. Replaced with: (a) a per-block fields check — every `_self` output must exist as a metadata field in some event file, failing fast in every worker; (b) a compute-time null-struct check — a null `metadata_components` struct among the declaring block's rows can only come from diagonal null-fill of a stale file, so it errors with a re-run remedy.
3. **`unique_by` interaction (documentation):** metadata-only columns participate in event dedup, so under a non-default `unique_by: null` merge config a `_self` block referencing per-occurrence-varying columns changes final row counts. Default `unique_by: "*"` pipelines are unaffected (verified). Documented in the README's `_self` section.

Tests: sentinel-dtype parity end-to-end (String cast + `List(String)` `parent_codes`), partially-stale-events error, all prior `_self` tests green. Full suite: 236 passed, 3 deselected; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)